### PR TITLE
feat(core): `Lists` add triangle bullet list type

### DIFF
--- a/projects/core/styles/markup/tui-list.less
+++ b/projects/core/styles/markup/tui-list.less
@@ -75,6 +75,20 @@
                 background-color: transparent;
             }
         }
+        
+        .tui-list_triangle & {
+            padding-left: @space * 7;
+
+            &:before {
+                content: '◤';
+                left: 0;
+                top: auto;
+                width: auto;
+                height: auto;
+                background-color: transparent;
+                color: #9299a2;
+            }
+        }
 
         .tui-list_ordered & {
             padding-left: @space * 5;

--- a/projects/core/styles/markup/tui-list.less
+++ b/projects/core/styles/markup/tui-list.less
@@ -75,20 +75,6 @@
                 background-color: transparent;
             }
         }
-        
-        .tui-list_triangle & {
-            padding-left: @space * 7;
-
-            &:before {
-                content: '◤';
-                left: 0;
-                top: auto;
-                width: auto;
-                height: auto;
-                background-color: transparent;
-                color: #9299a2;
-            }
-        }
 
         .tui-list_ordered & {
             padding-left: @space * 5;
@@ -102,6 +88,20 @@
                 height: auto;
                 color: var(--tui-text-03);
                 background-color: transparent;
+            }
+        }
+
+        .tui-list_triangle > & {
+            padding-left: @space * 7;
+
+            &:before {
+                content: '\25E4'; // represent symbol '◤'
+                left: 0;
+                top: auto;
+                width: auto;
+                height: auto;
+                background-color: transparent;
+                color: var(--tui-base-06);
             }
         }
     }

--- a/projects/demo/src/modules/markup/lists/examples/7/index.html
+++ b/projects/demo/src/modules/markup/lists/examples/7/index.html
@@ -1,0 +1,32 @@
+<ul class="tui-list tui-list_triangle">
+    <li class="tui-list__item">Code Review ($ 10)</li>
+    <li class="tui-list__item">
+        The whole project refactoring ($ 1000)
+        <ul class="tui-list tui-list_linear tui-list_nested">
+            <li class="tui-list__item">
+                Add auto prettier and linters on precommit ($ 50)
+            </li>
+            <li class="tui-list__item">
+                Rewrite to react and back ($ Infinity)
+            </li>
+        </ul>
+    </li>
+    <li class="tui-list__item">
+        Live workshop from
+        <a
+            tuiLink
+            href="https://angular.institute/corporate"
+            target="_blank"
+        >
+            angular.institute
+        </a>
+        ($ 3000)
+        <ol class="tui-list tui-list_ordered tui-list_nested">
+            <li class="tui-list__item">Interactive samples</li>
+            <li class="tui-list__item">Case analysis</li>
+            <li class="tui-list__item">
+                Angular knowledge that keeps on growing
+            </li>
+        </ol>
+    </li>
+</ul>

--- a/projects/demo/src/modules/markup/lists/examples/7/index.ts
+++ b/projects/demo/src/modules/markup/lists/examples/7/index.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+
+@Component({
+    selector: 'tui-lists-example-7',
+    templateUrl: './index.html',
+    changeDetection,
+    encapsulation,
+})
+export class TuiList7 {}

--- a/projects/demo/src/modules/markup/lists/lists.component.ts
+++ b/projects/demo/src/modules/markup/lists/lists.component.ts
@@ -7,6 +7,7 @@ import {default as example3Html} from '!!raw-loader!./examples/3/index.html';
 import {default as example4Html} from '!!raw-loader!./examples/4/index.html';
 import {default as example5Html} from '!!raw-loader!./examples/5/index.html';
 import {default as example6Html} from '!!raw-loader!./examples/6/index.html';
+import {default as example7Html} from '!!raw-loader!./examples/7/index.html';
 
 import {FrontEndExample} from '../../interfaces/front-end-example';
 
@@ -38,5 +39,9 @@ export class ListsComponent {
 
     readonly example6: FrontEndExample = {
         HTML: example6Html,
+    };
+
+    readonly example7: FrontEndExample = {
+        HTML: example7Html,
     };
 }

--- a/projects/demo/src/modules/markup/lists/lists.module.ts
+++ b/projects/demo/src/modules/markup/lists/lists.module.ts
@@ -10,6 +10,7 @@ import {TuiList3} from './examples/3';
 import {TuiList4} from './examples/4';
 import {TuiList5} from './examples/5';
 import {TuiList6} from './examples/6';
+import {TuiList7} from './examples/7';
 import {ListsComponent} from './lists.component';
 
 @NgModule({
@@ -27,6 +28,7 @@ import {ListsComponent} from './lists.component';
         TuiList4,
         TuiList5,
         TuiList6,
+        TuiList7,
     ],
     exports: [ListsComponent],
 })

--- a/projects/demo/src/modules/markup/lists/lists.template.html
+++ b/projects/demo/src/modules/markup/lists/lists.template.html
@@ -52,7 +52,7 @@
     </tui-doc-example>
 
     <tui-doc-example
-        id="triangle-title"
+        id="triangle-bullets"
         heading="triangle bullets"
         [content]="example7"
     >

--- a/projects/demo/src/modules/markup/lists/lists.template.html
+++ b/projects/demo/src/modules/markup/lists/lists.template.html
@@ -50,4 +50,12 @@
     >
         <tui-lists-example-6></tui-lists-example-6>
     </tui-doc-example>
+
+    <tui-doc-example
+        id="triangle-title"
+        heading="triangle bullets"
+        [content]="example7"
+    >
+        <tui-lists-example-7></tui-lists-example-7>
+    </tui-doc-example>
 </tui-doc-page>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Tinkoff add new core style for bullet list - it appears as triangle - "◤" but taiga doesn't have it.

## What is the new behavior?
Adds new style without changing others. It has same usage as regular linear: `<ul class="tui-list tui-list_triangle">`

![Screenshot_89](https://user-images.githubusercontent.com/1676900/166969801-1d8ca151-d905-416a-b060-51ad2f447ae4.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
