### PR TITLE
feat(cdk): add valueOf and Symbol.toPrimitive to TuiDay, TuiMonth, TuiYear and TuiTime 

### DIFF
--- a/projects/cdk/date-time/month.ts
+++ b/projects/cdk/date-time/month.ts
@@ -203,6 +203,10 @@ export class TuiMonth extends TuiYear implements TuiMonthLike {
         return this.formattedMonth;
     }
 
+    valueOf(): number {
+        return this.toLocalNativeDate().valueOf();
+    }
+
     toJSON(): string {
         return `${super.toJSON()}-${this.formattedMonthPart}`;
     }

--- a/projects/cdk/date-time/test/day.spec.ts
+++ b/projects/cdk/date-time/test/day.spec.ts
@@ -1046,6 +1046,17 @@ describe('TuiDay', () => {
                     });
                 });
             });
+
+            describe('valueOf returns', () => {
+                it('the primitive value of TuiDay', () => {
+                    const day = new TuiDay(2000, 5, 13);
+
+                    expect(Number(day)).toBeInstanceOf(Number);
+                    expect(day.valueOf()).toBeInstanceOf(Number);
+                    expect(day > new TuiDay(2000, 5, 10)).toBeTrue();
+                    expect(day < new TuiDay(2001, 5, 10)).toBeTrue();
+                });
+            });
         });
     });
 });

--- a/projects/cdk/date-time/test/day.spec.ts
+++ b/projects/cdk/date-time/test/day.spec.ts
@@ -1048,13 +1048,38 @@ describe('TuiDay', () => {
             });
 
             describe('valueOf returns', () => {
-                it('the primitive value of TuiDay', () => {
+                it('the primitive value of a TuiDay object', () => {
                     const day = new TuiDay(2000, 5, 13);
 
                     expect(Number(day)).toBeInstanceOf(Number);
                     expect(day.valueOf()).toBeInstanceOf(Number);
                     expect(day > new TuiDay(2000, 5, 10)).toBeTrue();
                     expect(day < new TuiDay(2001, 5, 10)).toBeTrue();
+                });
+            });
+
+            describe('Symbol.toPrimitive returns', () => {
+                it('a number if the hint is number', () => {
+                    const day = new TuiDay(2009, 2, 28);
+
+                    expect(Number(day)).toBeInstanceOf(Number);
+                    expect(day.valueOf()).toBeInstanceOf(Number);
+                    expect(day[Symbol.toPrimitive]('number')).toBeInstanceOf(Number);
+                });
+
+                it('a string if the hint is string', () => {
+                    const day = new TuiDay(2004, 3, 22);
+
+                    expect(String(day)).toBeInstanceOf(String);
+                    expect(day.toString()).toBeInstanceOf(String);
+                    expect(day[Symbol.toPrimitive]('string')).toBeInstanceOf(String);
+                });
+
+                it('a string if the hint is default', () => {
+                    const day = new TuiDay(2012, 7, 18);
+
+                    expect(`${day}`).toBeInstanceOf(String);
+                    expect(day[Symbol.toPrimitive]('default')).toBeInstanceOf(String);
                 });
             });
         });

--- a/projects/cdk/date-time/test/month.spec.ts
+++ b/projects/cdk/date-time/test/month.spec.ts
@@ -619,13 +619,38 @@ describe('TuiMonth', () => {
             });
 
             describe('valueOf returns', () => {
-                it('the primitive value of TuiMonth', () => {
+                it('the primitive value of a TuiMonth object', () => {
                     const month = new TuiMonth(2000, 5);
 
                     expect(Number(month)).toBeInstanceOf(Number);
                     expect(month.valueOf()).toBeInstanceOf(Number);
                     expect(month > new TuiMonth(2000, 4)).toBeTrue();
                     expect(month < new TuiMonth(2001, 6)).toBeTrue();
+                });
+            });
+
+            describe('Symbol.toPrimitive returns', () => {
+                it('a number if the hint is number', () => {
+                    const month = new TuiMonth(1998, 7);
+
+                    expect(Number(month)).toBeInstanceOf(Number);
+                    expect(month.valueOf()).toBeInstanceOf(Number);
+                    expect(month[Symbol.toPrimitive]('number')).toBeInstanceOf(Number);
+                });
+
+                it('a string if the hint is string', () => {
+                    const month = new TuiMonth(2030, 1);
+
+                    expect(String(month)).toBeInstanceOf(String);
+                    expect(month.toString()).toBeInstanceOf(String);
+                    expect(month[Symbol.toPrimitive]('string')).toBeInstanceOf(String);
+                });
+
+                it('a string if the hint is default', () => {
+                    const month = new TuiMonth(1905, 2);
+
+                    expect(`${month}`).toBeInstanceOf(String);
+                    expect(month[Symbol.toPrimitive]('default')).toBeInstanceOf(String);
                 });
             });
         });

