### PR TITLE
feat(i18n): add language switcher

### DIFF
--- a/projects/i18n/constants/index.ts
+++ b/projects/i18n/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './language-code';

--- a/projects/i18n/constants/language-code.ts
+++ b/projects/i18n/constants/language-code.ts
@@ -1,0 +1,14 @@
+export enum TUI_LANGUAGE_CODE {
+    ENGLISH = 'en',
+    RUSSIAN = 'ru',
+    DUTCH = 'nl',
+    FRENCH = 'fr',
+    GERMAN = 'de',
+    POLISH = 'pl',
+    PORTUGUESE = 'pt',
+    SPANISH = 'es',
+    TURKISH = 'tr',
+    UKRANIAN = 'ua',
+    VIETNAMESE = 'vi',
+    ITALIAN = 'it',
+}

--- a/projects/i18n/constants/language-code.ts
+++ b/projects/i18n/constants/language-code.ts
@@ -1,4 +1,4 @@
-export enum TUI_LANGUAGE_CODE {
+export enum TuiLanguageCode {
     ENGLISH = 'en',
     RUSSIAN = 'ru',
     DUTCH = 'nl',

--- a/projects/i18n/interfaces/language.ts
+++ b/projects/i18n/interfaces/language.ts
@@ -1,9 +1,11 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {TuiCountryIsoCode} from '@taiga-ui/i18n/enums';
 
 // prettier-ignore
 type MONTHS_ARRAY = [string, string, string, string, string, string, string, string, string, string, string, string];
 
 export interface LanguageCore {
+    code: TUI_LANGUAGE_CODE;
     months: MONTHS_ARRAY;
     close: string;
     nothingFoundMessage: string;

--- a/projects/i18n/interfaces/language.ts
+++ b/projects/i18n/interfaces/language.ts
@@ -1,11 +1,11 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {TuiCountryIsoCode} from '@taiga-ui/i18n/enums';
 
 // prettier-ignore
 type MONTHS_ARRAY = [string, string, string, string, string, string, string, string, string, string, string, string];
 
 export interface LanguageCore {
-    code: TUI_LANGUAGE_CODE;
+    code: TuiLanguageCode;
     months: MONTHS_ARRAY;
     close: string;
     nothingFoundMessage: string;

--- a/projects/i18n/languages/dutch/core.ts
+++ b/projects/i18n/languages/dutch/core.ts
@@ -1,10 +1,10 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_DUTCH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_DUTCH_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.DUTCH,
+    code: TuiLanguageCode.DUTCH,
     months: [
         'Januari',
         'Februari',

--- a/projects/i18n/languages/dutch/core.ts
+++ b/projects/i18n/languages/dutch/core.ts
@@ -1,8 +1,10 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_DUTCH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_DUTCH_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.DUTCH,
     months: [
         'Januari',
         'Februari',

--- a/projects/i18n/languages/english/core.ts
+++ b/projects/i18n/languages/english/core.ts
@@ -1,8 +1,10 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_ENGLISH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_ENGLISH_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.ENGLISH,
     months: [
         'January',
         'February',

--- a/projects/i18n/languages/english/core.ts
+++ b/projects/i18n/languages/english/core.ts
@@ -1,10 +1,10 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_ENGLISH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_ENGLISH_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.ENGLISH,
+    code: TuiLanguageCode.ENGLISH,
     months: [
         'January',
         'February',

--- a/projects/i18n/languages/french/core.ts
+++ b/projects/i18n/languages/french/core.ts
@@ -1,8 +1,10 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_FRENCH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_FRENCH_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.FRENCH,
     months: [
         'Janvier',
         'Février',

--- a/projects/i18n/languages/french/core.ts
+++ b/projects/i18n/languages/french/core.ts
@@ -1,10 +1,10 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_FRENCH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_FRENCH_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.FRENCH,
+    code: TuiLanguageCode.FRENCH,
     months: [
         'Janvier',
         'Février',

--- a/projects/i18n/languages/german/core.ts
+++ b/projects/i18n/languages/german/core.ts
@@ -1,9 +1,9 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 import {TUI_ENGLISH_LANGUAGE_COUNTRIES} from '@taiga-ui/i18n/languages/english';
 
 export const TUI_GERMAN_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.GERMAN,
+    code: TuiLanguageCode.GERMAN,
     months: [
         'Januar',
         'Februar',

--- a/projects/i18n/languages/german/core.ts
+++ b/projects/i18n/languages/german/core.ts
@@ -1,7 +1,9 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 import {TUI_ENGLISH_LANGUAGE_COUNTRIES} from '@taiga-ui/i18n/languages/english';
 
 export const TUI_GERMAN_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.GERMAN,
     months: [
         'Januar',
         'Februar',

--- a/projects/i18n/languages/index.ts
+++ b/projects/i18n/languages/index.ts
@@ -9,3 +9,4 @@ export * from '@taiga-ui/i18n/languages/spanish';
 export * from '@taiga-ui/i18n/languages/turkish';
 export * from '@taiga-ui/i18n/languages/ukrainian';
 export * from '@taiga-ui/i18n/languages/vietnamese';
+export * from '@taiga-ui/i18n/languages/italian';

--- a/projects/i18n/languages/italian/core.ts
+++ b/projects/i18n/languages/italian/core.ts
@@ -1,8 +1,10 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_ITALIAN_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_ITALIAN_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.ITALIAN,
     months: [
         'Gennaio',
         'Febbraio',

--- a/projects/i18n/languages/italian/core.ts
+++ b/projects/i18n/languages/italian/core.ts
@@ -1,10 +1,10 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_ITALIAN_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_ITALIAN_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.ITALIAN,
+    code: TuiLanguageCode.ITALIAN,
     months: [
         'Gennaio',
         'Febbraio',

--- a/projects/i18n/languages/polish/core.ts
+++ b/projects/i18n/languages/polish/core.ts
@@ -1,8 +1,10 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_POLISH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_POLISH_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.POLISH,
     months: [
         'styczeń',
         'luty',

--- a/projects/i18n/languages/polish/core.ts
+++ b/projects/i18n/languages/polish/core.ts
@@ -1,10 +1,10 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_POLISH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_POLISH_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.POLISH,
+    code: TuiLanguageCode.POLISH,
     months: [
         'styczeń',
         'luty',

--- a/projects/i18n/languages/portuguese/core.ts
+++ b/projects/i18n/languages/portuguese/core.ts
@@ -1,10 +1,10 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_PORTUGUESE_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_PORTUGUESE_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.PORTUGUESE,
+    code: TuiLanguageCode.PORTUGUESE,
     months: [
         'Janeiro',
         'Fevereiro',

--- a/projects/i18n/languages/portuguese/core.ts
+++ b/projects/i18n/languages/portuguese/core.ts
@@ -1,8 +1,10 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_PORTUGUESE_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_PORTUGUESE_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.PORTUGUESE,
     months: [
         'Janeiro',
         'Fevereiro',

--- a/projects/i18n/languages/russian/core.ts
+++ b/projects/i18n/languages/russian/core.ts
@@ -1,10 +1,10 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_RUSSIAN_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_RUSSIAN_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.RUSSIAN,
+    code: TuiLanguageCode.RUSSIAN,
     months: [
         'Январь',
         'Февраль',

--- a/projects/i18n/languages/russian/core.ts
+++ b/projects/i18n/languages/russian/core.ts
@@ -1,8 +1,10 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_RUSSIAN_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_RUSSIAN_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.RUSSIAN,
     months: [
         'Январь',
         'Февраль',

--- a/projects/i18n/languages/spanish/core.ts
+++ b/projects/i18n/languages/spanish/core.ts
@@ -1,8 +1,10 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_SPANISH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_SPANISH_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.SPANISH,
     months: [
         'Enero',
         'Febrero',

--- a/projects/i18n/languages/spanish/core.ts
+++ b/projects/i18n/languages/spanish/core.ts
@@ -1,10 +1,10 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_SPANISH_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_SPANISH_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.SPANISH,
+    code: TuiLanguageCode.SPANISH,
     months: [
         'Enero',
         'Febrero',

--- a/projects/i18n/languages/turkish/core.ts
+++ b/projects/i18n/languages/turkish/core.ts
@@ -1,7 +1,9 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 import {TUI_ENGLISH_LANGUAGE_COUNTRIES} from '@taiga-ui/i18n/languages/english';
 
 export const TUI_TURKISH_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.TURKISH,
     months: [
         'Ocak',
         'Şubat',

--- a/projects/i18n/languages/turkish/core.ts
+++ b/projects/i18n/languages/turkish/core.ts
@@ -1,9 +1,9 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 import {TUI_ENGLISH_LANGUAGE_COUNTRIES} from '@taiga-ui/i18n/languages/english';
 
 export const TUI_TURKISH_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.TURKISH,
+    code: TuiLanguageCode.TURKISH,
     months: [
         'Ocak',
         'Şubat',

--- a/projects/i18n/languages/ukrainian/core.ts
+++ b/projects/i18n/languages/ukrainian/core.ts
@@ -1,9 +1,9 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 import {TUI_ENGLISH_LANGUAGE_COUNTRIES} from '@taiga-ui/i18n/languages/english';
 
 export const TUI_UKRAINIAN_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.UKRANIAN,
+    code: TuiLanguageCode.UKRANIAN,
     months: [
         'Січень',
         'Лютий',

--- a/projects/i18n/languages/ukrainian/core.ts
+++ b/projects/i18n/languages/ukrainian/core.ts
@@ -1,7 +1,9 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 import {TUI_ENGLISH_LANGUAGE_COUNTRIES} from '@taiga-ui/i18n/languages/english';
 
 export const TUI_UKRAINIAN_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.UKRANIAN,
     months: [
         'Січень',
         'Лютий',

--- a/projects/i18n/languages/vietnamese/core.ts
+++ b/projects/i18n/languages/vietnamese/core.ts
@@ -1,8 +1,10 @@
+import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_VIETNAMESE_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_VIETNAMESE_LANGUAGE_CORE: LanguageCore = {
+    code: TUI_LANGUAGE_CODE.VIETNAMESE,
     months: [
         'Tháng 1',
         'Tháng 2',

--- a/projects/i18n/languages/vietnamese/core.ts
+++ b/projects/i18n/languages/vietnamese/core.ts
@@ -1,10 +1,10 @@
-import {TUI_LANGUAGE_CODE} from '@taiga-ui/i18n/constants';
+import {TuiLanguageCode} from '@taiga-ui/i18n/constants';
 import {LanguageCore} from '@taiga-ui/i18n/interfaces';
 
 import {TUI_VIETNAMESE_LANGUAGE_COUNTRIES} from './countries';
 
 export const TUI_VIETNAMESE_LANGUAGE_CORE: LanguageCore = {
-    code: TUI_LANGUAGE_CODE.VIETNAMESE,
+    code: TuiLanguageCode.VIETNAMESE,
     months: [
         'Tháng 1',
         'Tháng 2',

--- a/projects/i18n/tools/default-lanuage.ts
+++ b/projects/i18n/tools/default-lanuage.ts
@@ -5,8 +5,6 @@ import {TUI_ENGLISH_LANGUAGE} from '@taiga-ui/i18n/languages';
 export const TUI_DEFAULT_LANGUAGE = new InjectionToken<Language>(
     `Default language for Taiga UI libraries i18n`,
     {
-        factory: () => {
-            return TUI_ENGLISH_LANGUAGE;
-        },
+        factory: () => TUI_ENGLISH_LANGUAGE,
     },
 );

--- a/projects/i18n/tools/default-lanuage.ts
+++ b/projects/i18n/tools/default-lanuage.ts
@@ -1,0 +1,12 @@
+import {InjectionToken} from '@angular/core';
+import {Language} from '@taiga-ui/i18n/interfaces';
+import {TUI_ENGLISH_LANGUAGE} from '@taiga-ui/i18n/languages';
+
+export const TUI_DEFAULT_LANGUAGE = new InjectionToken<Language>(
+    `Default language for Taiga UI libraries i18n`,
+    {
+        factory: () => {
+            return TUI_ENGLISH_LANGUAGE;
+        },
+    },
+);

--- a/projects/i18n/tools/index.ts
+++ b/projects/i18n/tools/index.ts
@@ -1,2 +1,6 @@
 export * from './extract-i18n';
 export * from './language';
+export * from './stored-language';
+export * from './default-lanuage';
+export * from './stored-i18n-key';
+export * from './language.service';

--- a/projects/i18n/tools/language.service.ts
+++ b/projects/i18n/tools/language.service.ts
@@ -1,0 +1,19 @@
+import {inject, Injectable} from '@angular/core';
+import {LOCAL_STORAGE} from '@ng-web-apis/common';
+import {Language} from '@taiga-ui/i18n';
+import {TUI_I18N_STORAGE_KEY, TUI_STORED_LANGUAGE} from '@taiga-ui/i18n/tools';
+import {ReplaySubject} from 'rxjs';
+@Injectable()
+export class TuiLanguageService extends ReplaySubject<Language> {
+    storedLanguage = inject(TUI_STORED_LANGUAGE);
+    storageKey = inject(TUI_I18N_STORAGE_KEY);
+    storage = inject(LOCAL_STORAGE);
+    constructor() {
+        super(1);
+        this.next(this.storedLanguage);
+    }
+    setLang(lang: Language) {
+        this.storage.setItem(this.storageKey, lang.code);
+        super.next(lang);
+    }
+}

--- a/projects/i18n/tools/language.service.ts
+++ b/projects/i18n/tools/language.service.ts
@@ -1,8 +1,9 @@
 import {Inject, Injectable} from '@angular/core';
 import {LOCAL_STORAGE} from '@ng-web-apis/common';
-import {Language} from '..';
 import {TUI_I18N_STORAGE_KEY, TUI_STORED_LANGUAGE} from '@taiga-ui/i18n/tools';
-import {BehaviorSubject, ReplaySubject} from 'rxjs';
+import {BehaviorSubject} from 'rxjs';
+
+import {Language} from '..';
 
 @Injectable({
     providedIn: 'root'
@@ -16,6 +17,7 @@ export class TuiLanguageService extends BehaviorSubject<Language> {
     ) {
         super(storedLanguage)
     }
+
     setLang(lang: Language) {
         this.storage.setItem(this.storageKey, lang.code);
         this.next(lang);

--- a/projects/i18n/tools/language.service.ts
+++ b/projects/i18n/tools/language.service.ts
@@ -1,19 +1,23 @@
-import {inject, Injectable} from '@angular/core';
+import {Inject, Injectable} from '@angular/core';
 import {LOCAL_STORAGE} from '@ng-web-apis/common';
-import {Language} from '@taiga-ui/i18n';
+import {Language} from '..';
 import {TUI_I18N_STORAGE_KEY, TUI_STORED_LANGUAGE} from '@taiga-ui/i18n/tools';
-import {ReplaySubject} from 'rxjs';
-@Injectable()
-export class TuiLanguageService extends ReplaySubject<Language> {
-    storedLanguage = inject(TUI_STORED_LANGUAGE);
-    storageKey = inject(TUI_I18N_STORAGE_KEY);
-    storage = inject(LOCAL_STORAGE);
-    constructor() {
-        super(1);
-        this.next(this.storedLanguage);
+import {BehaviorSubject, ReplaySubject} from 'rxjs';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class TuiLanguageService extends BehaviorSubject<Language> {
+
+    constructor(
+        @Inject(TUI_STORED_LANGUAGE) private storedLanguage: Language,
+        @Inject(TUI_I18N_STORAGE_KEY) private storageKey: string,
+        @Inject(LOCAL_STORAGE) private storage: Storage,
+    ) {
+        super(storedLanguage)
     }
     setLang(lang: Language) {
         this.storage.setItem(this.storageKey, lang.code);
-        super.next(lang);
+        this.next(lang);
     }
 }

--- a/projects/i18n/tools/language.ts
+++ b/projects/i18n/tools/language.ts
@@ -1,6 +1,18 @@
 import {InjectionToken} from '@angular/core';
 import {Language} from '@taiga-ui/i18n/interfaces';
-import {TUI_ENGLISH_LANGUAGE} from '@taiga-ui/i18n/languages';
+import {
+    TUI_DUTCH_LANGUAGE,
+    TUI_ENGLISH_LANGUAGE,
+    TUI_FRENCH_LANGUAGE,
+    TUI_GERMAN_LANGUAGE,
+    TUI_ITALIAN_LANGUAGE,
+    TUI_POLISH_LANGUAGE,
+    TUI_PORTUGUESE_LANGUAGE,
+    TUI_RUSSIAN_LANGUAGE,
+    TUI_TURKISH_LANGUAGE,
+    TUI_UKRAINIAN_LANGUAGE,
+    TUI_VIETNAMESE_LANGUAGE,
+} from '@taiga-ui/i18n/languages';
 import {Observable, of} from 'rxjs';
 
 export const TUI_LANGUAGE = new InjectionToken<Observable<Language>>(
@@ -8,4 +20,20 @@ export const TUI_LANGUAGE = new InjectionToken<Observable<Language>>(
     {
         factory: () => of(TUI_ENGLISH_LANGUAGE),
     },
+);
+
+export const TUI_LANGUAGE_MAP = new Map<string, Language>(
+    Object.entries({
+        [TUI_ENGLISH_LANGUAGE.code]: TUI_ENGLISH_LANGUAGE,
+        [TUI_DUTCH_LANGUAGE.code]: TUI_DUTCH_LANGUAGE,
+        [TUI_RUSSIAN_LANGUAGE.code]: TUI_RUSSIAN_LANGUAGE,
+        [TUI_GERMAN_LANGUAGE.code]: TUI_GERMAN_LANGUAGE,
+        [TUI_POLISH_LANGUAGE.code]: TUI_POLISH_LANGUAGE,
+        [TUI_PORTUGUESE_LANGUAGE.code]: TUI_PORTUGUESE_LANGUAGE,
+        [TUI_FRENCH_LANGUAGE.code]: TUI_FRENCH_LANGUAGE,
+        [TUI_TURKISH_LANGUAGE.code]: TUI_TURKISH_LANGUAGE,
+        [TUI_ITALIAN_LANGUAGE.code]: TUI_ITALIAN_LANGUAGE,
+        [TUI_UKRAINIAN_LANGUAGE.code]: TUI_UKRAINIAN_LANGUAGE,
+        [TUI_VIETNAMESE_LANGUAGE.code]: TUI_VIETNAMESE_LANGUAGE,
+    }),
 );

--- a/projects/i18n/tools/stored-i18n-key.ts
+++ b/projects/i18n/tools/stored-i18n-key.ts
@@ -5,8 +5,6 @@ const TUI_I18N_STORAGE_DEFAULT_KEY = 'taiga_ui_i18n';
 export const TUI_I18N_STORAGE_KEY = new InjectionToken<string>(
     `Storage key for language of Taiga UI libraries i18n`,
     {
-        factory: () => {
-            return TUI_I18N_STORAGE_DEFAULT_KEY;
-        },
+        factory: () => TUI_I18N_STORAGE_DEFAULT_KEY,
     },
 );

--- a/projects/i18n/tools/stored-i18n-key.ts
+++ b/projects/i18n/tools/stored-i18n-key.ts
@@ -1,0 +1,12 @@
+import {InjectionToken} from '@angular/core';
+
+const TUI_I18N_STORAGE_DEFAULT_KEY = 'taiga_ui_i18n';
+
+export const TUI_I18N_STORAGE_KEY = new InjectionToken<string>(
+    `Storage key for language of Taiga UI libraries i18n`,
+    {
+        factory: () => {
+            return TUI_I18N_STORAGE_DEFAULT_KEY;
+        },
+    },
+);

--- a/projects/i18n/tools/stored-language.ts
+++ b/projects/i18n/tools/stored-language.ts
@@ -1,7 +1,7 @@
 import {inject, InjectionToken} from '@angular/core';
 import {LOCAL_STORAGE} from '@ng-web-apis/common';
-import {TUI_I18N_STORAGE_KEY} from '@taiga-ui/i18n';
-import {TUI_LANGUAGE_MAP} from '@taiga-ui/i18n';
+import {TUI_I18N_STORAGE_KEY, TUI_LANGUAGE_MAP} from '@taiga-ui/i18n';
+
 import {Language} from '..';
 import {TUI_DEFAULT_LANGUAGE} from './default-lanuage';
 
@@ -13,14 +13,13 @@ export const TUI_STORED_LANGUAGE = new InjectionToken<Language>(
             const defaultLanguage = inject(TUI_DEFAULT_LANGUAGE);
             const storageKey = inject(TUI_I18N_STORAGE_KEY);
             const storedLanguageCode = storage.getItem(storageKey);
-            const storedLanguage =
-                storedLanguageCode &&
-                TUI_LANGUAGE_MAP.has(storedLanguageCode) &&
-                TUI_LANGUAGE_MAP.get(storedLanguageCode);
+            let result: Language = defaultLanguage;
 
-            return storedLanguage
-                ? storedLanguage
-                : defaultLanguage;
+            if (storedLanguageCode && TUI_LANGUAGE_MAP.has(storedLanguageCode)) {
+                result = TUI_LANGUAGE_MAP.get(storedLanguageCode) as Language;
+            }
+
+            return result;
         },
     },
 );

--- a/projects/i18n/tools/stored-language.ts
+++ b/projects/i18n/tools/stored-language.ts
@@ -2,7 +2,7 @@ import {inject, InjectionToken} from '@angular/core';
 import {LOCAL_STORAGE} from '@ng-web-apis/common';
 import {TUI_I18N_STORAGE_KEY} from '@taiga-ui/i18n';
 import {TUI_LANGUAGE_MAP} from '@taiga-ui/i18n';
-import {Language, TUI_ENGLISH_LANGUAGE} from '..';
+import {Language} from '..';
 import {TUI_DEFAULT_LANGUAGE} from './default-lanuage';
 
 export const TUI_STORED_LANGUAGE = new InjectionToken<Language>(
@@ -20,7 +20,7 @@ export const TUI_STORED_LANGUAGE = new InjectionToken<Language>(
 
             return storedLanguage
                 ? storedLanguage
-                : defaultLanguage || TUI_ENGLISH_LANGUAGE;
+                : defaultLanguage;
         },
     },
 );

--- a/projects/i18n/tools/stored-language.ts
+++ b/projects/i18n/tools/stored-language.ts
@@ -1,0 +1,26 @@
+import {inject, InjectionToken} from '@angular/core';
+import {LOCAL_STORAGE} from '@ng-web-apis/common';
+import {TUI_I18N_STORAGE_KEY} from '@taiga-ui/i18n';
+import {TUI_LANGUAGE_MAP} from '@taiga-ui/i18n';
+import {Language, TUI_ENGLISH_LANGUAGE} from '..';
+import {TUI_DEFAULT_LANGUAGE} from './default-lanuage';
+
+export const TUI_STORED_LANGUAGE = new InjectionToken<Language>(
+    `Stored language for Taiga UI libraries i18n`,
+    {
+        factory: () => {
+            const storage = inject(LOCAL_STORAGE);
+            const defaultLanguage = inject(TUI_DEFAULT_LANGUAGE);
+            const storageKey = inject(TUI_I18N_STORAGE_KEY);
+            const storedLanguageCode = storage.getItem(storageKey);
+            const storedLanguage =
+                storedLanguageCode &&
+                TUI_LANGUAGE_MAP.has(storedLanguageCode) &&
+                TUI_LANGUAGE_MAP.get(storedLanguageCode);
+
+            return storedLanguage
+                ? storedLanguage
+                : defaultLanguage || TUI_ENGLISH_LANGUAGE;
+        },
+    },
+);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

https://github.com/TinkoffCreditSystems/taiga-ui/pull/846#discussion_r725963229
Users can't change i18n for taiga-ui on the fly.

Closes #

Using special service users can change i18n on the fly. The selected locale saved to LOCAL_STORAGE and retrieved on page reload.
Usage example (will be update in https://github.com/TinkoffCreditSystems/taiga-ui/pull/846)
```
  TuiLanguageService,
    {
        provide: TUI_LANGUAGE,
        deps: [TUI_STORED_LANGUAGE],
        useExisting: TuiLanguageService,
    },
    {
        provide: TUI_DEFAULT_LANGUAGE,
        useValue: TUI_ITALIAN_LANGUAGE,
    },
    {
        provide: TUI_I18N_STORAGE_KEY,
        useValue: 'tui_key_i18n',
    }
```

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
