### PR TITLE
feat(format-number): add zeroPadding flag

### DIFF
--- a/projects/core/pipes/format-number/format-number.pipe.ts
+++ b/projects/core/pipes/format-number/format-number.pipe.ts
@@ -17,13 +17,21 @@ export class TuiFormatNumberPipe implements PipeTransform {
      * @param decimalSeparator
      * @param thousandSeparator
      * @param decimalLimit number of digits of decimal part, null to keep untouched
+     * @param zeroPadding enable zeros at the end of decimal part
      */
     transform(
         value: number,
         decimalLimit: number | null = null,
         decimalSeparator: string = this.numberFormat.decimalSeparator,
         thousandSeparator: string = this.numberFormat.thousandSeparator,
+        zeroPadding: boolean = this.numberFormat.zeroPadding,
     ): string {
-        return formatNumber(value, decimalLimit, decimalSeparator, thousandSeparator);
+        return formatNumber(
+            value,
+            decimalLimit,
+            decimalSeparator,
+            thousandSeparator,
+            zeroPadding,
+        );
     }
 }

--- a/projects/core/utils/format/format-number.ts
+++ b/projects/core/utils/format/format-number.ts
@@ -33,9 +33,7 @@ export function formatNumber(
             const zeroPartString = '0'.repeat(zeroPaddingSize);
 
             fractionPartPadded = `${fractionPartPadded}${zeroPartString}`;
-        }
-
-        if (!zeroPadding) {
+        } else {
             fractionPartPadded = fractionPartPadded.replace(/0*$/, '');
         }
     }

--- a/projects/core/utils/format/format-number.ts
+++ b/projects/core/utils/format/format-number.ts
@@ -25,12 +25,19 @@ export function formatNumber(
     let fractionPartPadded = getFractionPartPadded(value, decimalLimit);
 
     if (decimalLimit !== null) {
-        const zeroPaddingSize: number = zeroPadding
-            ? Math.max(decimalLimit - fractionPartPadded.length, 0)
-            : 0;
-        const zeroPartString = '0'.repeat(zeroPaddingSize);
+        if (zeroPadding) {
+            const zeroPaddingSize: number = Math.max(
+                decimalLimit - fractionPartPadded.length,
+                0,
+            );
+            const zeroPartString = '0'.repeat(zeroPaddingSize);
 
-        fractionPartPadded = `${fractionPartPadded}${zeroPartString}`;
+            fractionPartPadded = `${fractionPartPadded}${zeroPartString}`;
+        }
+
+        if (!zeroPadding) {
+            fractionPartPadded = fractionPartPadded.replace(/0*$/, '');
+        }
     }
 
     const remainder = integerPartString.length % 3;
@@ -45,7 +52,5 @@ export function formatNumber(
         result += integerPartString.charAt(i);
     }
 
-    return !!fractionPartPadded || decimalLimit
-        ? result + decimalSeparator + fractionPartPadded
-        : result;
+    return fractionPartPadded ? result + decimalSeparator + fractionPartPadded : result;
 }

--- a/projects/core/utils/format/test/format-number.spec.ts
+++ b/projects/core/utils/format/test/format-number.spec.ts
@@ -72,4 +72,12 @@ describe('Number formatting', () => {
     it('displays without decimal separator when zero padding flag is disabled and there is no significant digits', () => {
         expect(formatNumber(12345.006, 2, ',', '.', false)).toBe('12.345');
     });
+
+    it('does not delete significant zeros in decimal part when padding flag is disabled', () => {
+        expect(formatNumber(0.01, 2, ',', '.', false)).toBe('0,01');
+    });
+
+    it('deletes trailing zeros only in decimal part when zero padding flag is disabled', () => {
+        expect(formatNumber(0.001, 2, ',', '.', false)).toBe('0');
+    });
 });

--- a/projects/core/utils/format/test/format-number.spec.ts
+++ b/projects/core/utils/format/test/format-number.spec.ts
@@ -64,4 +64,12 @@ describe('Number formatting', () => {
     it('value with exponent and fractional part with and decimal bigger than precision', () => {
         expect(formatNumber(1.23e-8, 12)).toBe('0,000000012300');
     });
+
+    it('deletes trailing zeros when zero padding flag is disabled', () => {
+        expect(formatNumber(12345.6078, 2, ',', '.', false)).toBe('12.345,6');
+    });
+
+    it('displays without decimal separator when zero padding flag is disabled and there is no significant digits', () => {
+        expect(formatNumber(12345.006, 2, ',', '.', false)).toBe('12.345');
+    });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?
When zeroPadding flag is disabled zeros are not adding at the end of decimal part.
Also, when zeroPadding flag is disabled trailing zeros in decimal part are deleting and if there are not significant digits at all - with decimal separator.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
