### PR TITLE
fix(addon-editor): fix of displaying opacity count below 58%

### DIFF
--- a/projects/addon-editor/components/color-selector/color-edit/color-edit.component.ts
+++ b/projects/addon-editor/components/color-selector/color-edit/color-edit.component.ts
@@ -41,7 +41,7 @@ export class TuiColorEditComponent {
     }
 
     get opacity(): number {
-        return this.color[3] * 100;
+        return Math.round(this.color[3] * 100);
     }
 
     onHexChange(hex: string) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Opacity count input doesnt work correctly with opacity below 58%

Closes # <!-- link to a relevant issue. -->

## What is the new behavior?

Opacity count input work correctly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
