### PR TITLE
feat(cdk):  TUI_IS_IOS USER_AGENT add new condition IOS devices

### DIFF
--- a/projects/cdk/tokens/is-ios.ts
+++ b/projects/cdk/tokens/is-ios.ts
@@ -1,8 +1,12 @@
 import {inject, InjectionToken} from '@angular/core';
-import {USER_AGENT} from '@ng-web-apis/common';
+import {NAVIGATOR, USER_AGENT} from '@ng-web-apis/common';
 
 const IOS_REG_EXP = /ipad|iphone|ipod/;
+const APPLE_REG_EXP = /apple/;
 
 export const TUI_IS_IOS = new InjectionToken<boolean>('iOS browser detection', {
-    factory: () => IOS_REG_EXP.test(inject(USER_AGENT).toLowerCase()),
+    factory: () =>
+        IOS_REG_EXP.test(inject(USER_AGENT).toLowerCase()) ||
+        (APPLE_REG_EXP.test(inject(USER_AGENT).toLowerCase()) &&
+            inject(NAVIGATOR).maxTouchPoints > 1),
 });

--- a/projects/cdk/tokens/tests/is-ios.spec.ts
+++ b/projects/cdk/tokens/tests/is-ios.spec.ts
@@ -1,0 +1,67 @@
+import {TestBed} from '@angular/core/testing';
+import {NAVIGATOR, USER_AGENT} from '@ng-web-apis/common';
+import {configureTestSuite} from '@taiga-ui/testing';
+
+import {TUI_IS_IOS} from '../is-ios';
+
+describe('TUI_IS_IOS basic is IOS positive', () => {
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                {
+                    provide: USER_AGENT,
+                    useValue:
+                        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1',
+                },
+            ],
+        });
+    });
+
+    it('TUI_IS_IOS is iPhone', () => {
+        expect(TestBed.inject(TUI_IS_IOS)).toBeTrue();
+    });
+});
+
+describe('TUI_IS_IOS apple iPadOS/iPhone positive', () => {
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                {
+                    provide: USER_AGENT,
+                    useValue:
+                        'Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15',
+                },
+                {
+                    provide: NAVIGATOR,
+                    useValue: {maxTouchPoints: 2},
+                },
+            ],
+        });
+    });
+
+    it('TUI_IS_IOS is IOS', () => {
+        expect(TestBed.inject(TUI_IS_IOS)).toBeTrue();
+    });
+});
+
+describe('TUI_IS_IOS, MacOS Desktop, negative', () => {
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                {
+                    provide: USER_AGENT,
+                    useValue:
+                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36',
+                },
+                {
+                    provide: NAVIGATOR,
+                    useValue: {maxTouchPoints: 0},
+                },
+            ],
+        });
+    });
+
+    it('TUI_IS_IOS not IOS', () => {
+        expect(TestBed.inject(TUI_IS_IOS)).toBeFalse();
+    });
+});

--- a/projects/cdk/tokens/tests/is-ios.spec.ts
+++ b/projects/cdk/tokens/tests/is-ios.spec.ts
@@ -4,64 +4,66 @@ import {configureTestSuite} from '@taiga-ui/testing';
 
 import {TUI_IS_IOS} from '../is-ios';
 
-describe('TUI_IS_IOS basic is IOS positive', () => {
-    configureTestSuite(() => {
-        TestBed.configureTestingModule({
-            providers: [
-                {
-                    provide: USER_AGENT,
-                    useValue:
-                        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1',
-                },
-            ],
+describe('TUI_IS_IOS', () => {
+    describe('basic is IOS positive', () => {
+        configureTestSuite(() => {
+            TestBed.configureTestingModule({
+                providers: [
+                    {
+                        provide: USER_AGENT,
+                        useValue:
+                            'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1',
+                    },
+                ],
+            });
+        });
+
+        it('return true if iPhone', () => {
+            expect(TestBed.inject(TUI_IS_IOS)).toBeTrue();
         });
     });
 
-    it('TUI_IS_IOS is iPhone', () => {
-        expect(TestBed.inject(TUI_IS_IOS)).toBeTrue();
-    });
-});
+    describe('Mac OS mobile positive', () => {
+        configureTestSuite(() => {
+            TestBed.configureTestingModule({
+                providers: [
+                    {
+                        provide: USER_AGENT,
+                        useValue:
+                            'Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15',
+                    },
+                    {
+                        provide: NAVIGATOR,
+                        useValue: {maxTouchPoints: 2},
+                    },
+                ],
+            });
+        });
 
-describe('TUI_IS_IOS apple iPadOS/iPhone positive', () => {
-    configureTestSuite(() => {
-        TestBed.configureTestingModule({
-            providers: [
-                {
-                    provide: USER_AGENT,
-                    useValue:
-                        'Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15',
-                },
-                {
-                    provide: NAVIGATOR,
-                    useValue: {maxTouchPoints: 2},
-                },
-            ],
+        it('return true if apple and maxTouchPoints > 1', () => {
+            expect(TestBed.inject(TUI_IS_IOS)).toBeTrue();
         });
     });
 
-    it('TUI_IS_IOS is IOS', () => {
-        expect(TestBed.inject(TUI_IS_IOS)).toBeTrue();
-    });
-});
-
-describe('TUI_IS_IOS, MacOS Desktop, negative', () => {
-    configureTestSuite(() => {
-        TestBed.configureTestingModule({
-            providers: [
-                {
-                    provide: USER_AGENT,
-                    useValue:
-                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36',
-                },
-                {
-                    provide: NAVIGATOR,
-                    useValue: {maxTouchPoints: 0},
-                },
-            ],
+    describe('Mac OS desktop negative', () => {
+        configureTestSuite(() => {
+            TestBed.configureTestingModule({
+                providers: [
+                    {
+                        provide: USER_AGENT,
+                        useValue:
+                            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36',
+                    },
+                    {
+                        provide: NAVIGATOR,
+                        useValue: {maxTouchPoints: 0},
+                    },
+                ],
+            });
         });
-    });
 
-    it('TUI_IS_IOS not IOS', () => {
-        expect(TestBed.inject(TUI_IS_IOS)).toBeFalse();
+        it('return false if MacOS Desktop', () => {
+            expect(TestBed.inject(TUI_IS_IOS)).toBeFalse();
+        });
     });
 });


### PR DESCRIPTION
feat(cdk):  TUI_IS_IOS USER_AGENT add new condition IOS devices

Co-Authored-By: AnteaterKit <ashatilovdev@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix

## What is the current behavior?
TUI_IS_IOS  not return true on some IOS devices 

Closes [https://github.com/Tinkoff/taiga-ui/issues/1451](url)

## What is the new behavior?
Correct detect device in Safari from iOS 13

## Does this PR introduce a breaking change?
- [ ] No
