### PR TITLE
chore(demo): fix `next`-demo anchor links to examples

### DIFF
--- a/scripts/postbuild-demo.js
+++ b/scripts/postbuild-demo.js
@@ -6,7 +6,7 @@ const NOT_FOUND_PATH = `${DEMO_PATH}/404.html`;
 
 const SMOKER_BALANCER = `<script>
 if (!localStorage.getItem('env') && location.pathname.includes('next')) {
-    localStorage.setItem('env', location.pathname + location.search)
+    localStorage.setItem('env', location.pathname + location.search + location.hash);
     location.replace('/next');
 } else {
     localStorage.removeItem('env');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Go to `next`-version of demo app:
https://taiga-ui.dev/next/utils/tokens#is-ios
(or any other url with anchor link) 

**Expected behavior**: scroll to the `TUI_IS_IOS`-token's description.
**Actual behavior**: no scroll.

## What is the new behavior?
The same behavior as in the released version of demo app:
https://taiga-ui.dev/utils/tokens#is-ios 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
