### PR TITLE
fix(kit): `Slider` change detection problem with `[(ngModel)]`

### DIFF
--- a/projects/kit/components/slider/slider.component.ts
+++ b/projects/kit/components/slider/slider.component.ts
@@ -1,5 +1,6 @@
 import {
     ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     ElementRef,
     HostBinding,
@@ -16,6 +17,7 @@ import {
     tuiDefaultProp,
 } from '@taiga-ui/cdk';
 import {TuiSizeS} from '@taiga-ui/core';
+import {take} from 'rxjs/operators';
 
 @Component({
     /**
@@ -60,6 +62,10 @@ export class TuiSliderComponent {
         return Number(this.elementRef.nativeElement.step) || 1;
     }
 
+    get value(): number {
+        return Number(this.elementRef.nativeElement.value) || 0;
+    }
+
     @HostBinding('style.--tui-slider-fill-percentage.%')
     get fillPercentage(): number {
         return (100 * this.value) / (this.max - this.min);
@@ -75,20 +81,26 @@ export class TuiSliderComponent {
         return isEdgeOlderThan(CHROMIUM_EDGE_START_VERSION, this.userAgent);
     }
 
-    get value(): number {
-        const {control} = this;
-        const controlValue =
-            control instanceof NgModel ? control.viewModel : control?.value;
-
-        return controlValue || Number(this.elementRef.nativeElement.value) || 0;
-    }
-
     constructor(
         @Optional()
         @Self()
         @Inject(NgControl)
-        private readonly control: NgControl | null,
+        readonly control: NgControl | null,
+        @Inject(ChangeDetectorRef) readonly changeDetectorRef: ChangeDetectorRef,
         @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLInputElement>,
         @Inject(USER_AGENT) private readonly userAgent: string,
-    ) {}
+    ) {
+        if (control instanceof NgModel) {
+            /**
+             * The ValueAccessor.writeValue method is called twice on any value accessor during component initialization,
+             * when a control is bound using [(ngModel)], first time with a phantom null value.
+             * With `changeDetection: ChangeDetectionStrategy.OnPush` the second call of writeValue with real value don't re-render the view.
+             * ___
+             * See this {@link https://github.com/angular/angular/issues/14988 issue}
+             */
+            control.valueChanges
+                ?.pipe(take(1))
+                .subscribe(() => this.changeDetectorRef.markForCheck());
+        }
+    }
 }

--- a/projects/kit/components/slider/slider.component.ts
+++ b/projects/kit/components/slider/slider.component.ts
@@ -15,6 +15,7 @@ import {
     CHROMIUM_EDGE_START_VERSION,
     isEdgeOlderThan,
     tuiDefaultProp,
+    watch,
 } from '@taiga-ui/cdk';
 import {TuiSizeS} from '@taiga-ui/core';
 import {take} from 'rxjs/operators';
@@ -85,8 +86,8 @@ export class TuiSliderComponent {
         @Optional()
         @Self()
         @Inject(NgControl)
-        readonly control: NgControl | null,
-        @Inject(ChangeDetectorRef) readonly changeDetectorRef: ChangeDetectorRef,
+        control: NgControl | null,
+        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
         @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLInputElement>,
         @Inject(USER_AGENT) private readonly userAgent: string,
     ) {
@@ -98,9 +99,7 @@ export class TuiSliderComponent {
              * ___
              * See this {@link https://github.com/angular/angular/issues/14988 issue}
              */
-            control.valueChanges
-                ?.pipe(take(1))
-                .subscribe(() => this.changeDetectorRef.markForCheck());
+            control.valueChanges?.pipe(watch(changeDetectorRef), take(1)).subscribe();
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
The ValueAccessor.writeValue method is called twice on any value accessor during component initialization, when a control is bound using `[(ngModel)]`, first time with a phantom `null` value.
With `changeDetection: ChangeDetectionStrategy.OnPush` the second call of writeValue with real value don't re-render the view.

See this issue https://github.com/angular/angular/issues/14988

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
