### PR TITLE
fix(addon-editor): set table without style inheritance

### DIFF
--- a/projects/addon-editor/abstract/editor-adapter.abstract.ts
+++ b/projects/addon-editor/abstract/editor-adapter.abstract.ts
@@ -68,4 +68,5 @@ export abstract class TuiEditor {
     abstract setValue(value: string): void;
     abstract setCellColor(color: string): void;
     abstract getOriginTiptapEditor(): Editor;
+    abstract enter(): void;
 }

--- a/projects/addon-editor/components/toolbar-tools/font-style/font-style.template.html
+++ b/projects/addon-editor/components/toolbar-tools/font-style/font-style.template.html
@@ -13,6 +13,7 @@
             icon="tuiIconFormatLarge"
             appearance="icon"
             tuiHintDirection="top-left"
+            automation-id="toolbar__font-style-button"
             [tuiHint]="texts.fontStyle"
             [tuiHintId]="formatBtn.id"
             [tuiDescribedBy]="formatBtn.id"

--- a/projects/addon-editor/components/toolbar-tools/list-configs/list-configs.template.html
+++ b/projects/addon-editor/components/toolbar-tools/list-configs/list-configs.template.html
@@ -13,6 +13,7 @@
             icon="tuiIconViewListLarge"
             appearance="icon"
             tuiHintDirection="top-left"
+            automation-id="toolbar__ordering-list-button"
             [tuiHint]="texts.list"
             [tuiHintId]="listBtn.id"
             [tuiDescribedBy]="listBtn.id"

--- a/projects/addon-editor/components/toolbar-tools/table-create/table-create.component.ts
+++ b/projects/addon-editor/components/toolbar-tools/table-create/table-create.component.ts
@@ -21,10 +21,17 @@ export class TuiTableCreateComponent {
     ) {}
 
     addTable({rows, cols}: {rows: number; cols: number}) {
-        const prev = this.editor.state.selection.anchor;
+        this.editor.enter(); // @note: clear previous styles
 
-        this.editor.setHardBreak();
-        this.editor.setTextSelection(prev);
+        const prevLine = this.editor.state.selection.anchor;
+
+        // @note: don't use `setHardBreak`,
+        // it inherits styles of previous lines
+        // required two line after
+        this.editor.enter();
+        this.editor.enter();
+
+        this.editor.setTextSelection(prevLine);
         this.editor.insertTable(rows, cols);
     }
 }

--- a/projects/addon-editor/directives/tiptap-editor/tiptap-editor.service.ts
+++ b/projects/addon-editor/directives/tiptap-editor/tiptap-editor.service.ts
@@ -292,4 +292,8 @@ export class TuiTiptapEditorService extends TuiEditor {
             this.editor.chain().setTextSelection(range).run();
         }
     }
+
+    enter() {
+        this.editor.commands.enter();
+    }
 }

--- a/projects/demo-integrations/cypress/tests/addon-editor/toolbar-new.spec.ts
+++ b/projects/demo-integrations/cypress/tests/addon-editor/toolbar-new.spec.ts
@@ -118,6 +118,53 @@ describe("Editor's toolbar", () => {
             .matchImageSnapshot('3-3-editor-table-2x2');
     });
 
+    it('set table without style inheritance', () => {
+        cy.get('#basic').findByAutomationId('tui-doc-example').as('wrapper');
+        cy.get('@wrapper').find('[contenteditable]').as('input');
+
+        cy.get('@input')
+            .scrollIntoView()
+            .type('{selectall}{backspace}')
+            .should('be.visible');
+
+        cy.get('@wrapper')
+            .findByAutomationId('toolbar__ordering-list-button')
+            .should('be.visible')
+            .click();
+
+        cy.get('button[icon="tuiIconViewListLarge"].t-option')
+            .should('be.visible')
+            .click();
+
+        cy.get('@wrapper')
+            .findByAutomationId('toolbar__font-style-button')
+            .should('be.visible')
+            .click();
+
+        cy.get('@input').type('12345');
+
+        cy.get('@wrapper')
+            .wait(WAIT_BEFORE_SCREENSHOT)
+            .matchImageSnapshot('4-1-set-unordered-list');
+
+        cy.get('@wrapper').find('button[icon="tuiIconTableLarge"]').as('tableTool');
+
+        cy.get('@tableTool').focus().should('be.focused').should('be.visible').click();
+
+        cy.get('@tableTool')
+            .wait(WAIT_BEFORE_SCREENSHOT)
+            .get('tui-table-size-selector .t-column')
+            .eq(1)
+            .find('.t-cell')
+            .eq(1)
+            .should('be.visible')
+            .click();
+
+        cy.get('#basic')
+            .wait(WAIT_BEFORE_SCREENSHOT)
+            .matchImageSnapshot('4-2-set-table-without-style-inheritance');
+    });
+
     describe('has keyboard horizontal navigation between tool-buttons', () => {
         it('focuses nearest left/right active tool on "Arrow Right"/"Arrow Left"', () => {
             cy.get('#basic').findByAutomationId('tui-doc-example').as('wrapper');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Part of #1302 <!-- link to a relevant issue. -->

## What is the new behavior?

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/12021443/155551595-27bb1e02-d40c-48ff-bee8-d9834a2be19b.png">

<img width="963" alt="image" src="https://user-images.githubusercontent.com/12021443/155551640-86bde702-f29b-4c94-87bd-1a8c36f63ebc.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
