### PR TITLE
fix(addon-commerce): having redundant padding when currency is empty

### DIFF
--- a/projects/addon-commerce/components/money/money.style.less
+++ b/projects/addon-commerce/components/money/money.style.less
@@ -18,6 +18,6 @@
     }
 }
 
-.t-currency {
+.t-currency:not(:empty) {
     padding-left: 0.2rem;
 }

--- a/projects/demo/src/modules/components/money/examples/5/index.html
+++ b/projects/demo/src/modules/components/money/examples/5/index.html
@@ -1,2 +1,18 @@
-$
-<tui-money currency="" [value]="12345.1"></tui-money>
+<div class="example">
+    $
+    <tui-money currency="" [value]="12345.1"></tui-money>
+</div>
+
+<div class="example">
+    £
+    <tui-money currency="" [value]="100"></tui-money>
+    <span>;</span>
+
+    €
+    <tui-money currency="" [value]="200"></tui-money>
+    <span>;</span>
+
+    ₽
+    <tui-money currency="" [value]="300"></tui-money>
+    <span>;</span>
+</div>

--- a/projects/demo/src/modules/components/money/examples/5/index.less
+++ b/projects/demo/src/modules/components/money/examples/5/index.less
@@ -1,0 +1,5 @@
+@import 'taiga-ui-local';
+
+.example {
+    .tui-space(bottom, 2);
+}

--- a/projects/demo/src/modules/components/money/examples/5/index.ts
+++ b/projects/demo/src/modules/components/money/examples/5/index.ts
@@ -6,6 +6,7 @@ import {TUI_NUMBER_FORMAT} from '@taiga-ui/core';
 @Component({
     selector: 'tui-money-example-5',
     templateUrl: './index.html',
+    styleUrls: ['./index.less'],
     providers: [
         {
             provide: TUI_NUMBER_FORMAT,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #1327

## What is the new behavior?

<img width="306" alt="image" src="https://user-images.githubusercontent.com/12021443/152699930-ae292e75-2ff8-4d0b-b882-d036e5069ac0.png">

<img width="362" alt="image" src="https://user-images.githubusercontent.com/12021443/152699933-bef766b2-b4f8-411c-96b1-5430552e70c8.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
