### PR TITLE
chore(demo): `StackBlitz` workaround for icons support

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/project-files/src/app/app.module.ts.txt
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/app/app.module.ts.txt
@@ -1,7 +1,8 @@
-import {APP_INITIALIZER, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {RouterModule} from '@angular/router';
 
 import {
     TUI_SANITIZER,
@@ -14,6 +15,8 @@ import {
     TuiMediaModule,
 } from '@taiga-ui/cdk';
 import {
+    iconsPathFactory,
+    TUI_ICONS_PATH,
     TuiButtonModule,
     TuiCalendarModule,
     TuiDataListModule,
@@ -41,7 +44,6 @@ import {
     TuiRootModule,
     TuiScrollbarModule,
     TuiSvgModule,
-    TuiSvgService,
     TuiTextfieldControllerModule,
     TuiTooltipModule,
 } from '@taiga-ui/core';
@@ -62,6 +64,7 @@ import {
     TuiDropdownContextModule,
     TuiDropdownSelectionModule,
     TuiFieldErrorModule,
+    TuiFilterByInputPipeModule,
     TuiFilterModule,
     TuiHighlightModule,
     TuiInputCopyModule,
@@ -91,7 +94,6 @@ import {
     TuiPresentModule,
     TuiProgressModule,
     TuiProjectClassModule,
-    TuiFilterByInputPipeModule,
     TuiRadioBlockModule,
     TuiRadioLabeledModule,
     TuiRadioListModule,
@@ -104,8 +106,6 @@ import {
     TuiTextAreaModule,
     TuiToggleModule,
 } from '@taiga-ui/kit';
-
-import * as icons from '@taiga-ui/icons';
 
 import {
     TuiAxesModule,
@@ -143,7 +143,6 @@ import {
 import {NgDompurifySanitizer} from '@tinkoff/ng-dompurify';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 import {AppComponent} from './app.component';
-import {RouterModule} from '@angular/router';
 
 @NgModule({
     imports: [
@@ -277,17 +276,15 @@ import {RouterModule} from '@angular/router';
         TuiCurrencyPipeModule,
         TuiProjectClassModule,
         TuiFilterByInputPipeModule,
-        RouterModule.forRoot([])
+        RouterModule.forRoot([]),
     ],
     declarations: [AppComponent],
     bootstrap: [AppComponent],
     providers: [
         // A workaround because StackBlitz does not support assets
         {
-            provide: APP_INITIALIZER,
-            multi: true,
-            deps: [TuiSvgService],
-            useFactory: iconsWorkaround,
+            provide: TUI_ICONS_PATH,
+            useValue: iconsPathFactory('https://taiga-ui.dev/assets/taiga-ui/icons'),
         },
         /**
          * If you use unsafe icons or have kind of WYSISYG editor in your app
@@ -304,8 +301,3 @@ import {RouterModule} from '@angular/router';
     ],
 })
 export class AppModule {}
-
-// A workaround because StackBlitz does not support assets
-export function iconsWorkaround(service: TuiSvgService): Function {
-    return () => service.define({...icons, tuiCoreIcons: '', tuiKitIcons: ''});
-}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Part of https://github.com/Tinkoff/taiga-ui/issues/673

Icons in our StackBlitz's examples dont work.

For example, press "Edit on StackBlitz" here:
https://taiga-ui.dev/components/input-phone-international#base
or here
https://taiga-ui.dev/components/input-date#base

## What is the new behavior?
Open any StackBlitz's examples from current branch.
Icons work now.
For example,  open `/components/input-phone-international#base` or `/components/input-date#base`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
