### PR TITLE
feat(core): use CSS variables for font (sizes) on textfields

### DIFF
--- a/projects/core/styles/mixins/textfield.less
+++ b/projects/core/styles/mixins/textfield.less
@@ -21,7 +21,7 @@
         height: var(--tui-height-l);
         min-height: var(--tui-height-l);
         max-height: var(--tui-height-l);
-        font-size: 0.9375rem;
+        font: var(--tui-font-text-m);
     }
 }
 
@@ -138,7 +138,6 @@
     .text-overflow();
     display: block;
     width: 100%;
-    font-size: 0.8125rem;
     user-select: none;
     color: var(--tui-text-02);
     pointer-events: none;
@@ -147,7 +146,7 @@
         transform: translateY(-0.625rem);
 
         :host[data-size='m'] & {
-            font-size: 0.69rem;
+            font: var(--tui-font-text-xs);
             transform: translateY(-0.5rem);
             letter-spacing: 0.025rem;
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #1471

## What is the new behavior?

The textfield mixins are now using corresponding CSS variables instead of hard coded values.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
