### PR TITLE
chore(core): `PrimitiveTextfield` postfix should be on the same line with input's value

### DIFF
--- a/projects/core/styles/mixins/textfield.less
+++ b/projects/core/styles/mixins/textfield.less
@@ -1,3 +1,5 @@
+@line-height-l: 1.25rem;
+
 .textfield-host() {
     .text-basic();
     position: relative;
@@ -22,6 +24,7 @@
         min-height: var(--tui-height-l);
         max-height: var(--tui-height-l);
         font: var(--tui-font-text-m);
+        line-height: @line-height-l;
     }
 }
 
@@ -96,7 +99,7 @@
 
     :host[data-size='l']:not(._label-outside) &,
     :host-context(tui-primitive-textfield[data-size='l']:not(._label-outside)):not(tui-primitive-textfield) {
-        padding-top: 1.25rem;
+        padding-top: @line-height-l;
 
         // Workaround for raising placeholder in temporary autofill
         &:-webkit-autofill + .content .placeholder {

--- a/projects/demo-integrations/cypress/tests/core/primitive-textfield/primitive-textfield.spec.ts
+++ b/projects/demo-integrations/cypress/tests/core/primitive-textfield/primitive-textfield.spec.ts
@@ -16,4 +16,14 @@ describe('TuiPrimitiveTextfield', () => {
             .click();
         cy.matchImageSnapshot('hint', {capture: 'viewport'});
     });
+
+    it("prefix + postfix align on the same line with input's value", () => {
+        cy.goToDemoPage(
+            `components/primitive-textfield/API?value=TEXT&postfix=__!&prefix=!__`,
+        );
+        cy.hideHeader();
+        cy.get('#demoContent')
+            .should('be.visible')
+            .matchImageSnapshot('02-prefix-postfix');
+    });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?
TOP of the image – new changes
![02-prefix-postfix diff](https://user-images.githubusercontent.com/35179038/158203763-12814541-37e8-405b-8520-c6597b01c836.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