--- a/projects/cdk/date-time/test/month.spec.ts
+++ b/projects/cdk/date-time/test/month.spec.ts
@@ -617,6 +617,17 @@ describe('TuiMonth', () => {
                     new Date(Date.UTC(2000, 0)).toString(),
                 );
             });
+
+            describe('valueOf returns', () => {
+                it('the primitive value of TuiMonth', () => {
+                    const month = new TuiMonth(2000, 5);
+
+                    expect(Number(month)).toBeInstanceOf(Number);
+                    expect(month.valueOf()).toBeInstanceOf(Number);
+                    expect(month > new TuiMonth(2000, 4)).toBeTrue();
+                    expect(month < new TuiMonth(2001, 6)).toBeTrue();
+                });
+            });
         });
     });
 

--- a/projects/cdk/date-time/test/time.spec.ts
+++ b/projects/cdk/date-time/test/time.spec.ts
@@ -362,4 +362,29 @@ describe('TuiTime', () => {
             expect(time < new TuiTime(7, 36, 0, 0)).toBeTrue();
         });
     });
+
+    describe('Symbol.toPrimitive returns', () => {
+        it('a number if the hint is number', () => {
+            const time = new TuiTime(10, 36, 5, 0);
+
+            expect(Number(time)).toBeInstanceOf(Number);
+            expect(time.valueOf()).toBeInstanceOf(Number);
+            expect(time[Symbol.toPrimitive]('number')).toBeInstanceOf(Number);
+        });
+
+        it('a string if the hint is string', () => {
+            const time = new TuiTime(1, 12, 5, 10);
+
+            expect(String(time)).toBeInstanceOf(String);
+            expect(time.toString()).toBeInstanceOf(String);
+            expect(time[Symbol.toPrimitive]('string')).toBeInstanceOf(String);
+        });
+
+        it('a string if the hint is default', () => {
+            const time = new TuiTime(15, 54, 0, 0);
+
+            expect(`${time}`).toBeInstanceOf(String);
+            expect(time[Symbol.toPrimitive]('default')).toBeInstanceOf(String);
+        });
+    });
 });

--- a/projects/cdk/date-time/test/time.spec.ts
+++ b/projects/cdk/date-time/test/time.spec.ts
@@ -351,4 +351,15 @@ describe('TuiTime', () => {
 
         expect(time.toString('HH:MM:SS.MSS')).toBe('06:36:00.000');
     });
+
+    describe('valueOf returns', () => {
+        it('the primitive value of TuiTime', () => {
+            const time = new TuiTime(6, 36, 0, 0);
+
+            expect(Number(time)).toBeInstanceOf(Number);
+            expect(time.valueOf()).toBeInstanceOf(Number);
+            expect(time > new TuiTime(5, 30, 0, 0)).toBeTrue();
+            expect(time < new TuiTime(7, 36, 0, 0)).toBeTrue();
+        });
+    });
 });

--- a/projects/cdk/date-time/test/year.spec.ts
+++ b/projects/cdk/date-time/test/year.spec.ts
@@ -662,6 +662,17 @@ describe('TuiYear', () => {
                     expect(y2000.append({year: 100}, true).year).toBe(1900);
                 });
             });
+
+            describe('valueOf returns', () => {
+                it('the primitive value of TuiYear', () => {
+                    const year = new TuiYear(2000);
+
+                    expect(Number(year)).toBeInstanceOf(Number);
+                    expect(year.valueOf()).toBeInstanceOf(Number);
+                    expect(year > new TuiYear(1999)).toBeTrue();
+                    expect(year < new TuiYear(2001)).toBeTrue();
+                });
+            });
         });
     });
 

--- a/projects/cdk/date-time/test/year.spec.ts
+++ b/projects/cdk/date-time/test/year.spec.ts
@@ -664,13 +664,38 @@ describe('TuiYear', () => {
             });
 
             describe('valueOf returns', () => {
-                it('the primitive value of TuiYear', () => {
+                it('the primitive value of a TuiYear object', () => {
                     const year = new TuiYear(2000);
 
                     expect(Number(year)).toBeInstanceOf(Number);
                     expect(year.valueOf()).toBeInstanceOf(Number);
                     expect(year > new TuiYear(1999)).toBeTrue();
                     expect(year < new TuiYear(2001)).toBeTrue();
+                });
+            });
+
+            describe('Symbol.toPrimitive returns', () => {
+                it('a number if the hint is number', () => {
+                    const year = new TuiYear(1701);
+
+                    expect(Number(year)).toBeInstanceOf(Number);
+                    expect(year.valueOf()).toBeInstanceOf(Number);
+                    expect(year[Symbol.toPrimitive]('number')).toBeInstanceOf(Number);
+                });
+
+                it('a string if the hint is string', () => {
+                    const year = new TuiYear(2201);
+
+                    expect(String(year)).toBeInstanceOf(String);
+                    expect(year.toString()).toBeInstanceOf(String);
+                    expect(year[Symbol.toPrimitive]('string')).toBeInstanceOf(String);
+                });
+
+                it('a string if the hint is default', () => {
+                    const year = new TuiYear(2002);
+
+                    expect(`${year}`).toBeInstanceOf(String);
+                    expect(year[Symbol.toPrimitive]('default')).toBeInstanceOf(String);
                 });
             });
         });

