### PR TITLE
Use appearance injection token for `InputRange`, `InputSlider` and `InputCardGrouped`

### DIFF
--- a/projects/addon-commerce/components/input-card-grouped/input-card-grouped.component.ts
+++ b/projects/addon-commerce/components/input-card-grouped/input-card-grouped.component.ts
@@ -43,6 +43,7 @@ import {
     TUI_DIGIT_REGEXP,
     TUI_MODE,
     TUI_NON_DIGIT_REGEXP,
+    TUI_TEXTFIELD_APPEARANCE,
     TuiBrightness,
     TuiDataListComponent,
     TuiDataListDirective,
@@ -182,6 +183,8 @@ export class TuiInputCardGroupedComponent
         @Inject(TUI_MODE) readonly mode$: Observable<TuiBrightness | null>,
         @Inject(TUI_INPUT_CARD_GROUPED_TEXTS)
         readonly cardGroupedTexts$: Observable<TuiCardGroupedTexts>,
+        @Inject(TUI_TEXTFIELD_APPEARANCE)
+        readonly appearance: string,
     ) {
         super(control, changeDetectorRef);
     }

--- a/projects/addon-commerce/components/input-card-grouped/input-card-grouped.template.html
+++ b/projects/addon-commerce/components/input-card-grouped/input-card-grouped.template.html
@@ -1,7 +1,7 @@
 <tui-wrapper
     *ngIf="cardGroupedTexts$ | async as texts"
-    appearance="textfield"
     class="t-common-wrapper"
+    [appearance]="appearance"
     [readOnly]="readOnly"
     [disabled]="computedDisabled"
     [focused]="computedFocused"

--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -25,6 +25,7 @@ import {
     maskedNumberStringToNumber,
     NumberFormatSettings,
     TUI_NUMBER_FORMAT,
+    TUI_TEXTFIELD_APPEARANCE,
     TuiModeDirective,
 } from '@taiga-ui/core';
 import {AbstractTuiInputSlider} from '@taiga-ui/kit/abstract';
@@ -65,6 +66,8 @@ export class TuiInputRangeComponent
         private readonly isMobile: boolean,
         @Inject(TUI_NUMBER_FORMAT)
         protected readonly numberFormat: NumberFormatSettings,
+        @Inject(TUI_TEXTFIELD_APPEARANCE)
+        readonly appearance: string,
     ) {
         super(control, changeDetectorRef);
     }

--- a/projects/kit/components/input-range/input-range.template.html
+++ b/projects/kit/components/input-range/input-range.template.html
@@ -1,6 +1,6 @@
 <div class="zone" (tuiActiveZoneChange)="onActiveZone($event)">
     <tui-wrapper
-        appearance="textfield"
+        [appearance]="appearance"
         [readOnly]="readOnly"
         [disabled]="disabled"
         [focused]="computedFocused"

--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -28,6 +28,7 @@ import {
     NumberFormatSettings,
     TUI_HINT_WATCHED_CONTROLLER,
     TUI_NUMBER_FORMAT,
+    TUI_TEXTFIELD_APPEARANCE,
     TuiHintControllerDirective,
     TuiModeDirective,
 } from '@taiga-ui/core';
@@ -71,6 +72,8 @@ export class TuiInputSliderComponent
         readonly hintController: TuiHintControllerDirective,
         @Inject(TUI_NUMBER_FORMAT)
         protected readonly numberFormat: NumberFormatSettings,
+        @Inject(TUI_TEXTFIELD_APPEARANCE)
+        readonly appearance: string,
     ) {
         super(control, changeDetectorRef);
     }

--- a/projects/kit/components/input-slider/input-slider.template.html
+++ b/projects/kit/components/input-slider/input-slider.template.html
@@ -1,5 +1,5 @@
 <tui-wrapper
-    appearance="textfield"
+    [appearance]="appearance"
     [readOnly]="readOnly"
     [disabled]="disabled"
     [focused]="computedFocused"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #1270

## What is the new behavior?

`InputRange`, `InputSlider` and `InputCardGrouped` are using appeareance injection token (`TUI_TEXTFIELD_APPEARANCE`) now, so that it is possible to apply cutom styles to it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
