### PR TITLE
fix(kit): `Slider` returns `number`-type value

### DIFF
--- a/projects/demo/src/modules/animations/animations.template.html
+++ b/projects/demo/src/modules/animations/animations.template.html
@@ -8,6 +8,7 @@
         <label tuiLabel label="Speed of animations:">
             <input
                 tuiSlider
+                type="range"
                 [segments]="5"
                 [min]="0"
                 [max]="3000"

--- a/projects/demo/src/modules/components/slider-old/slider-old.template.html
+++ b/projects/demo/src/modules/components/slider-old/slider-old.template.html
@@ -4,7 +4,7 @@
             <strong>Deprecated component</strong>
             . Use
             <a tuiLink routerLink="/components/slider">
-                &lt;input tuiSlider /&gt;
+                &lt;input tuiSlider type="range" /&gt;
             </a>
             from the same module.
         </tui-notification>

--- a/projects/demo/src/modules/components/slider/examples/1/index.html
+++ b/projects/demo/src/modules/components/slider/examples/1/index.html
@@ -1,3 +1,3 @@
-<input tuiSlider max="10" step="1" size="s" [(ngModel)]="value" />
+<input tuiSlider type="range" max="10" step="1" size="s" [(ngModel)]="value" />
 
-<input tuiSlider value="60" size="m" [formControl]="formControl" />
+<input tuiSlider type="range" value="60" size="m" [formControl]="formControl" />

--- a/projects/demo/src/modules/components/slider/examples/2/index.html
+++ b/projects/demo/src/modules/components/slider/examples/2/index.html
@@ -1,3 +1,3 @@
-<input tuiSlider value="65" class="first" />
-<input tuiSlider value="80" class="second" />
-<input tuiSlider value="40" class="third" />
+<input tuiSlider type="range" value="65" class="first" />
+<input tuiSlider type="range" value="80" class="second" />
+<input tuiSlider type="range" value="40" class="third" />

--- a/projects/demo/src/modules/components/slider/examples/3/index.html
+++ b/projects/demo/src/modules/components/slider/examples/3/index.html
@@ -1,4 +1,11 @@
-<input tuiSlider max="4" size="m" [segments]="4" [formControl]="formControl" />
+<input
+    tuiSlider
+    type="range"
+    max="4"
+    size="m"
+    [segments]="4"
+    [formControl]="formControl"
+/>
 
 <div class="labels">
     <span *ngFor="let label of labels" class="label">${{label}}</span>

--- a/projects/demo/src/modules/components/slider/examples/4/index.html
+++ b/projects/demo/src/modules/components/slider/examples/4/index.html
@@ -1,1 +1,1 @@
-<input tuiSlider disabled value="80" />
+<input tuiSlider type="range" disabled value="80" />

--- a/projects/demo/src/modules/components/slider/examples/import/declare-form.md
+++ b/projects/demo/src/modules/components/slider/examples/import/declare-form.md
@@ -7,6 +7,6 @@ import {FormControl} from '@angular/forms';
   // ...
 })
 export class MyComponent {
-  readonly control = new FormControl('1');
+  readonly control = new FormControl(1);
 }
 ```

--- a/projects/demo/src/modules/components/slider/examples/import/insert-template.md
+++ b/projects/demo/src/modules/components/slider/examples/import/insert-template.md
@@ -1,3 +1,3 @@
 ```html
