### PR TITLE
refactor(kit): `InputSlider` use `InputNumber` inside

### DIFF
--- a/projects/demo-integrations/cypress/support/shared.entities.ts
+++ b/projects/demo-integrations/cypress/support/shared.entities.ts
@@ -8,4 +8,5 @@ export const EDITOR_PAGE_URL = 'components/editor-new';
 export const MULTI_SELECT_PAGE_URL = 'components/multi-select';
 export const SELECT_PAGE_URL = 'components/select';
 export const SLIDER_PAGE_URL = 'components/slider';
+export const INPUT_SLIDER_PAGE_URL = 'components/input-slider';
 export const INPUT_PAGE_URL = 'components/input';

--- a/projects/demo-integrations/cypress/tests/kit/input-slider/input-slider.spec.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-slider/input-slider.spec.ts
@@ -1,0 +1,62 @@
+import {INPUT_SLIDER_PAGE_URL} from '../../../support/shared.entities';
+
+describe('InputSlider', () => {
+    describe('examples page', () => {
+        beforeEach(() => {
+            cy.viewport('macbook-13');
+            cy.goToDemoPage(`${INPUT_SLIDER_PAGE_URL}`);
+            cy.hideHeader();
+            cy.hideNavigation();
+        });
+
+        it('typing new value inside text input also change slider position', () => {
+            const EXAMPLE_ID = '#base';
+
+            cy.get(`${EXAMPLE_ID} input[type="range"]`).should('be.visible').as('slider');
+            cy.get(`${EXAMPLE_ID} tui-input-slider tui-input-number input`)
+                .should('be.visible')
+                .as('textInput');
+
+            const valueToSliderStep = [
+                {value: 5, step: 0},
+                {value: 9, step: 4},
+                {value: 12, step: 7},
+                {value: 18, step: 13},
+                {value: 20, step: 15},
+            ];
+
+            for (const {value, step} of valueToSliderStep) {
+                cy.get('@textInput').clear().type(`${value}`);
+                cy.get('@slider').should('have.value', step);
+                cy.get(EXAMPLE_ID).matchImageSnapshot(`1-slider-check-${value}-${step}`);
+            }
+        });
+
+        it('pressing ArrowUp/ArrowDown change textInput value and slider position', () => {
+            const EXAMPLE_ID = '#right-label';
+
+            cy.get(`${EXAMPLE_ID} input[type="range"]`).should('be.visible').as('slider');
+            cy.get(`${EXAMPLE_ID} tui-input-slider tui-input-number input`)
+                .should('be.visible')
+                .as('textInput');
+
+            cy.get('@textInput').clear().type('0');
+
+            for (let i = 1; i <= 10; i++) {
+                cy.get('@textInput').focus().type('{uparrow}').blur();
+                cy.get('@textInput').should('have.value', i);
+                cy.get('@slider').should('have.value', i);
+
+                cy.get(EXAMPLE_ID).matchImageSnapshot(`2-arrow-up-checks-${i}`);
+            }
+
+            for (let i = 9; i >= 0; i--) {
+                cy.get('@textInput').focus().type('{downarrow}').blur();
+                cy.get('@textInput').should('have.value', i);
+                cy.get('@slider').should('have.value', i);
+
+                cy.get(EXAMPLE_ID).matchImageSnapshot(`2-arrow-down-checks-${i}`);
+            }
+        });
+    });
+});

--- a/projects/demo/src/modules/components/input-slider/examples/5/index.html
+++ b/projects/demo/src/modules/components/input-slider/examples/5/index.html
@@ -1,16 +1,19 @@
 <tui-input-slider
-    maxLabel="Digits can't describe my love!"
     class="control tui-space_bottom-7"
-    [max]="100"
+    [min]="min"
+    [max]="max"
+    [valueContent]="customLabel"
     [formControl]="controlWithMaxLabel"
 >
     How much do you love Taiga UI?
 </tui-input-slider>
 
 <tui-input-slider
-    minLabel="Just a label for min value"
-    size="m"
+    new
+    tuiTextfieldSize="m"
     class="control"
-    [max]="100"
+    [min]="min"
+    [max]="max"
+    [valueContent]="customLabel"
     [formControl]="controlWithMinLabel"
 ></tui-input-slider>

--- a/projects/demo/src/modules/components/input-slider/examples/5/index.ts
+++ b/projects/demo/src/modules/components/input-slider/examples/5/index.ts
@@ -2,6 +2,7 @@ import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
+import {TuiContextWithImplicit} from '@taiga-ui/cdk';
 
 @Component({
     selector: 'tui-input-slider-example-5',
@@ -11,6 +12,22 @@ import {encapsulation} from '@demo/emulate/encapsulation';
     encapsulation,
 })
 export class TuiInputSliderExample5 {
-    readonly controlWithMinLabel = new FormControl(0);
-    readonly controlWithMaxLabel = new FormControl(100);
+    readonly max = 100;
+    readonly min = 0;
+
+    readonly controlWithMinLabel = new FormControl(this.min);
+    readonly controlWithMaxLabel = new FormControl(this.max);
+
+    readonly customLabel = ({$implicit}: TuiContextWithImplicit<number>) => {
+        switch ($implicit) {
+            case this.max:
+                return "Digits can't describe my love!";
+            case this.min:
+                return 'Just a label for min value';
+            case (this.max - this.min) / 2:
+                return 'Middle';
+            default:
+                return $implicit;
+        }
+    };
 }

--- a/projects/demo/src/modules/components/input-slider/input-slider.component.ts
+++ b/projects/demo/src/modules/components/input-slider/input-slider.component.ts
@@ -2,6 +2,7 @@ import {Component, forwardRef} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {TuiDocExample} from '@taiga-ui/addon-doc';
+import {TuiContextWithImplicit, TuiTransactionAutofillName} from '@taiga-ui/cdk';
 import {TuiPluralize, TuiSizeL} from '@taiga-ui/core';
 import {TuiKeySteps} from '@taiga-ui/kit';
 
@@ -53,7 +54,7 @@ export class ExampleTuiInputSliderComponent extends AbstractExampleTuiControl {
         LESS: import('!!raw-loader!./examples/5/index.less'),
     };
 
-    readonly control = new FormControl();
+    readonly control = new FormControl(0);
 
     readonly minVariants: readonly number[] = [0, 1, 5, 7.77, -10];
 
