### PR TITLE
chore(demo-integrations): `tuiVisit` wait when fonts start and finish loading

### DIFF
--- a/projects/demo-integrations/cypress/support/visit.ts
+++ b/projects/demo-integrations/cypress/support/visit.ts
@@ -70,6 +70,7 @@ export function tuiVisit(path: string, options: TuiVisitOptions = {}): void {
 
     cy.clearLocalStorage(NEXT_URL_STORAGE_KEY);
 
+    cy.document().its('fonts.size').should('be.greaterThan', 0);
     cy.document().its('fonts.status').should('equal', 'loaded');
 
     if (waitAllIcons) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
1. Try add artificial delay to fonts loading. For example, you can replace this line
https://github.com/Tinkoff/taiga-ui/blob/73959ffa523edaca6f1e6fd70a767fa641876b58/projects/core/styles/theme/fonts.css#L1
by 
```css
@import 'https://deelay.me/3000/https://fonts.googleapis.com/css2?family=Manrope:wght@500;800&display=swap';
```

2. Launch any cypress test
We have this line inside `tuiVisit`:
https://github.com/Tinkoff/taiga-ui/blob/73959ffa523edaca6f1e6fd70a767fa641876b58/projects/demo-integrations/cypress/support/visit.ts#L73

But it does help to wait fonts loading.
It does not work because at the start of the page loading, `document.fonts.status` already has status `loaded` (and it the assertion immediately completes). The status changes to `loading` later (with the first font-request).

## What is the new behavior?
No flaky tests caused by not-loaded fonts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
