### PR TITLE
fix(addon-editor): add space after table created

### DIFF
--- a/projects/addon-editor/abstract/editor-adapter.abstract.ts
+++ b/projects/addon-editor/abstract/editor-adapter.abstract.ts
@@ -1,5 +1,6 @@
 import {Directive} from '@angular/core';
-import type {Editor} from '@tiptap/core';
+import type {Editor, Range} from '@tiptap/core';
+import type {EditorState} from 'prosemirror-state';
 import {Observable, Subject} from 'rxjs';
 
 @Directive()
@@ -10,6 +11,8 @@ export abstract class TuiEditor {
 
     readonly stateChange$ = new Subject();
     readonly valueChange$ = new Subject<string>();
+
+    abstract get state(): EditorState;
 
     abstract isActive$(name: string | Record<string, string>): Observable<boolean>;
 
@@ -52,6 +55,8 @@ export abstract class TuiEditor {
     abstract splitCell(): void;
     abstract setHeading(level: number): void;
     abstract setParagraph(): void;
+    abstract setHardBreak(): void;
+    abstract setTextSelection(value: number | Range): void;
     abstract toggleLink(href: string): void;
     abstract setLink(href: string): void;
     abstract unsetLink(): void;

--- a/projects/addon-editor/components/toolbar-tools/table-create/table-create.component.ts
+++ b/projects/addon-editor/components/toolbar-tools/table-create/table-create.component.ts
@@ -21,6 +21,10 @@ export class TuiTableCreateComponent {
     ) {}
 
     addTable({rows, cols}: {rows: number; cols: number}) {
+        const prev = this.editor.state.selection.anchor;
+
+        this.editor.setHardBreak();
+        this.editor.setTextSelection(prev);
         this.editor.insertTable(rows, cols);
     }
 }

--- a/projects/addon-editor/directives/tiptap-editor/tiptap-editor.service.ts
+++ b/projects/addon-editor/directives/tiptap-editor/tiptap-editor.service.ts
@@ -4,7 +4,8 @@ import {Inject, Injectable} from '@angular/core';
 import {TuiEditor} from '@taiga-ui/addon-editor/abstract';
 import {TIPTAP_EDITOR} from '@taiga-ui/addon-editor/tokens';
 import {getMarkRange} from '@taiga-ui/addon-editor/utils';
-import type {Editor} from '@tiptap/core';
+import type {Editor, Range} from '@tiptap/core';
+import type {EditorState} from 'prosemirror-state';
 import {Observable} from 'rxjs';
 import {distinctUntilChanged, map, startWith} from 'rxjs/operators';
 
@@ -29,6 +30,10 @@ export class TuiTiptapEditorService extends TuiEditor {
 
     set editable(editable: boolean) {
         this.editor.setEditable(editable);
+    }
+
+    get state(): EditorState {
+        return this.editor.state;
     }
 
     editor!: Editor;
@@ -232,6 +237,14 @@ export class TuiTiptapEditorService extends TuiEditor {
 
     setParagraph() {
         this.editor.chain().focus().setParagraph().run();
+    }
+
+    setHardBreak() {
+        this.editor.chain().setHardBreak().run();
+    }
+
+    setTextSelection(value: number | Range) {
+        this.editor.commands.setTextSelection(value);
     }
 
     toggleLink(href: string) {

--- a/projects/demo-integrations/cypress/tests/addon-editor/toolbar-new.spec.ts
+++ b/projects/demo-integrations/cypress/tests/addon-editor/toolbar-new.spec.ts
@@ -69,6 +69,36 @@ describe("Editor's toolbar", () => {
         cy.get('@wrapper').matchImageSnapshot('2-3-inserted-new-smile');
     });
 
+    it('make a html table by 2x2', () => {
+        cy.get('#basic').findByAutomationId('tui-doc-example').as('wrapper');
+        cy.get('@wrapper').find('[contenteditable]').as('input');
+
+        cy.get('@input').scrollIntoView().type('\n').should('be.visible');
+
+        cy.get('#basic')
+            .wait(WAIT_BEFORE_SCREENSHOT)
+            .matchImageSnapshot('3-1-editor-break-line');
+
+        cy.get('@wrapper').find('button[icon="tuiIconTableLarge"]').as('tableTool');
+
+        cy.get('@tableTool').focus().should('be.focused').click();
+
+        cy.get('#basic')
+            .wait(WAIT_BEFORE_SCREENSHOT)
+            .matchImageSnapshot('3-2-editor-table-tool');
+
+        cy.get('@tableTool')
+            .get('tui-table-size-selector .t-column')
+            .eq(1)
+            .find('.t-cell')
+            .eq(1)
+            .click();
+
+        cy.get('#basic')
+            .wait(WAIT_BEFORE_SCREENSHOT)
+            .matchImageSnapshot('3-3-editor-table-2x2');
+    });
+
     describe('has keyboard horizontal navigation between tool-buttons', () => {
         it('focuses nearest left/right active tool on "Arrow Right"/"Arrow Left"', () => {
             cy.get('#basic').findByAutomationId('tui-doc-example').as('wrapper');


### PR DESCRIPTION
The table, when created, sticks to the bottom of the component and does not allow you to create a new row after itself

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Part of #1302

## What is the new behavior?

![3-1-editor-break-line snap](https://user-images.githubusercontent.com/12021443/154947867-ca6db3eb-55cd-4a6f-afe5-67611190b6a9.png)
![3-2-editor-table-tool snap](https://user-images.githubusercontent.com/12021443/154947876-9bb214ee-fed5-46b9-b336-a89ca38910b1.png)
![3-3-editor-table-2x2 snap](https://user-images.githubusercontent.com/12021443/154947877-824100a0-3f23-4ec9-8bbc-351884849066.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