--- a/projects/cdk/date-time/time.ts
+++ b/projects/cdk/date-time/time.ts
@@ -171,6 +171,15 @@ export class TuiTime implements TuiTimeLike {
     }
 
     /**
+     * Returns the primitive value of the given Date object.
+     * Depending on the argument, the method can return either a string or a number.
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive
+     */
+    [Symbol.toPrimitive](hint: string): string | number {
+        return Date.prototype[Symbol.toPrimitive].call(this, hint);
+    }
+
+    /**
      * Converts TuiTime to milliseconds
      */
     toAbsoluteMilliseconds(): number {

--- a/projects/cdk/date-time/time.ts
+++ b/projects/cdk/date-time/time.ts
@@ -166,6 +166,10 @@ export class TuiTime implements TuiTimeLike {
         );
     }
 
+    valueOf(): number {
+        return this.toAbsoluteMilliseconds();
+    }
+
     /**
      * Converts TuiTime to milliseconds
      */

--- a/projects/cdk/date-time/year.ts
+++ b/projects/cdk/date-time/year.ts
@@ -164,6 +164,15 @@ export class TuiYear implements TuiYearLike {
         return this.year;
     }
 
+    /**
+     * Returns the primitive value of the given Date object.
+     * Depending on the argument, the method can return either a string or a number.
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive
+     */
+    [Symbol.toPrimitive](hint: string): string | number {
+        return Date.prototype[Symbol.toPrimitive].call(this, hint);
+    }
+
     toJSON(): string {
         return this.formattedYear;
     }

--- a/projects/cdk/date-time/year.ts
+++ b/projects/cdk/date-time/year.ts
@@ -160,6 +160,10 @@ export class TuiYear implements TuiYearLike {
         return this.formattedYear;
     }
 
+    valueOf(): number {
+        return this.year;
+    }
+
     toJSON(): string {
         return this.formattedYear;
     }

--- a/projects/demo-integrations/cypress/tests/kit/input-time/input-time.spec.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-time/input-time.spec.ts
@@ -1,0 +1,58 @@
+describe('InputTime', () => {
+    beforeEach(() => {
+        cy.clock(Date.UTC(2021, 10, 10, 15, 30, 0, 0), ['Date']);
+    });
+
+    describe('items are passed', () => {
+        it('the dropdown is visible when the input is focused', () => {
+            visitBy('items$=1');
+
+            getInput().click();
+            cy.matchImageSnapshot('dropdown_is_visible', {capture: 'viewport'});
+        });
+
+        it('disabledItemHandler disables the specified items in the dropdown', () => {
+            visitBy('disabledItemHandler$=1&items$=1');
+
+            getInput().click();
+            getDropdown().scrollTo(0, 500).matchImageSnapshot('06_00_is_disabled');
+        });
+
+        for (const size of ['s', 'm', 'l']) {
+            it(`the dropdown is configured for ${size} size`, () => {
+                visitBy(`items$=1&itemSize=${size}`);
+
+                getInput().click();
+                getDropdown().matchImageSnapshot(`dropdown_size_${size}`);
+            });
+        }
+
+        it('strict forces to select the closest value from items', () => {
+            visitBy('strict=true&items$=1');
+
+            getInput().clear().type('07:55', {force: true}).should('have.value', '08:00');
+        });
+    });
+
+    for (const mode of ['HH:MM', 'HH:MM:SS', 'HH:MM:SS.MSS']) {
+        it(`the input is configured for ${mode} mode`, () => {
+            visitBy(`mode=${mode}`);
+
+            getInput().click().matchImageSnapshot(`dropdown_mode_${mode}`);
+        });
+    }
+
+    function visitBy(params: string): void {
+        cy.tuiVisit(`components/input-time/API?tuiMode=null&${params}`);
+    }
+
+    function getInput(): Cypress.Chainable<JQuery> {
+        return cy
+            .get('#demoContent')
+            .findByAutomationId('tui-primitive-textfield__native-input');
+    }
+
+    function getDropdown(): Cypress.Chainable<JQuery> {
+        return cy.get('tui-dropdown-box tui-scrollbar');
+    }
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #1729

## What is the new behavior?

`valueOf` and `Symbol.toPrimitive` are added to TuiDay, TuiMonth, TuiYear and TuiTime

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