@@ -65,19 +66,20 @@ export class ExampleTuiInputSliderComponent extends AbstractExampleTuiControl {
 
     readonly segmentsVariants: readonly number[] = [0, 1, 5, 13];
 
-    segments = this.segmentsVariants[0];
+    segments = 1;
 
-    readonly stepsVariants: readonly number[] = [0, 4, 10];
+    steps = 0;
 
-    steps = this.stepsVariants[0];
-
-    readonly quantumVariants: readonly number[] = [1, 0.01, 0.001, 0.0001, 10, 100];
+    readonly quantumVariants: readonly number[] = [1, 0.01, 0.001, 0.0001, 10, 20, 100];
 
     quantum = this.quantumVariants[0];
 
     readonly sizeVariants: ReadonlyArray<TuiSizeL> = ['m', 'l'];
 
     size = this.sizeVariants[1];
+
+    prefix = '';
+    postfix = '';
 
     readonly pluralizeVariants: ReadonlyArray<TuiPluralize | Record<string, string>> = [
         ['year', 'years', 'years'],
@@ -96,6 +98,18 @@ export class ExampleTuiInputSliderComponent extends AbstractExampleTuiControl {
 
     secondarySelected = null;
 
+    readonly valueContentVariants = [
+        '',
+        'TOP SECRET',
+        ({$implicit: val}: TuiContextWithImplicit<number>) =>
+            val === this.max ? 'MAX' : val,
+        ({$implicit: val}: TuiContextWithImplicit<number>) =>
+            val === this.min ? 'MIN' : val,
+        ({$implicit: val}: TuiContextWithImplicit<number>) => (val === 5 ? 'FIVE' : val),
+    ];
+
+    valueContent = this.valueContentVariants[0];
+
     readonly minLabelVariants: readonly string[] = ['', 'Nothing'];
 
     minLabel = this.minLabelVariants[0];
@@ -107,6 +121,16 @@ export class ExampleTuiInputSliderComponent extends AbstractExampleTuiControl {
     readonly keyStepsVariants: ReadonlyArray<TuiKeySteps> = [[[50, 1000]]];
 
     keySteps = null;
+
+    readonly autocompleteVariants = ['off', 'transaction-amount'];
+    autocomplete: TuiTransactionAutofillName | null = null;
+
+    readonly customContentVariants: string[] = [
+        'tuiIconVisaMono',
+        'tuiIconMastercardMono',
+    ];
+
+    customContentSelected = null;
 
     get secondary(): string | null {
         return this.secondarySelected === this.secondaryVariants[0]

--- a/projects/demo/src/modules/components/input-slider/input-slider.template.html
+++ b/projects/demo/src/modules/components/input-slider/input-slider.template.html
@@ -104,24 +104,37 @@
         <tui-doc-demo [control]="control">
             <ng-template>
                 <tui-input-slider
+                    new
                     [formControl]="control"
-                    [focusable]="focusable"
                     [min]="min"
                     [max]="max"
-                    [minLabel]="minLabel"
-                    [maxLabel]="maxLabel"
-                    [segments]="segments"
-                    [size]="size"
-                    [keySteps]="keySteps"
-                    [pluralize]="pluralize"
-                    [segmentsPluralize]="segmentsPluralize"
-                    [steps]="steps"
                     [quantum]="quantum"
+                    [steps]="steps"
+                    [segments]="segments"
+                    [keySteps]="keySteps"
+                    [valueContent]="valueContent"
+                    [prefix]="prefix"
+                    [postfix]="postfix"
+                    [focusable]="focusable"
                     [readOnly]="readOnly"
-                    [secondary]="secondary"
+                    [pseudoInvalid]="pseudoInvalid"
+                    [pseudoFocused]="pseudoFocused"
+                    [pseudoHovered]="pseudoHovered"
+                    [pseudoPressed]="pseudoPressed"
+                    [tuiTextfieldAutocomplete]="autocomplete"
+                    [tuiTextfieldCleaner]="cleaner"
+                    [tuiTextfieldCustomContent]="customContentSelected"
+                    [tuiTextfieldExampleText]="exampleText"
+                    [tuiTextfieldSize]="size"
                     [tuiHintContent]="hintContent"
                     [tuiHintDirection]="hintDirection"
                     [tuiHintMode]="hintMode"
+                    [size]="size"
+                    [pluralize]="pluralize"
+                    [segmentsPluralize]="segmentsPluralize"
+                    [minLabel]="minLabel"
+                    [maxLabel]="maxLabel"
+                    [secondary]="secondary"
                 >
                     Range
                 </tui-input-slider>
@@ -137,16 +150,6 @@
                 Disabled state (use
                 <code>formControl.disable()</code>
                 )
-            </ng-template>
-            <ng-template
-                i18n
-                documentationPropertyName="keySteps"
-                documentationPropertyMode="input"
-                documentationPropertyType="TuiKeySteps"
-                [documentationPropertyValues]="keyStepsVariants"
-                [(documentationPropertyValue)]="keySteps"
-            >
-                Key steps to bind slider position and value
             </ng-template>
             <ng-template
                 i18n
@@ -170,44 +173,6 @@
             </ng-template>
             <ng-template
                 i18n
-                documentationPropertyName="minLabel"
-                documentationPropertyMode="input"
-                documentationPropertyType="string"
-                [documentationPropertyValues]="minLabelVariants"
-                [(documentationPropertyValue)]="minLabel"
-            >
-                Label for min value
-            </ng-template>
-            <ng-template
-                i18n
-                documentationPropertyName="maxLabel"
-                documentationPropertyMode="input"
-                documentationPropertyType="string"
-                [documentationPropertyValues]="maxLabelVariants"
-                [(documentationPropertyValue)]="maxLabel"
-            >
-                Label for max value
-            </ng-template>
-            <ng-template
-                i18n
-                documentationPropertyName="pluralize"
-                documentationPropertyMode="input"
-                documentationPropertyType="TuiPluralize | Record<string, string>"
-                [documentationPropertyValues]="pluralizeVariants"
-                [(documentationPropertyValue)]="pluralize"
-            >
-                Plural forms for labels. TuiPluralize array is deprecated. Use
-                object that mimics the
-                <a
-                    tuiLink
-                    href="https://unicode-org.github.io/icu/userguide/format_parse/messages/"
-                >
-                    ICU format
-                </a>
-                for i18nPlural
-            </ng-template>
-            <ng-template
-                i18n
                 documentationPropertyName="quantum"
                 documentationPropertyMode="input"
                 documentationPropertyType="number"
@@ -218,33 +183,118 @@
             </ng-template>
             <ng-template
                 i18n
+                documentationPropertyName="steps"
+                documentationPropertyMode="input"
+                documentationPropertyType="number"
+                [(documentationPropertyValue)]="steps"
+            >
+                Number of actual discrete slider steps
+
+                <p>
+                    If property is not set (i.e. equals to default value
+                    <strong>0</strong>
+                    ), number of steps equals
+                    <code>(max&nbsp;-&nbsp;min)&nbsp;/&nbsp;quantum</code>
+                </p>
+            </ng-template>
+            <ng-template
+                i18n
                 documentationPropertyName="segments"
                 documentationPropertyMode="input"
                 documentationPropertyType="number"
-                [documentationPropertyValues]="segmentsVariants"
                 [(documentationPropertyValue)]="segments"
             >
-                A number of visual segments
+                A number of visual segments (use
+                <code>1</code>
+                for no ticks)
+            </ng-template>
+            <ng-template
+                i18n
+                documentationPropertyName="keySteps"
+                documentationPropertyMode="input"
+                documentationPropertyType="TuiKeySteps"
+                [documentationPropertyValues]="keyStepsVariants"
+                [(documentationPropertyValue)]="keySteps"
+            >
+                Key steps to bind slider position and value
+            </ng-template>
+            <ng-template
+                i18n
+                documentationPropertyName="valueContent"
+                documentationPropertyMode="input"
+                documentationPropertyType="PolymorpheusContent"
+                [documentationPropertyValues]="valueContentVariants"
+                [(documentationPropertyValue)]="valueContent"
+            >
+                A template for custom view of selected value.
+            </ng-template>
+            <ng-template
+                i18n
+                documentationPropertyName="prefix"
+                documentationPropertyMode="input"
+                documentationPropertyType="string"
+                [(documentationPropertyValue)]="prefix"
+            >
+                A prefix symbol, like currency
+            </ng-template>
+            <ng-template
+                i18n
+                documentationPropertyName="postfix"
+                documentationPropertyMode="input"
+                documentationPropertyType="string"
+                [(documentationPropertyValue)]="postfix"
+            >
+                A postfix symbol, like currency
+            </ng-template>
+            <ng-template
+                i18n
+                documentationPropertyName="minLabel"
+                documentationPropertyMode="input"
+                documentationPropertyType="string"
+                [documentationPropertyDeprecated]="true"
+                [documentationPropertyValues]="minLabelVariants"
+                [(documentationPropertyValue)]="minLabel"
+            >
+                Label for min value.
+
+                <p>
+                    Use
+                    <code>valueContent</code>
+                    instead.
+                </p>
+            </ng-template>
+            <ng-template
+                i18n
+                documentationPropertyName="maxLabel"
+                documentationPropertyMode="input"
+                documentationPropertyType="string"
+                [documentationPropertyDeprecated]="true"
+                [documentationPropertyValues]="maxLabelVariants"
+                [(documentationPropertyValue)]="maxLabel"
+            >
+                Label for max value.
+
+                <p>
+                    Use
+                    <code>valueContent</code>
+                    instead.
+                </p>
             </ng-template>
             <ng-template
                 i18n
                 documentationPropertyName="size"
                 documentationPropertyMode="input"
                 documentationPropertyType="TuiSizeL"
+                [documentationPropertyDeprecated]="true"
                 [documentationPropertyValues]="sizeVariants"
                 [(documentationPropertyValue)]="size"
             >
                 Size
-            </ng-template>
-            <ng-template
-                i18n
-                documentationPropertyName="steps"
-                documentationPropertyMode="input"
-                documentationPropertyType="number"
-                [documentationPropertyValues]="stepsVariants"
-                [(documentationPropertyValue)]="steps"
-            >
-                Number of actual discrete slider steps
+                <p>
+                    Use
+                    <code>tuiTextfieldSize</code>
+                    instead.
+                </p>
             </ng-template>
             <ng-template
                 i18n
@@ -264,6 +314,31 @@
             </ng-template>
             <ng-template
                 i18n
+                documentationPropertyName="pluralize"
+                documentationPropertyMode="input"
+                documentationPropertyType="TuiPluralize | Record<string, string>"
+                [documentationPropertyDeprecated]="true"
+                [documentationPropertyValues]="pluralizeVariants"
+                [(documentationPropertyValue)]="pluralize"
+            >
+                Plural forms for labels. TuiPluralize array is deprecated. Use
+                object that mimics the
+                <a
+                    tuiLink
+                    href="https://unicode-org.github.io/icu/userguide/format_parse/messages/"
+                >
+                    ICU format
+                </a>
+                for i18nPlural.
+
+                <p>
+                    Use
+                    <code>postfix</code>
+                    instead.
+                </p>
+            </ng-template>
+            <ng-template
+                i18n
                 documentationPropertyName="segmentsPluralize"
                 documentationPropertyMode="input"
                 documentationPropertyType="TuiPluralize"
@@ -273,6 +348,11 @@
             >
                 Plural forms for
                 <code>segments</code>
+
+                <p>
+                    See examples how create ticks without this property (outside
+                    of the component).
+                </p>
             </ng-template>
         </tui-doc-documentation>
         <inherited-documentation></inherited-documentation>

--- a/projects/kit/abstract/input-slider.ts
+++ b/projects/kit/abstract/input-slider.ts
@@ -11,10 +11,8 @@ import {
 import {
     maskedNumberStringToNumber,
     NumberFormatSettings,
-    TuiBrightness,
     tuiCreateAutoCorrectedNumberPipe,
     tuiCreateNumberMask,
-    TuiModeDirective,
     TuiPluralize,
     tuiPluralizeToICU,
     TuiSizeL,
@@ -33,13 +31,13 @@ export function quantumAssertion(quantum: number): boolean {
 
 /**
  * @internal
+ * @deprecated TODO delete me after `InputSlider` and `InputRange` stop using it
  */
 @Directive()
 export abstract class AbstractTuiInputSlider<T>
     extends AbstractTuiControl<T>
     implements TuiWithOptionalMinMax<number>
 {
-    protected abstract readonly modeDirective: TuiModeDirective | null;
     protected abstract readonly numberFormat: NumberFormatSettings;
 
     @Input()
@@ -110,9 +108,13 @@ export abstract class AbstractTuiInputSlider<T>
     pluralizeMap: Record<string, string> | null = null;
     /** @deprecated TODO remove in v3.0 */
     segmentsPluralizeMap: Record<string, string> | null = null;
-
-    abstract get showMinLabel(): boolean;
-    abstract get showMaxLabel(): boolean;
+    /** @deprecated TODO remove in v3.0 */
+    readonly pluralizeMapFallback = {
+        one: '',
+        few: '',
+        many: '',
+        other: '',
+    };
 
     /** @deprecated TODO remove in v3.0 */
     @tuiPure
@@ -173,11 +175,6 @@ export abstract class AbstractTuiInputSlider<T>
 
     get computedKeySteps(): TuiKeySteps {
         return this.computePureKeySteps(this.keySteps, this.min, this.max);
-    }
-
-    @HostBinding('attr.data-mode')
-    get hostMode(): TuiBrightness | null {
-        return this.modeDirective && this.modeDirective.mode;
     }
 
     onHovered(hovered: boolean) {

--- a/projects/kit/components/input-number/input-number.module.ts
+++ b/projects/kit/components/input-number/input-number.module.ts
@@ -1,3 +1,4 @@
+import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {TuiMapperPipeModule} from '@taiga-ui/cdk';
 import {
@@ -6,6 +7,7 @@ import {
     TuiTextfieldControllerModule,
 } from '@taiga-ui/core';
 import {TuiValueAccessorModule} from '@taiga-ui/kit/directives';
+import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 import {TextMaskModule} from 'angular2-text-mask';
 
 import {TuiInputNumberComponent} from './input-number.component';
@@ -13,11 +15,13 @@ import {TuiInputNumberDirective} from './input-number.directive';
 
 @NgModule({
     imports: [
+        CommonModule,
         TextMaskModule,
         TuiMapperPipeModule,
         TuiPrimitiveTextfieldModule,
         TuiTextfieldControllerModule,
         TuiValueAccessorModule,
+        PolymorpheusModule,
     ],
     declarations: [TuiInputNumberComponent, TuiInputNumberDirective],
     exports: [TuiInputNumberComponent, TuiInputNumberDirective, TuiTextfieldComponent],

--- a/projects/kit/components/input-number/input-number.template.html
+++ b/projects/kit/components/input-number/input-number.template.html
@@ -4,6 +4,7 @@
     class="textfield"
     [pseudoHovered]="pseudoHovered"
     [pseudoFocused]="computedFocused"
+    [pseudoPressed]="pseudoPressed"
     [invalid]="computedInvalid"
     [tuiTextfieldMaxLength]="calculatedMaxLength"
     [readOnly]="readOnly"
@@ -21,4 +22,13 @@
 >
     <ng-content></ng-content>
     <ng-content select="input" ngProjectAs="input"></ng-content>
+    <div
+        *ngIf="polymorpheusValueContent"
+        polymorpheus-outlet
+        [content]="valueContent"
+    ></div>
 </tui-primitive-textfield>
+
+<ng-template #valueContent>
+    <ng-content select="[polymorpheus-outlet]"></ng-content>
+</ng-template>

--- a/projects/kit/components/input-number/input-number.template.html
+++ b/projects/kit/components/input-number/input-number.template.html
@@ -2,9 +2,9 @@
     tuiValueAccessor
     tuiTextfieldInputMode="decimal"
     class="textfield"
-    [pseudoHovered]="pseudoHovered"
+    [pseudoHovered]="computedHovered"
     [pseudoFocused]="computedFocused"
-    [pseudoPressed]="pseudoPressed"
+    [pseudoPressed]="computedPressed"
     [invalid]="computedInvalid"
     [tuiTextfieldMaxLength]="calculatedMaxLength"
     [readOnly]="readOnly"

--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -27,6 +27,7 @@ import {
     NumberFormatSettings,
     TUI_NUMBER_FORMAT,
     TUI_TEXTFIELD_APPEARANCE,
+    TuiBrightness,
     TuiModeDirective,
 } from '@taiga-ui/core';
 import {AbstractTuiInputSlider} from '@taiga-ui/kit/abstract';
@@ -97,6 +98,11 @@ export class TuiInputRangeComponent
     @HostBinding('class._max-label')
     get showMaxLabel(): boolean {
         return !this.focusedRight && !!this.maxLabel && this.value[1] === this.max;
+    }
+
+    @HostBinding('attr.data-mode')
+    get hostMode(): TuiBrightness | null {
+        return this.modeDirective && this.modeDirective.mode;
     }
 
     get inputValueLeft(): string {

--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -244,7 +244,7 @@ export class TuiInputSliderComponent
             this.safelyUpdateValue(value);
         }
 
-        this.updateTextInputValue(value);
+        this.updateTextInputValue(this.valueGuard(value));
     }
 
     onFocused(focused: boolean) {

--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -5,7 +5,6 @@ import {
     Directive,
     ElementRef,
     forwardRef,
-    HostBinding,
     Inject,
     Input,
     Optional,
@@ -14,34 +13,39 @@ import {
 } from '@angular/core';
 import {NgControl} from '@angular/forms';
 import {
+    clamp,
     isNativeFocused,
+    round,
     setNativeFocused,
     TUI_FOCUSABLE_ITEM_ACCESSOR,
+    tuiAssert,
+    TuiContextWithImplicit,
     tuiDefaultProp,
     TuiFocusableElementAccessor,
     TuiNativeFocusableElement,
+    tuiPure,
 } from '@taiga-ui/cdk';
 import {
-    formatNumber,
+    getFractionPartPadded,
     HINT_CONTROLLER_PROVIDER,
-    maskedMoneyValueIsEmpty,
-    maskedNumberStringToNumber,
     NumberFormatSettings,
     TEXTFIELD_CONTROLLER_PROVIDER,
-    TUI_HINT_WATCHED_CONTROLLER,
     TUI_NUMBER_FORMAT,
-    TUI_TEXTFIELD_APPEARANCE,
     TUI_TEXTFIELD_WATCHED_CONTROLLER,
-    TuiHintControllerDirective,
-    TuiModeDirective,
+    TuiDecimalT,
+    TuiSizeL,
     TuiTextfieldController,
 } from '@taiga-ui/core';
 import {AbstractTuiInputSlider} from '@taiga-ui/kit/abstract';
+import {TuiInputNumberComponent} from '@taiga-ui/kit/components/input-number';
 import {
     TuiSliderComponent,
     tuiSliderOptionsProvider,
 } from '@taiga-ui/kit/components/slider';
+import {TUI_FLOATING_PRECISION} from '@taiga-ui/kit/constants';
 import {TUI_FROM_TO_TEXTS} from '@taiga-ui/kit/tokens';
+import {TuiKeySteps} from '@taiga-ui/kit/types';
+import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {Observable} from 'rxjs';
 
 /**
@@ -77,15 +81,63 @@ export class TuiNewInputSliderDirective {}
         TEXTFIELD_CONTROLLER_PROVIDER,
     ],
 })
+/**
+ * TODO replace `extends AbstractTuiInputSlider<number>` by `extends AbstractTuiControl<number> implements TuiWithOptionalMinMax<number>`
+ * in v3.0
+ */
 export class TuiInputSliderComponent
     extends AbstractTuiInputSlider<number>
     implements TuiFocusableElementAccessor
 {
-    @ViewChild('focusableElement')
-    private readonly focusableElement?: ElementRef<HTMLInputElement>;
+    @ViewChild(TuiInputNumberComponent)
+    private readonly inputNumberRef?: TuiInputNumberComponent;
 
     @ViewChild(TuiSliderComponent, {read: ElementRef})
     private readonly sliderRef?: ElementRef<HTMLInputElement>;
+
+    @Input()
+    @tuiDefaultProp()
+    min = 0;
+
+    @Input()
+    @tuiDefaultProp()
+    max = Infinity;
+
+    @Input()
+    @tuiDefaultProp(quantumAssertion, 'Quantum must be positive')
+    quantum = 1;
+
+    @Input()
+    @tuiDefaultProp()
+    steps = 0;
+
+    @Input()
+    @tuiDefaultProp()
+    segments = 0;
+
+    @Input()
+    @tuiDefaultProp()
+    keySteps: TuiKeySteps | null = null;
+
+    @Input()
+    @tuiDefaultProp()
+    valueContent: PolymorpheusContent<TuiContextWithImplicit<number>> = '';
+
+    @Input()
+    @tuiDefaultProp()
+    prefix = '';
+
+    @Input()
+    @tuiDefaultProp()
+    postfix = '';
+
+    /**
+     * @deprecated use `tuiTextfieldSize` instead
+     * TODO delete in v3.0
+     */
+    @Input()
+    @tuiDefaultProp()
+    size: TuiSizeL = 'l';
 
     /**
      * @deprecated use `tuiTextfieldCustomContent` instead
@@ -101,17 +153,10 @@ export class TuiInputSliderComponent
         @Inject(NgControl)
         control: NgControl | null,
         @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
-        @Optional()
-        @Inject(TuiModeDirective)
-        protected readonly modeDirective: TuiModeDirective | null,
-        @Inject(TUI_HINT_WATCHED_CONTROLLER)
-        readonly hintController: TuiHintControllerDirective,
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         readonly controller: TuiTextfieldController,
         @Inject(TUI_NUMBER_FORMAT)
         protected readonly numberFormat: NumberFormatSettings,
-        @Inject(TUI_TEXTFIELD_APPEARANCE)
-        readonly appearance: string,
         @Inject(TUI_FROM_TO_TEXTS) readonly fromToTexts$: Observable<[string, string]>,
         @Optional()
         @Inject(TuiNewInputSliderDirective)
@@ -121,9 +166,9 @@ export class TuiInputSliderComponent
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {
-        return !this.focusableElement || this.computedDisabled
+        return !this.inputNumberRef?.nativeFocusableElement || this.computedDisabled
             ? null
-            : this.focusableElement.nativeElement;
+            : this.inputNumberRef.nativeFocusableElement;
     }
 
     get focused(): boolean {
@@ -133,149 +178,133 @@ export class TuiInputSliderComponent
         );
     }
 
-    @HostBinding('class._has-tooltip')
-    get hasTooltip(): boolean {
-        return !!this.hintController.content && !this.disabled;
+    get computedSteps(): number {
+        return this.steps || (this.max - this.min) / this.quantum;
     }
 
-    @HostBinding('class._min-label')
-    get showMinLabel(): boolean {
-        return !this.focused && this.value === this.min && !!this.minLabel;
+    get precision(): number {
+        return getFractionPartPadded(this.quantum).length;
     }
 
-    @HostBinding('class._max-label')
-    get showMaxLabel(): boolean {
-        return !this.focused && this.value === this.max && !!this.maxLabel;
+    get decimal(): TuiDecimalT {
+        return this.precision ? 'not-zero' : 'never';
     }
 
-    get computedValue(): string {
-        if (this.focused && this.isInputValueNotFinished) {
-            return this.inputValue;
+    /**
+     * TODO remove old property `size` in v3.0
+     */
+    get computedSize(): TuiSizeL {
+        if (this.isNew) {
+            tuiAssert.assert(
+                this.controller.size !== 's',
+                "Size 's' is not supported by this input.",
+            );
+
+            return this.controller.size === 'l' ? 'l' : 'm';
         }
 
-        return this.formattedValue;
+        return this.size;
     }
 
-    get showValue(): boolean {
-        return !this.showMinLabel && !this.showMaxLabel;
+    /**
+     * @deprecated for backward compatibility
+     * TODO replace by just `this.valueContent` in v3.0
+     */
+    get computedValueContent(): PolymorpheusContent<TuiContextWithImplicit<number>> {
+        return this.minLabel || this.maxLabel
+            ? legacyMinMaxLabel(this)
+            : this.valueContent;
     }
 
-    get inputValue(): string {
-        return this.focusableElement ? this.focusableElement.nativeElement.value : '';
-    }
-
-    set inputValue(value: string) {
-        if (this.focusableElement) {
-            this.focusableElement.nativeElement.value = value;
-        }
+    @tuiPure
+    computeContext(value: number): TuiContextWithImplicit<number> {
+        return {$implicit: value};
     }
 
     focusTextInput() {
-        if (this.focusableElement) {
-            setNativeFocused(this.focusableElement.nativeElement);
+        const focusableElement = this.inputNumberRef?.nativeFocusableElement;
+
+        if (focusableElement) {
+            setNativeFocused(focusableElement);
         }
     }
 
-    onKeyDownArrowUp(event: KeyboardEvent) {
+    safelyUpdateValue(value: number | null) {
+        this.updateValue(this.valueGuard(value ?? this.safeCurrentValue));
+    }
+
+    onVerticalArrowKeyDown(coefficient: number) {
         if (this.readOnly) {
             return;
         }
 
-        event.preventDefault();
-        this.processStep(true);
-        this.inputValue = this.formattedValue;
-    }
+        const value = this.value + coefficient * this.step;
 
-    onKeyDownArrowDown(event: KeyboardEvent) {
-        if (this.readOnly) {
-            return;
+        if (value !== this.value) {
+            this.safelyUpdateValue(value);
         }
 
-        event.preventDefault();
-        this.processStep(false);
-        this.inputValue = this.formattedValue;
+        this.updateTextInputValue(value);
     }
 
     onFocused(focused: boolean) {
+        if (!focused && !this.textInputValue) {
+            this.updateTextInputValue(this.safeCurrentValue);
+        }
+
         this.updateFocused(focused);
-
-        if (focused) {
-            return;
-        }
-
-        const inputValue = maskedNumberStringToNumber(
-            this.computedValue,
-            this.numberFormat.decimalSeparator,
-            this.numberFormat.thousandSeparator,
-        );
-        const value = isNaN(inputValue) ? this.min : this.valueGuard(inputValue);
-
-        this.updateValue(value);
-        this.inputValue = this.formattedValue;
     }
 
-    onValue(value: string) {
-        const capped = this.capInputValue(value);
-        const postfix = value.slice(-1)[0] === ',' ? ',' : '';
-
-        if (maskedMoneyValueIsEmpty(value) || capped === null) {
-            return;
-        }
-
-        const newValue = this.formatNumber(capped) + postfix;
-
-        if (value !== newValue) {
-            this.inputValue = newValue;
-        }
-
-        this.updateValue(capped);
+    onPressed(pressed: boolean) {
+        this.updatePressed(pressed);
     }
 
-    onSliderValue(value: number) {
-        this.updateValue(this.valueGuard(value));
-        this.inputValue = this.formattedValue;
+    onHovered(hovered: boolean) {
+        this.updateHovered(hovered);
+    }
+
+    private get textInputValue(): string {
+        return this.inputNumberRef?.nativeValue || '';
     }
 
     protected getFallbackValue(): number {
         return 0;
     }
 
-    private get formattedValue(): string {
-        return this.formatNumber(this.value);
-    }
-
-    private get isInputValueNotFinished(): boolean {
-        if (this.inputValue === '') {
-            return true;
-        }
-
-        const nativeNumberValue = maskedNumberStringToNumber(
-            this.inputValue,
-            this.numberFormat.decimalSeparator,
-            this.numberFormat.thousandSeparator,
+    protected valueGuard(value: number): number {
+        const roundedValue = round(
+            Math.round(value / this.quantum) * this.quantum,
+            TUI_FLOATING_PRECISION,
         );
 
-        return nativeNumberValue < 0
-            ? nativeNumberValue > this.max
-            : nativeNumberValue < this.min;
+        return clamp(roundedValue, this.min, this.max);
     }
 
-    private processStep(increment: boolean) {
-        const value = this.valueGuard(
-            increment ? this.value + this.step : this.value - this.step,
-        );
-
-        if (value !== this.value) {
-            this.updateValue(value);
+    private updateTextInputValue(value: number) {
+        if (this.inputNumberRef) {
+            this.inputNumberRef.nativeValue =
+                this.inputNumberRef.getFormattedValue(value);
         }
     }
+}
 
-    private formatNumber(value: number): string {
-        return formatNumber(
-            value,
-            null,
-            this.numberFormat.decimalSeparator,
-            this.numberFormat.thousandSeparator,
-        );
-    }
+function quantumAssertion(quantum: number): boolean {
+    return quantum > 0;
+}
+
+/**
+ * @deprecated helper for backward compatibility.
+ * TODO remove in v3.0
+ */
+function legacyMinMaxLabel({min, max, minLabel, maxLabel}: TuiInputSliderComponent) {
+    return ({$implicit: value}: TuiContextWithImplicit<number>) => {
+        switch (value) {
+            case min:
+                return minLabel || value;
+            case max:
+                return maxLabel || value;
+            default:
+                return value;
+        }
+    };
 }

--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -23,7 +23,6 @@ import {
     tuiDefaultProp,
     TuiFocusableElementAccessor,
     TuiNativeFocusableElement,
-    tuiPure,
 } from '@taiga-ui/cdk';
 import {
     getFractionPartPadded,
@@ -214,11 +213,6 @@ export class TuiInputSliderComponent
         return this.minLabel || this.maxLabel
             ? legacyMinMaxLabel(this)
             : this.valueContent;
-    }
-
-    @tuiPure
-    computeContext(value: number): TuiContextWithImplicit<number> {
-        return {$implicit: value};
     }
 
     focusTextInput() {

--- a/projects/kit/components/input-slider/input-slider.module.ts
+++ b/projects/kit/components/input-slider/input-slider.module.ts
@@ -12,9 +12,11 @@ import {
 } from '@taiga-ui/cdk';
 import {
     TuiFormatNumberPipeModule,
+    TuiTextfieldControllerModule,
     TuiTooltipModule,
     TuiWrapperModule,
 } from '@taiga-ui/core';
+import {TuiInputNumberModule} from '@taiga-ui/kit/components/input-number';
 import {TuiSliderModule} from '@taiga-ui/kit/components/slider';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 import {TextMaskModule} from 'angular2-text-mask';
@@ -42,6 +44,8 @@ import {
         TuiFormatNumberPipeModule,
         TuiRepeatTimesModule,
         PolymorpheusModule,
+        TuiInputNumberModule,
+        TuiTextfieldControllerModule,
     ],
     declarations: [TuiInputSliderComponent, TuiNewInputSliderDirective],
     exports: [TuiInputSliderComponent, TuiNewInputSliderDirective],

--- a/projects/kit/components/input-slider/input-slider.style.less
+++ b/projects/kit/components/input-slider/input-slider.style.less
@@ -1,107 +1,14 @@
 @import 'taiga-ui-local';
 
-@padding: 1rem;
-@padding2: @padding * 2;
-
 :host {
     .createStackingContext();
     display: block;
-    font: var(--tui-font-text-m);
-    border-radius: var(--tui-radius-m);
-    color: var(--tui-text-01);
 
     &._segmented._show-ticks-labels {
         // TODO: remove in v3.0
         /* stylelint-disable-next-line */
         border-bottom: 26px solid transparent;
     }
-}
-
-.t-native {
-    .fullsize();
-    .clearinput();
-    width: 100%;
-    color: var(--tui-text-01);
-    box-sizing: border-box;
-    padding: 0 @padding;
-    outline: none;
-
-    :host._disabled & {
-        color: var(--tui-text-03);
-        user-select: none;
-    }
-
-    :host._min-label &,
-    :host._max-label & {
-        opacity: 0;
-    }
-
-    :host[data-size='l'] & {
-        padding: 1.25rem @padding 0;
-    }
-
-    :host[data-mode='onDark'] & {
-        color: var(--tui-text-01-night);
-    }
-
-    :host[data-mode='onDark']._disabled & {
-        color: var(--tui-text-03-night);
-    }
-}
-
-.t-content {
-    display: flex;
-    align-items: center;
-    height: var(--tui-height-m);
-    padding: 0 @padding;
-    justify-content: space-between;
-
-    :host[data-size='l'] & {
-        height: var(--tui-height-l);
-        padding: 0 @padding;
-    }
-}
-
-.t-placeholder {
-    .textfield-placeholder();
-    .fullsize();
-    padding: 0 var(--tui-padding-l);
-    line-height: var(--tui-height-l);
-    box-sizing: border-box;
-    pointer-events: none;
-
-    :host._has-tooltip & {
-        max-width: calc(100% - 1.75rem);
-    }
-}
-
-.t-value {
-    visibility: hidden;
-}
-
-.t-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-
-    :host[data-size='l'] & {
-        padding-top: 1.25rem;
-    }
-}
-
-.t-secondary {
-    color: var(--tui-text-01);
-
-    :host._disabled & {
-        color: var(--tui-text-03);
-    }
-
-    :host[data-mode='onDark']._disabled & {
-        color: var(--tui-text-03-night);
-    }
-}
-
-.t-tooltip {
-    margin-left: 0.75rem;
 }
 
 // TODO: remove wrapper and move all styles to input[type='range'] in v3.0

--- a/projects/kit/components/input-slider/input-slider.template.html
+++ b/projects/kit/components/input-slider/input-slider.template.html
@@ -1,78 +1,38 @@
-<tui-wrapper
-    [appearance]="appearance"
+<tui-input-number
+    [min]="min"
+    [max]="max"
+    [precision]="precision"
+    [decimal]="decimal"
+    [prefix]="prefix"
+    [postfix]="postfix || (value | i18nPlural: pluralizeMap || pluralizeMapFallback)"
+    [tuiTextfieldCustomContent]="controller.customContent || deprecatedSecondary"
+    [tuiTextfieldSize]="computedSize"
+    [tuiTextfieldLabelOutside]="computedSize !== 'l'"
     [readOnly]="readOnly"
-    [disabled]="disabled"
-    [focused]="computedFocused"
-    [hovered]="computedHovered"
-    [invalid]="computedInvalid"
+    [pseudoFocused]="computedFocused"
+    [pseudoHovered]="pseudoHovered"
+    [pseudoPressed]="pseudoPressed"
+    [pseudoInvalid]="pseudoInvalid"
+    [ngModel]="value"
+    (ngModelChange)="safelyUpdateValue($event)"
+    (focusedChange)="onFocused($event)"
+    (hoveredChange)="onHovered($event)"
+    (pressedChange)="onPressed($event)"
+    (keydown.arrowUp.prevent)="onVerticalArrowKeyDown(1)"
+    (keydown.arrowDown.prevent)="onVerticalArrowKeyDown(-1)"
 >
-    <span
-        *ngIf="hasPlaceholder"
-        automation-id="tui-input-slider__placeholder"
-        class="t-placeholder t-placeholder_raised"
-    >
-        <ng-content></ng-content>
-    </span>
-    <input
-        #focusableElement
-        automation-id="tui-input-slider__native"
-        class="t-native"
-        [disabled]="disabled"
-        [readOnly]="readOnly"
-        [tuiInputMode]="inputMode"
-        [tuiFocusable]="focusable"
-        [textMask]="quantum | tuiMapper: mask:min"
-        [ngModel]="computedValue"
-        (ngModelChange)="onValue($event)"
-        (tuiFocusedChange)="onFocused($event)"
-        (tuiHoveredChange)="onHovered($event)"
-        (keydown.arrowUp)="onKeyDownArrowUp($event)"
-        (keydown.arrowDown)="onKeyDownArrowDown($event)"
-    />
-    <div class="t-content">
-        <span *ngIf="showValue" class="t-label">
-            <span class="t-value">{{ computedValue }}</span>
-            <span
-                *ngIf="pluralizeMap"
-                automation-id="tui-input-slider__pluralize"
-            >
-                {{ value | i18nPlural: pluralizeMap }}
-            </span>
-        </span>
-        <span
-            *ngIf="showMinLabel"
-            automation-id="tui-input-slider__min-label"
-            class="t-label"
-        >
-            {{ minLabel }}
-        </span>
-        <span
-            *ngIf="showMaxLabel"
-            automation-id="tui-input-slider__max-label"
-            class="t-label"
-        >
-            {{ maxLabel }}
-        </span>
-        <span automation-id="tui-input-slider__secondary" class="t-secondary">
-            <span
-                polymorpheus-outlet
-                [content]="controller.customContent || secondary"
-            ></span>
-            <tui-tooltip
-                *ngIf="hasTooltip"
-                automation-id="tui-input-slider__tooltip"
-                describeId="placeholer_until_accesibility_is_added"
-                class="t-tooltip"
-                [content]="hintController.content"
-                [direction]="hintController.direction"
-                [mode]="hintController.mode"
-                [showDelay]="hintController.showDelay"
-                [hideDelay]="hintController.hideDelay"
-                (mousedown.prevent)="focusTextInput()"
-            ></tui-tooltip>
-        </span>
-    </div>
-</tui-wrapper>
+    <ng-content></ng-content>
+    <div
+        *ngIf="computedValueContent && !focused"
+        polymorpheus-outlet
+        automation-id="tui-input-slider__value-content"
+        [content]="computedValueContent"
+        [context]="computeContext(value)"
+    ></div>
+</tui-input-number>
+
+<!--TODO: remove in v3.0-->
+<ng-template #deprecatedSecondary>{{secondary}}</ng-template>
 
 <!--TODO: remove wrapper + ticks labels (leave only slider) in v3.0-->
 <div class="t-slider-wrapper">
@@ -85,12 +45,12 @@
         [keySteps]="computedKeySteps"
         [attr.disabled]="readOnly || disabled || null"
         [ngModel]="value"
-        (keyStepsInput)="onSliderValue($event)"
+        (keyStepsInput)="safelyUpdateValue($event)"
         (click)="focusTextInput()"
     />
 
     <!--TODO delete ticks labels in v3.0-->
-    <div *ngIf="segmented && !isNew" class="t-ticks-labels">
+    <div *ngIf="segments && !isNew" class="t-ticks-labels">
         <span
             *tuiRepeatTimes="let tickIndex of segments + 1"
             automation-id="tui-slider__segment"

--- a/projects/kit/components/input-slider/input-slider.template.html
+++ b/projects/kit/components/input-slider/input-slider.template.html
@@ -10,8 +10,8 @@
     [tuiTextfieldLabelOutside]="computedSize !== 'l'"
     [readOnly]="readOnly"
     [pseudoFocused]="computedFocused"
-    [pseudoHovered]="pseudoHovered"
-    [pseudoPressed]="pseudoPressed"
+    [pseudoHovered]="computedHovered"
+    [pseudoPressed]="computedPressed"
     [pseudoInvalid]="pseudoInvalid"
     [ngModel]="value"
     (ngModelChange)="safelyUpdateValue($event)"
@@ -27,7 +27,7 @@
         polymorpheus-outlet
         automation-id="tui-input-slider__value-content"
         [content]="computedValueContent"
-        [context]="computeContext(value)"
+        [context]="{$implicit: value}"
     ></div>
 </tui-input-number>
 

--- a/projects/kit/components/input-slider/test/input-slider-new.component.spec.ts
+++ b/projects/kit/components/input-slider/test/input-slider-new.component.spec.ts
@@ -1,0 +1,398 @@
+import {Component, TemplateRef, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {TuiContextWithImplicit} from '@taiga-ui/cdk';
+import {TuiRootModule, TuiTextfieldControllerModule} from '@taiga-ui/core';
+import {TuiInputSliderComponent, TuiInputSliderModule} from '@taiga-ui/kit';
+import {configureTestSuite, NativeInputPO, PageObject} from '@taiga-ui/testing';
+
+@Component({
+    template: `
+        <tui-root>
+            <tui-input-slider
+                new
+                [formControl]="control"
+                [max]="max"
+                [min]="min"
+                [quantum]="quantum"
+                [steps]="steps"
+                [valueContent]="valueContent"
+                [tuiTextfieldCustomContent]="textfieldCustomContent"
+            ></tui-input-slider>
+
+            <ng-template #progressPercent>{{ percent }}%</ng-template>
+        </tui-root>
+    `,
+})
+class TestComponent {
+    @ViewChild(TuiInputSliderComponent)
+    component!: TuiInputSliderComponent;
+
+    @ViewChild('progressPercent')
+    progressPercentCustomContent!: TemplateRef<unknown>;
+
+    control = new FormControl(0);
+
+    min = -100;
+    max = 100;
+    quantum = 10;
+    steps = 0;
+    valueContent: unknown = '';
+    textfieldCustomContent: unknown = '';
+
+    get percent(): number {
+        return Math.round((this.control.value / (this.max - this.min)) * 100);
+    }
+}
+
+const testContext = {
+    get textInputInsideAutoId() {
+        return 'tui-primitive-textfield__native-input';
+    },
+
+    get textInputValueAutoId() {
+        return 'tui-primitive-textfield__value';
+    },
+
+    get customContentAutoId() {
+        return 'tui-primitive-textfield__custom-content';
+    },
+};
+
+let fixture: ComponentFixture<TestComponent>;
+let testComponent: TestComponent;
+let pageObject: PageObject<TestComponent>;
+let inputPO: NativeInputPO;
+
+describe('InputSlider[new]', () => {
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                TuiRootModule,
+                TuiTextfieldControllerModule,
+                TuiInputSliderModule,
+                ReactiveFormsModule,
+            ],
+            declarations: [TestComponent],
+        });
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        pageObject = new PageObject(fixture);
+        testComponent = fixture.componentInstance;
+        fixture.detectChanges();
+        inputPO = new NativeInputPO(fixture, testContext.textInputInsideAutoId);
+    });
+
+    describe('`quantum` prop', () => {
+        beforeEach(() => {
+            testComponent.control = new FormControl(0);
+            testComponent.quantum = 10;
+            testComponent.steps = 0;
+        });
+
+        it('Pressing `Arrow Up` increases value by `quantum`-value if property `step` was not provided', () => {
+            inputPO.focus();
+
+            inputPO.sendKeydown('arrowUp');
+            expect(testComponent.control.value).toBe(10);
+
+            inputPO.sendKeydown('arrowUp');
+            expect(testComponent.control.value).toBe(20);
+
+            inputPO.sendKeydown('arrowUp');
+            expect(testComponent.control.value).toBe(30);
+        });
+
+        it('Pressing `Arrow Down` decreases value by `quantum`-value if property `step` was not provided', () => {
+            inputPO.focus();
+
+            inputPO.sendKeydown('arrowDown');
+            expect(testComponent.control.value).toBe(-10);
+
+            inputPO.sendKeydown('arrowDown');
+            expect(testComponent.control.value).toBe(-20);
+
+            inputPO.sendKeydown('arrowDown');
+            expect(testComponent.control.value).toBe(-30);
+        });
+
+        it('cannot type decimal number if `quantum` is integer', () => {
+            testComponent.quantum = 1;
+            fixture.detectChanges();
+
+            inputPO.sendTextAndBlur('0,1234412');
+            expect(testComponent.control.value).toBe(0);
+        });
+
+        it('can type decimal number if `quantum` is decimal', () => {
+            testComponent.quantum = 0.000001;
+            fixture.detectChanges();
+
+            inputPO.sendTextAndBlur('0,123456');
+            expect(testComponent.control.value).toBe(0.123456);
+        });
+
+        it('cannot type more digits after comma than digits after comma in `quantum`', () => {
+            testComponent.quantum = 0.001;
+            fixture.detectChanges();
+
+            inputPO.sendTextAndBlur('0,123456');
+            expect(testComponent.control.value).toBe(0.123);
+        });
+
+        describe('rounds to the nearest `quantum` on blur', () => {
+            describe('`quantum` = 20 | `max` = 100 | `min` = 0', () => {
+                beforeEach(() => {
+                    testComponent.quantum = 20;
+                    testComponent.min = 0;
+                    testComponent.max = 100;
+                });
+
+                it('16 => 20', () => {
+                    inputPO.sendTextAndBlur('16');
+                    expect(testComponent.control.value).toBe(20);
+                });
+
+                it('27 => 20', () => {
+                    inputPO.sendTextAndBlur('27');
+                    expect(testComponent.control.value).toBe(20);
+                });
+
+                it('42 => 40', () => {
+                    inputPO.sendTextAndBlur('42');
+                    expect(testComponent.control.value).toBe(40);
+                });
+
+                it('78 => 80', () => {
+                    inputPO.sendTextAndBlur('78');
+                    expect(testComponent.control.value).toBe(80);
+                });
+            });
+
+            describe('`quantum` = 0.25 | `max` = 10 | `min` = -10', () => {
+                beforeEach(() => {
+                    testComponent.quantum = 0.25;
+                    testComponent.min = -10;
+                    testComponent.max = 10;
+                });
+
+                it('7.59 => 7.5', () => {
+                    inputPO.sendTextAndBlur('7.59');
+                    expect(testComponent.control.value).toBe(7.5);
+                });
+
+                it('-2.44 => -2.5', () => {
+                    inputPO.sendTextAndBlur('-2.44');
+                    expect(testComponent.control.value).toBe(-2.5);
+                });
+
+                it('-9.99 => -10', () => {
+                    inputPO.sendTextAndBlur('-9.99');
+                    expect(testComponent.control.value).toBe(-10);
+                });
+
+                it('4.13 => 4.25', () => {
+                    inputPO.sendTextAndBlur('4.13');
+                    expect(testComponent.control.value).toBe(4.25);
+                });
+            });
+        });
+    });
+
+    describe('`valueContent` prop', () => {
+        const customLabel = ({$implicit}: TuiContextWithImplicit<number>) => {
+            switch ($implicit) {
+                case 100:
+                    return 'MAX';
+                case 75:
+                    return 'Three quarters';
+                case 50:
+                    return 'Middle';
+                case 10:
+                    return 'TEN';
+                default:
+                    return $implicit;
+            }
+        };
+
+        beforeEach(() => {
+            testComponent.min = 0;
+            testComponent.max = 100;
+            testComponent.quantum = 1;
+            testComponent.valueContent = customLabel;
+
+            fixture.detectChanges();
+        });
+
+        const checkValueContent = async (value: number, expectedContent: string) => {
+            inputPO.sendTextAndBlur(`${value}`);
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            expect(testComponent.control.value).toBe(value);
+            expect(getTextInputVisualValue()).toBe(expectedContent);
+        };
+
+        it('100 => MAX', async () => {
+            await checkValueContent(100, 'MAX');
+        });
+
+        it('90 => 90', async () => {
+            await checkValueContent(90, '90');
+        });
+
+        it('78 => 78', async () => {
+            await checkValueContent(78, '78');
+        });
+
+        it('75 => `Three quarters`', async () => {
+            await checkValueContent(75, 'Three quarters');
+        });
+
+        it('60 => 60', async () => {
+            await checkValueContent(60, '60');
+        });
+
+        it('50 => `Middle`', async () => {
+            await checkValueContent(50, 'Middle');
+        });
+
+        it('30 => 30', async () => {
+            await checkValueContent(30, '30');
+        });
+
+        it('10 => `Ten`', async () => {
+            await checkValueContent(10, 'TEN');
+        });
+    });
+
+    describe('`min` prop', () => {
+        describe('positive numbers', () => {
+            beforeEach(() => {
+                testComponent.min = 10;
+                testComponent.max = 100;
+                testComponent.quantum = 0.001;
+
+                fixture.detectChanges();
+            });
+
+            it('cannot type number less than `min` property', async () => {
+                inputPO.sendTextAndBlur('9.999');
+                await fixture.whenStable();
+                expect(testComponent.control.value).toBe(10);
+            });
+
+            it('cannot even type minus if `min` is positive', async () => {
+                inputPO.sendTextAndBlur('-11');
+                await fixture.whenStable();
+                expect(testComponent.control.value).toBe(11);
+            });
+        });
+
+        describe('negative numbers', () => {
+            beforeEach(() => {
+                testComponent.min = -10;
+                testComponent.max = 100;
+                testComponent.quantum = 0.001;
+
+                fixture.detectChanges();
+            });
+
+            it('can type negative number more than `min`', () => {
+                inputPO.sendTextAndBlur('-5');
+                expect(testComponent.control.value).toBe(-5);
+            });
+
+            it('cannot type negative number less than `min`', () => {
+                inputPO.sendTextAndBlur('-11');
+                expect(testComponent.control.value).toBe(-10);
+            });
+        });
+    });
+
+    describe('`max` prop', () => {
+        beforeEach(() => {
+            testComponent.min = -200;
+            testComponent.max = 100;
+            testComponent.quantum = 0.001;
+
+            fixture.detectChanges();
+        });
+
+        it('cannot type float number more than `max` property', () => {
+            inputPO.sendTextAndBlur('100.001');
+            expect(testComponent.control.value).toBe(100);
+        });
+
+        it('cannot type integer number more than `max` property', () => {
+            inputPO.sendTextAndBlur('150');
+            expect(testComponent.control.value).toBe(100);
+        });
+
+        it('can type large negative number', () => {
+            inputPO.sendTextAndBlur('-200');
+            expect(testComponent.control.value).toBe(-200);
+        });
+    });
+
+    describe('`tuiTextfieldCustomContent` controller', () => {
+        describe('progress percent case', () => {
+            beforeEach(() => {
+                testComponent.textfieldCustomContent =
+                    testComponent.progressPercentCustomContent;
+                testComponent.min = 0;
+                testComponent.max = 10;
+                testComponent.quantum = 0.1;
+
+                fixture.detectChanges();
+            });
+
+            it('0 => 0%', () => {
+                inputPO.sendTextAndBlur('0');
+                expect(getTextfieldCustomContent()).toBe('0%');
+            });
+
+            it('1.5 => 15%', () => {
+                inputPO.sendTextAndBlur('1.5');
+                expect(getTextfieldCustomContent()).toBe('15%');
+            });
+
+            it('4.8 => 48%', () => {
+                inputPO.sendTextAndBlur('4.8');
+                expect(getTextfieldCustomContent()).toBe('48%');
+            });
+
+            it('6.3 => 63%', () => {
+                inputPO.sendTextAndBlur('6.3');
+                expect(getTextfieldCustomContent()).toBe('63%');
+            });
+
+            it('8 => 80%', () => {
+                inputPO.sendTextAndBlur('8');
+                expect(getTextfieldCustomContent()).toBe('80%');
+            });
+
+            it('10 => 100%', () => {
+                inputPO.sendTextAndBlur('10');
+                expect(getTextfieldCustomContent()).toBe('100%');
+            });
+        });
+    });
+});
+
+function getTextInputVisualValue(): string {
+    return (
+        pageObject.getByAutomationId(testContext.textInputValueAutoId)?.nativeElement
+            .textContent || ''
+    );
+}
+
+function getTextfieldCustomContent(): string {
+    return (
+        pageObject.getByAutomationId(testContext.customContentAutoId)?.nativeElement
+            .textContent || ''
+    );
+}

--- a/projects/kit/components/input-slider/test/input-slider-new.component.spec.ts
+++ b/projects/kit/components/input-slider/test/input-slider-new.component.spec.ts
@@ -50,7 +50,7 @@ const testContext = {
         return 'tui-primitive-textfield__native-input';
     },
 
-    get textInputValueAutoId() {
+    get textInputCustomValueAutoId() {
         return 'tui-primitive-textfield__value';
     },
 
@@ -233,7 +233,7 @@ describe('InputSlider[new]', () => {
             await fixture.whenStable();
 
             expect(testComponent.control.value).toBe(value);
-            expect(getTextInputVisualValue()).toBe(expectedContent);
+            expect(getTextInputCustomValue()).toBe(expectedContent);
         };
 
         it('100 => MAX', async () => {
@@ -290,6 +290,21 @@ describe('InputSlider[new]', () => {
                 await fixture.whenStable();
                 expect(testComponent.control.value).toBe(11);
             });
+
+            it('cannot set value less than min using ArrowDown', async () => {
+                inputPO.sendTextAndBlur('10');
+
+                await fixture.whenStable();
+
+                inputPO.focus();
+                inputPO.sendKeydown('arrowDown');
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                expect(testComponent.control.value).toBe(10);
+                expect(inputPO.value).toBe('10');
+            });
         });
 
         describe('negative numbers', () => {
@@ -335,6 +350,21 @@ describe('InputSlider[new]', () => {
         it('can type large negative number', () => {
             inputPO.sendTextAndBlur('-200');
             expect(testComponent.control.value).toBe(-200);
+        });
+
+        it('cannot set value more than max using ArrowUp', async () => {
+            inputPO.sendTextAndBlur('100');
+
+            await fixture.whenStable();
+
+            inputPO.focus();
+            inputPO.sendKeydown('arrowUp');
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            expect(testComponent.control.value).toBe(100);
+            expect(inputPO.value).toBe('100');
         });
     });
 
@@ -383,10 +413,10 @@ describe('InputSlider[new]', () => {
     });
 });
 
-function getTextInputVisualValue(): string {
+function getTextInputCustomValue(): string {
     return (
-        pageObject.getByAutomationId(testContext.textInputValueAutoId)?.nativeElement
-            .textContent || ''
+        pageObject.getByAutomationId(testContext.textInputCustomValueAutoId)
+            ?.nativeElement.textContent || ''
     );
 }
 

--- a/projects/kit/components/input-slider/test/input-slider.component.spec.ts
+++ b/projects/kit/components/input-slider/test/input-slider.component.spec.ts
@@ -2,32 +2,35 @@ import {Component, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk';
+import {TuiRootModule} from '@taiga-ui/core';
 import {configureTestSuite, NativeInputPO, PageObject} from '@taiga-ui/testing';
 
 import {TuiInputSliderComponent} from '../input-slider.component';
 import {TuiInputSliderModule} from '../input-slider.module';
 
-describe('InputSlider', () => {
+describe('InputSlider[legacy props]', () => {
     @Component({
         template: `
-            <tui-input-slider
-                *ngIf="default"
-                max="10"
-                [formControl]="control"
-            ></tui-input-slider>
-            <tui-input-slider
-                *ngIf="!default"
-                [formControl]="control"
-                [max]="max"
-                [min]="min"
-                [steps]="steps"
-                [minLabel]="minLabel"
-                [maxLabel]="maxLabel"
-                [pluralize]="pluralize"
-                [readOnly]="readOnly"
-                [secondary]="secondary"
-                [quantum]="quantum"
-            ></tui-input-slider>
+            <tui-root>
+                <tui-input-slider
+                    *ngIf="default"
+                    max="10"
+                    [formControl]="control"
+                ></tui-input-slider>
+                <tui-input-slider
+                    *ngIf="!default"
+                    [formControl]="control"
+                    [max]="max"
+                    [min]="min"
+                    [steps]="steps"
+                    [minLabel]="minLabel"
+                    [maxLabel]="maxLabel"
+                    [pluralize]="pluralize"
+                    [readOnly]="readOnly"
+                    [secondary]="secondary"
+                    [quantum]="quantum"
+                ></tui-input-slider>
+            </tui-root>
         `,
     })
     class TestComponent {
@@ -55,6 +58,18 @@ describe('InputSlider', () => {
         get prefix() {
             return 'tui-input-slider__';
         },
+
+        get customContentAutoId() {
+            return 'tui-primitive-textfield__custom-content';
+        },
+
+        get valueContentAutoId() {
+            return `${this.prefix}value-content`;
+        },
+
+        get valueDecorationAutoId() {
+            return 'tui-primitive-textfield__value-decoration';
+        },
     };
 
     function aid(aid: string): HTMLElement & {textContent: string} {
@@ -63,7 +78,7 @@ describe('InputSlider', () => {
 
     configureTestSuite(() => {
         TestBed.configureTestingModule({
-            imports: [TuiInputSliderModule, ReactiveFormsModule],
+            imports: [TuiRootModule, TuiInputSliderModule, ReactiveFormsModule],
             declarations: [TestComponent],
         });
     });
@@ -73,7 +88,7 @@ describe('InputSlider', () => {
         pageObject = new PageObject(fixture);
         testComponent = fixture.componentInstance;
         fixture.detectChanges();
-        inputPO = new NativeInputPO(fixture, `${testContext.prefix}native`);
+        inputPO = new NativeInputPO(fixture, 'tui-primitive-textfield__native-input');
     });
 
     describe('Default values', () => {
@@ -86,89 +101,87 @@ describe('InputSlider', () => {
             expect(testComponent.component.min).toBe(0);
         });
 
-        it('minLabel is missing', () => {
+        it('custom valueContent is missing (value is min)', () => {
             expect(
-                pageObject.getByAutomationId(`${testContext.prefix}min-label`),
+                pageObject.getByAutomationId(testContext.valueContentAutoId),
             ).toBeNull();
         });
 
-        it('maxLabel is missing', () => {
+        it('valueContent is missing (value is max)', () => {
             testComponent.control.setValue(10);
             fixture.detectChanges();
 
             expect(
-                pageObject.getByAutomationId(`${testContext.prefix}min-label`),
+                pageObject.getByAutomationId(testContext.valueContentAutoId),
             ).toBeNull();
         });
 
-        it('Plural signature missing', () => {
+        it('Plural signature missing (legacy prop)', () => {
             expect(
-                pageObject.getByAutomationId(`${testContext.prefix}pluralize`),
-            ).toBeNull();
+                pageObject
+                    .getByAutomationId(testContext.valueDecorationAutoId)
+                    ?.nativeElement.textContent.trim(),
+            ).toBe('0');
         });
 
         it('There is no label on the right', () => {
-            expect(aid(`${testContext.prefix}secondary`).textContent.trim()).toBe('');
+            expect(aid(testContext.customContentAutoId).textContent.trim()).toBe('');
         });
     });
 
     describe('Labels', () => {
-        it('The label on the right is shown', () => {
-            expect(aid(`${testContext.prefix}secondary`).textContent.trim()).toBe(
-                testComponent.secondary,
-            );
+        it('valueContent not shown (max > value > min)', () => {
+            expect(aid(testContext.valueContentAutoId).textContent.trim()).toBe('');
         });
 
-        it('Plural signature is present', () => {
-            expect(aid(`${testContext.prefix}pluralize`).textContent.trim()).toBe('лет');
-        });
-
-        it('minLabel not shown at start> min', () => {
-            expect(
-                pageObject.getByAutomationId(`${testContext.prefix}min-label`),
-            ).toBeNull();
-        });
-
-        it('minLabel is shown', () => {
-            testComponent.control.setValue(-10);
-            fixture.detectChanges();
-
-            expect(aid(`${testContext.prefix}min-label`).textContent.trim()).toBe(
-                testComponent.minLabel,
-            );
-        });
-
-        it('minLabel missing on focus', () => {
+        it('valueContent is missing on focus (value = min)', () => {
             testComponent.control.setValue(-10);
             inputPO.focus();
 
             expect(
-                pageObject.getByAutomationId(`${testContext.prefix}min-label`),
+                pageObject.getByAutomationId(testContext.valueContentAutoId),
             ).toBeNull();
         });
 
-        it('maxLabel not shown when end < max', () => {
-            expect(
-                pageObject.getByAutomationId(`${testContext.prefix}min-label`),
-            ).toBeNull();
-        });
-
-        it('maxLabel is shown', () => {
-            testComponent.control.setValue(10);
-            fixture.detectChanges();
-
-            expect(aid(`${testContext.prefix}max-label`).textContent.trim()).toBe(
-                testComponent.maxLabel,
-            );
-        });
-
-        it('maxLabel missing on focus', () => {
+        it('valueContent missing on focus (value = max)', () => {
             testComponent.control.setValue(10);
             inputPO.focus();
 
             expect(
-                pageObject.getByAutomationId(`${testContext.prefix}max-label`),
+                pageObject.getByAutomationId(testContext.valueContentAutoId),
             ).toBeNull();
+        });
+
+        describe('legacy props checks', () => {
+            it('Plural signature is present (legacy `pluralize` prop)', () => {
+                expect(aid(testContext.valueDecorationAutoId).textContent.trim()).toMatch(
+                    /0\s+лет/,
+                );
+            });
+
+            it('minLabel is shown (legacy prop)', () => {
+                testComponent.control.setValue(-10);
+                fixture.detectChanges();
+
+                expect(aid(testContext.valueContentAutoId).textContent.trim()).toBe(
+                    testComponent.minLabel,
+                );
+            });
+
+            it('The label on the right is shown (legacy `secondary` prop)', () => {
+                expect(aid(testContext.customContentAutoId).textContent.trim()).toBe(
+                    testComponent.secondary,
+                );
+            });
+
+            it('maxLabel is shown (legacy prop)', () => {
+                testComponent.control.setValue(10);
+                fixture.detectChanges();
+
+                expect(aid(testContext.valueContentAutoId).textContent.trim()).toBe(
+                    testComponent.maxLabel,
+                );
+            });
         });
     });
 
@@ -179,8 +192,12 @@ describe('InputSlider', () => {
             expect(testComponent.control.value).toBe(5);
         });
 
-        it('Rounds the input field value to the nearest quantum when focus is lost', () => {
+        it('Rounds the input field value to the nearest quantum when focus is lost', async () => {
             inputPO.sendTextAndBlur('7');
+
+            await fixture.whenStable();
+            fixture.detectChanges();
+            await fixture.whenStable();
 
             expect(inputPO.value).toBe('5');
         });
@@ -203,9 +220,13 @@ describe('InputSlider', () => {
         });
     });
 
-    it(`Doesn't change value when content is removed`, () => {
+    it(`Doesn't change value when content is removed`, async () => {
         inputPO.sendTextAndBlur('5');
+        await fixture.whenStable();
+
         inputPO.sendTextAndBlur('');
+        fixture.detectChanges();
+        await fixture.whenStable();
 
         expect(testComponent.control.value).toBe(5);
         expect(inputPO.value).toBe('5');
@@ -220,7 +241,7 @@ describe('InputSlider', () => {
             fixture.detectChanges();
         });
 
-        describe('Quantum', () => {
+        describe('Quantum (Steps were not set)', () => {
             it('Up arrow increases the value by a quantum', () => {
                 inputPO.sendKeydown('arrowUp');
 
@@ -260,8 +281,11 @@ describe('InputSlider', () => {
                 fixture.detectChanges();
             });
 
-            it('Up arrow increments the value', () => {
+            it('Up arrow increments the value', async () => {
                 inputPO.sendKeydown('arrowUp');
+
+                fixture.detectChanges();
+                await fixture.whenStable();
 
                 expect(testComponent.control.value).toBe(8);
             });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

## What is the new behavior?
`InputSlider` uses `InputNumber` inside itself.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
