### PR TITLE
fix(core): `tui-slider-ticks-labels` error `Operation on an invalid type`

### DIFF
--- a/projects/core/styles/mixins/slider.less
+++ b/projects/core/styles/mixins/slider.less
@@ -4,7 +4,7 @@
 };
 
 .tui-slider-ticks-labels(@input-size: m) {
-    @first-tick-center: @thumb-diameters[ @@input-size] / 2;
+    @first-tick-center: (@thumb-diameters[ @@input-size] / 2);
     display: flex;
     margin: 0 @first-tick-center;
     font: var(--tui-font-text-s);

--- a/projects/kit/components/range/range.style.less
+++ b/projects/kit/components/range/range.style.less
@@ -34,7 +34,7 @@
 
 .track(@thumb-width) {
     position: relative;
-    margin: 0 @thumb-width / 2;
+    margin: 0 (@thumb-width / 2);
     height: 100%;
 
     /* Filled selected range */
@@ -46,7 +46,7 @@
         right: var(--right);
         height: 100%;
         background: var(--tui-primary);
-        margin: 0 -@thumb-width / 2;
+        margin: 0 (-@thumb-width / 2);
     }
 }
 
@@ -102,7 +102,7 @@
     .ignore-track-pointer-events();
     .remove-track-background();
     position: absolute;
-    top: @track-height / 2;
+    top: (@track-height / 2);
     left: 0;
     right: 0;
     z-index: 1;
@@ -135,12 +135,12 @@
 
     :host[data-size='s'] & {
         .tui-slider-ticks-labels(s);
-        padding: 0 @thumb-diameters[ @s] / 2;
+        padding: 0 (@thumb-diameters[ @s] / 2);
     }
 
     :host[data-size='m'] & {
         .tui-slider-ticks-labels(m);
-        padding: 0 @thumb-diameters[ @m] / 2;
+        padding: 0 (@thumb-diameters[ @m] / 2);
     }
 }
 
@@ -159,11 +159,11 @@
 // TODO delete in v3.0
 .segment {
     &:last-of-type .number {
-        margin-right: -@thumb-diameters[ @m] / 2;
+        margin-right: (-@thumb-diameters[ @m] / 2);
     }
 
     &:first-of-type .number {
-        margin-left: -@thumb-diameters[ @m] / 2;
+        margin-left: (-@thumb-diameters[ @m] / 2);
     }
 }
 

--- a/projects/kit/components/slider/slider.style.less
+++ b/projects/kit/components/slider/slider.style.less
@@ -20,7 +20,7 @@
     The most left point of the track is the most left point of the thumb (at the zero-position).
     The first tick should start at the center of thumb to set correct position for all other ticks.
     */
-    @first-tick-offset: (@thumb-width - @ticks-thickness) / 2;
+    @first-tick-offset: ((@thumb-width - @ticks-thickness) / 2);
     @ticks-background-size: calc(100% - @thumb-width);
 
     @hide-first-tick: linear-gradient(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Use Angular 13
```
.some-class {
  .tui-slider-ticks-labels();
^
Operation on an invalid type
      Error in .../.../app.component.less
```


## What is the new behavior?
See [Less documentation](https://lesscss.org/usage/#less-options-math):
> In order to cause fewer conflicts with CSS, which now liberally uses the / symbol between values, there is now a math mode that only requires parentheses for division. (This is now the default in Less 4.) "Strict math" has also been tweaked to operate more intuitively, although the legacy behavior is supported.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
