### PR TITLE
fix(kit): dropdown content jumping and rerendering multiselect after adding new tags

### DIFF
--- a/projects/kit/components/input-tag/input-tag.component.ts
+++ b/projects/kit/components/input-tag/input-tag.component.ts
@@ -441,6 +441,11 @@ export class TuiInputTagComponent
         this.open = false;
     }
 
+    trackByFn(_: number, tag: string): string {
+        // Actually tag has TuiStringifiableItem type not string
+        return tag.toString();
+    }
+
     protected updateValue(value: string[]) {
         const seen = new Set();
 

--- a/projects/kit/components/input-tag/input-tag.template.html
+++ b/projects/kit/components/input-tag/input-tag.template.html
@@ -50,7 +50,7 @@
                     >
                         <ng-container *ngIf="labelOutside; else text">
                             <tui-tag
-                                *ngFor="let item of value; index as index"
+                                *ngFor="let item of value; index as index; trackBy: trackByFn"
                                 #tag
                                 automation-id="tui-input-tag__tag"
                                 class="t-tag"


### PR DESCRIPTION
fix(kit): dropdown content jumping and rerendering multiselect after adding new tags

Fixes #1534

I'm not sure about trackBy because I haven't found any using of it in library. If there is any solution without it I can implement it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #1534

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
