### PR TITLE
chore(demo-integrations): fix `InputTag`, `DataList` flaky tests

### DIFF
--- a/projects/demo-integrations/cypress/tests/core/data-list/data-list.spec.ts
+++ b/projects/demo-integrations/cypress/tests/core/data-list/data-list.spec.ts
@@ -5,7 +5,7 @@ describe('DataList', () => {
         cy.tuiVisit('/components/data-list');
     });
 
-    it('Complex', () => {
+    it('Complex', {responseTimeout: 30_000}, () => {
         const demo = `tui-doc-example[id=complex] .t-demo`;
 
         cy.get(demo).scrollIntoView().should('be.visible');

--- a/projects/demo-integrations/cypress/tests/kit/input/input-tag.spec.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input/input-tag.spec.ts
@@ -5,7 +5,7 @@ describe('Input tag', () => {
         cy.tuiVisit(`components/input-tag`);
     });
 
-    it('switch theme mode', () => {
+    it('switch theme mode', {responseTimeout: 30_000}, () => {
         cy.get('tui-doc-example').should('be.visible');
 
         cy.wait(DEFAULT_TIMEOUT_AFTER_PAGE_REDIRECTION).matchImageSnapshot(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
These test suites take screenshots of the whole page.
It is time-consuming and sometimes in CI (when we have low CPU-performance) the tests can fail.
See [recent example](https://github.com/Tinkoff/taiga-ui/runs/6319429143?check_suite_focus=true#step:10:2287) from the main branch. Or [this example](https://github.com/Tinkoff/taiga-ui/runs/6305554585?check_suite_focus=true#step:10:993).
It was caused by the recent changes [on this line](https://github.com/Tinkoff/taiga-ui/pull/1720/files#diff-ac6ea6a0d601a116bf2b6e2cf157ac8c26487e529b0e3bb41d7eca8a2473fa3eR14).

<img width="1193" alt="input-tag-error" src="https://user-images.githubusercontent.com/35179038/167120447-555406c4-377a-4735-9f46-cc30713fc97c.png">


## What is the new behavior?
Increased time of the config for these tests only (the same value as it was before).
It is a default value of [this config](https://docs.cypress.io/guides/references/configuration#Timeouts).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