-<input tuiSlider [formControl]="control" />
+<input tuiSlider type="range" [formControl]="control" />
 ```

--- a/projects/demo/src/modules/components/slider/slider.component.html
+++ b/projects/demo/src/modules/components/slider/slider.component.html
@@ -21,7 +21,10 @@
         </p>
         <p i18n>
             <strong>Usage:</strong>
-            <code>&lt;input tuiSlider min="0" max="100" step="1" /&gt;</code>
+            <code>
+                &lt;input tuiSlider type="range" min="0" max="100" step="1"
+                /&gt;
+            </code>
             .
         </p>
 
@@ -67,6 +70,7 @@
             <ng-template>
                 <input
                     tuiSlider
+                    type="range"
                     [max]="max"
                     [min]="min"
                     [step]="step"

--- a/projects/kit/components/slider/slider.component.ts
+++ b/projects/kit/components/slider/slider.component.ts
@@ -18,11 +18,16 @@ import {
 import {TuiSizeS} from '@taiga-ui/core';
 
 @Component({
-    selector: 'input[tuiSlider]',
+    /**
+     * We have to call our component as `<input tuiSlider type="range" ... />`
+     * because otherwise built-in angular
+     * {@link https://github.com/angular/angular/blob/master/packages/forms/src/directives/range_value_accessor.ts#L45 RangeValueAccessor}
+     * cannot be matched by its CSS selector.
+     */
+    selector: 'input[type=range][tuiSlider]',
     template: ``,
     styleUrls: ['./slider.style.less'],
     host: {
-        type: 'range',
         /**
          * For change detection.
          * Webkit does not have built-in method for customization of filling progress (as Firefox).

--- a/projects/kit/components/slider/test/slider-old.component.spec.ts
+++ b/projects/kit/components/slider/test/slider-old.component.spec.ts
@@ -11,7 +11,7 @@ import {TuiKeySteps} from '../../../types/key-steps';
 import {TuiSliderModule} from '../slider.module';
 import {TuiSliderOldComponent} from '../slider-old.component';
 
-describe('Slider', () => {
+describe('Slider-old', () => {
     @Component({
         template: `
             <tui-slider *ngIf="default" max="10" [formControl]="testValue"></tui-slider>

--- a/projects/kit/components/slider/test/slider.spec.ts
+++ b/projects/kit/components/slider/test/slider.spec.ts
@@ -1,0 +1,84 @@
+import {Component, ElementRef, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {configureTestSuite} from '@taiga-ui/testing';
+
+import {TuiSliderModule} from '../slider.module';
+
+describe('Slider', () => {
+    @Component({
+        template: `
+            <input
+                #controller
+                tuiSlider
+                type="range"
+                [max]="max"
+                [min]="min"
+                [formControl]="formController"
+            />
+            <input
+                #model
+                tuiSlider
+                type="range"
+                [max]="max"
+                [min]="min"
+                [(ngModel)]="ngModelValue"
+            />
+        `,
+    })
+    class TestComponent {
+        @ViewChild('controller', {static: true, read: ElementRef})
+        formControllerComponent!: ElementRef<HTMLInputElement>;
+
+        @ViewChild('model', {static: true, read: ElementRef})
+        ngModelComponent!: ElementRef<HTMLInputElement>;
+
+        ngModelValue = 5;
+        formController = new FormControl(5);
+
+        max = 11;
+        min = 0;
+    }
+
+    let fixture: ComponentFixture<TestComponent>;
+    let testComponent: TestComponent;
+
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            imports: [FormsModule, ReactiveFormsModule, TuiSliderModule],
+            declarations: [TestComponent],
+        });
+    });
+
+    beforeEach(async () => {
+        fixture = TestBed.createComponent(TestComponent);
+        testComponent = fixture.componentInstance;
+        fixture.detectChanges();
+
+        return fixture.whenStable();
+    });
+
+    it('has initial value of "number"-type', () => {
+        expect(typeof testComponent.formController.value).toBe('number');
+        expect(typeof testComponent.ngModelValue).toBe('number');
+    });
+
+    it('returns "number"-type value on input', async () => {
+        expect(testComponent.formController.value).toBe(5);
+        expect(testComponent.ngModelValue).toBe(5);
+
+        changeSliderValue(testComponent.formControllerComponent.nativeElement, '3');
+        changeSliderValue(testComponent.ngModelComponent.nativeElement, '3');
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(testComponent.formController.value).toBe(3);
+        expect(testComponent.ngModelValue).toBe(3);
+    });
+
+    function changeSliderValue(el: HTMLInputElement, newValue: string) {
+        el.value = newValue;
+        el.dispatchEvent(new Event('input'));
+    }
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?
We should call our component as `<input type="range" tuiSlider ... />` because otherwise built-in angular [RangeValueAccessor](https://github.com/angular/angular/blob/master/packages/forms/src/directives/range_value_accessor.ts#L45) cannot be matched by its CSS selector.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
