### PR TITLE
fix(kit): `Slider` improve a11y for `keySteps`

### DIFF
--- a/projects/kit/components/slider/slider-key-steps.directive.ts
+++ b/projects/kit/components/slider/slider-key-steps.directive.ts
@@ -29,6 +29,11 @@ import {TuiSliderComponent} from './slider.component';
 // @dynamic
 @Directive({
     selector: 'input[tuiSlider][keySteps]',
+    host: {
+        '[attr.aria-valuenow]': 'controlValue',
+        '[attr.aria-valuemin]': 'min',
+        '[attr.aria-valuemax]': 'max',
+    },
 })
 export class TuiSliderKeyStepsDirective
     extends AbstractTuiControl<number>
@@ -51,7 +56,15 @@ export class TuiSliderKeyStepsDirective
         return isNativeFocused(this.nativeFocusableElement);
     }
 
-    private get controlValue(): number {
+    get min(): number {
+        return this.keySteps[0]?.[1] || 0;
+    }
+
+    get max(): number {
+        return this.keySteps[this.keySteps.length - 1]?.[1] || 100;
+    }
+
+    get controlValue(): number {
         const {valuePercentage} = this.slider;
         const [lowerStep, upperStep] = findKeyStepsBoundariesByFn(
             this.keySteps,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
1. Open `Slider`'s example with `keySteps` https://taiga-ui.dev/components/slider#keySteps
2. Turn on `VoiceOver` (or another screen reader)
3. Screen reader pronounces wrong value (because of key steps)

## What is the new behavior?
...
3. Screen reader pronounces correct value

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
