### PR TITLE
[WIP] feat(testing): new `tuiWaitAllIconsInside` cypress-command

### DIFF
--- a/projects/demo-integrations/cypress/support/visit.ts
+++ b/projects/demo-integrations/cypress/support/visit.ts
@@ -47,7 +47,7 @@ const MOBILE_USER_AGENT =
 export function tuiVisit(path: string, options: TuiVisitOptions = {}): void {
     const {
         inIframe = true,
-        waitAllIcons = true,
+        waitAllIcons = false,
         enableNightMode = false,
         hideCursor = true,
         hideScrollbar = true,

--- a/projects/demo-integrations/cypress/support/wait-requests.util.ts
+++ b/projects/demo-integrations/cypress/support/wait-requests.util.ts
@@ -5,6 +5,7 @@ const getNotLoadedRequests = (alias: string): Cypress.Chainable =>
         .get<Array<{state: string}>>(`${alias}.all`)
         .then(reqs => reqs.filter(req => req.state !== 'Complete'));
 
+/** TODO delete me after we make sure that {@link tuiWaitAllIconsInside} actually works as expected */
 export const waitAllRequests = (alias: string): void => {
     getNotLoadedRequests(alias)
         .then(reqs => {

--- a/projects/demo-integrations/cypress/tests/addon-preview/addon-preview.spec.ts
+++ b/projects/demo-integrations/cypress/tests/addon-preview/addon-preview.spec.ts
@@ -4,7 +4,7 @@ describe('Addon preview', () => {
     });
 
     it('Full preview scrolled', () => {
-        cy.get(`tui-preview-example-1 button`).first().click();
+        cy.get(`tui-preview-example-1 button`).first().tuiScrollIntoView().click();
         cy.tuiWaitKitDialog('tui-preview');
         cy.get('tui-preview')
             .wait(350)
@@ -18,7 +18,7 @@ describe('Addon preview', () => {
     });
 
     it('No preview available', () => {
-        cy.get(`tui-preview-example-3 button`).first().click();
+        cy.get(`tui-preview-example-3 button`).first().tuiScrollIntoView().click();
         cy.tuiWaitKitDialog('tui-preview');
         cy.get('tui-preview')
             .wait(350)

--- a/projects/demo-integrations/cypress/tests/core/dialogs/dialog-browser-back.spec.ts
+++ b/projects/demo-integrations/cypress/tests/core/dialogs/dialog-browser-back.spec.ts
@@ -31,6 +31,7 @@ describe('Dialogs + browser back navigation', () => {
                 .findByAutomationId('tui-doc-example')
                 .find('button')
                 .first()
+                .tuiScrollIntoView()
                 .click();
             cy.tuiWaitKitDialog();
 

--- a/projects/demo-integrations/cypress/tests/kit/multi-select/multi-select.spec.ts
+++ b/projects/demo-integrations/cypress/tests/kit/multi-select/multi-select.spec.ts
@@ -11,7 +11,10 @@ describe('MultiSelect', () => {
         });
 
         it('does not overflow arrow icon by many tags', () => {
-            cy.get('#object-array').findByAutomationId('tui-doc-example').as('wrapper');
+            cy.get('#object-array')
+                .findByAutomationId('tui-doc-example')
+                .should('be.visible')
+                .as('wrapper');
 
             cy.get('@wrapper').find('tui-multi-select').click();
 

--- a/projects/testing/cypress/commands/index.ts
+++ b/projects/testing/cypress/commands/index.ts
@@ -1,0 +1,1 @@
+export * from './wait-all-icons-inside.command';

--- a/projects/testing/cypress/commands/wait-all-icons-inside.command.ts
+++ b/projects/testing/cypress/commands/wait-all-icons-inside.command.ts
@@ -1,0 +1,74 @@
+/// <reference types="cypress" />
+
+declare global {
+    namespace Cypress {
+        interface Chainable {
+            /**
+             * Wait until all svg-icons have non-zero height
+             * @param enabled=true
+             * @example cy.get('#selector').tuiWaitAllIconsInside()
+             */
+            tuiWaitAllIconsInside(
+                enabled?: boolean,
+            ): Chainable<JQuery | Document | Window>;
+        }
+    }
+}
+
+function isExceptionSVG(
+    $el: JQuery<unknown>,
+    // SVGs with current `use`-element pattern always have height equal to zero
+    svgExceptions = ['tuiIconHrLarge.svg', '#iconBlank'],
+): boolean {
+    const [$use] = $el.toArray() as SVGUseElement[];
+
+    return svgExceptions.some(exception => $use.href.baseVal.includes(exception));
+}
+
+export const tuiWaitAllIconsInside = (
+    prevSubject: JQuery | Document | Window | void,
+    enabled: boolean = true,
+): Cypress.Chainable<JQuery | Document | Window> => {
+    const target =
+        prevSubject && Cypress.dom.isJquery(prevSubject)
+            ? cy.wrap(prevSubject, {log: false})
+            : cy.get('body');
+
+    target.then($target => {
+        const svgUses = $target.find('svg use');
+
+        if (svgUses.length && enabled) {
+            const log = Cypress.log({
+                displayName: 'Icons',
+                message: 'Wait for icons',
+                name: 'tuiWaitAllIconsInside',
+                autoEnd: false,
+                consoleProps: () => ({
+                    prevSubject,
+                    svgUses,
+                }),
+            });
+
+            cy.wrap($target, {log: false})
+                .find('svg use', {log: false})
+                .each($use => {
+                    if (!isExceptionSVG($use) && Cypress.dom.isVisible($use)) {
+                        cy.wrap($use, {log: false})
+                            .invoke({log: false}, 'height')
+                            .should('be.greaterThan', 0);
+                    }
+                })
+                .then(() => log.end());
+        }
+    });
+
+    return target;
+};
+
+export const tuiAddWaitAllIconsInsideCommand = (): void => {
+    Cypress.Commands.add(
+        'tuiWaitAllIconsInside',
+        {prevSubject: ['optional', 'element', 'window', 'document']},
+        tuiWaitAllIconsInside,
+    );
+};

--- a/projects/testing/cypress/index.ts
+++ b/projects/testing/cypress/index.ts
@@ -1,3 +1,4 @@
 export * from './assertions';
+export * from './commands';
 export * from './snapshot/command';
 export * from './snapshot/plugin';

--- a/projects/testing/cypress/snapshot/command.ts
+++ b/projects/testing/cypress/snapshot/command.ts
@@ -1,6 +1,44 @@
-import {Options} from 'cypress-image-snapshot';
-import {addMatchImageSnapshotCommand} from 'cypress-image-snapshot/command';
+/// <reference types="cypress" />
 
-export function tuiAddMatchImageSnapshotCommand(options: Options): void {
-    addMatchImageSnapshotCommand(options);
+import {Options} from 'cypress-image-snapshot';
+import {matchImageSnapshotCommand} from 'cypress-image-snapshot/command';
+
+import {tuiWaitAllIconsInside} from '../commands/wait-all-icons-inside.command';
+
+declare module 'cypress-image-snapshot/command' {
+    function matchImageSnapshotCommand(options: Options): (...args: unknown[]) => void;
+}
+
+interface TuiSnapshotCommandOptions {
+    waitAllIcons?: boolean;
+}
+
+declare global {
+    namespace Cypress {
+        interface Chainable {
+            matchImageSnapshot(
+                name: string,
+                options?: Options & TuiSnapshotCommandOptions,
+            ): void;
+        }
+    }
+}
+
+export function tuiAddMatchImageSnapshotCommand(
+    options: Options & TuiSnapshotCommandOptions,
+): void {
+    const matchSnapshotFn = matchImageSnapshotCommand(options);
+
+    Cypress.Commands.add(
+        'matchImageSnapshot',
+        {
+            prevSubject: ['optional', 'element', 'window', 'document'],
+        },
+        (prevSubject, name: string, options?: Options & TuiSnapshotCommandOptions) => {
+            const {waitAllIcons = true} = options || {};
+
+            tuiWaitAllIconsInside(prevSubject, waitAllIcons);
+            matchSnapshotFn(prevSubject, name, options);
+        },
+    );
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
### Blinking icons
Try to add artificial delay to any cypress-test
```ts
cy.intercept(
    {
        url: '*/assets/taiga-ui/icons/*.svg',
        middleware: true,
    },
    req => {
        req.on('response', res => {
            res.setDelay(Math.random() * 5_000);
        });
    },
);
```
It causes this problem:
<img src="https://user-images.githubusercontent.com/35179038/166725374-d0dbdf05-0205-4720-a474-af5e0f874749.png" height="300">

### Old solution error
Old utils for waiting icons sometimes causes this error
```
CypressError:
Timed out retrying after 5000ms:
`cy.wait()` timed out waiting `5000ms` for the Xth request to the route: `icons`.
No request ever occurred.
```

## What is the new behavior?
New command (which is based on Cypress [Retry-ability](https://docs.cypress.io/guides/core-concepts/retry-ability)) ensures that our icons is actually loaded.
Try again to add artificial delay to any cypress-test.
No problem with "blinking" icons.
No problem with "No request ever occurred".

Also, this solution can be reusable in any app (we can publish it later).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
