### PR TITLE
chore(cdk): `schematics` replace deprecated `TuiNotificationsModule` by `TuiAlertModule`

### DIFF
--- a/projects/cdk/schematics/ng-add/constants/modules.ts
+++ b/projects/cdk/schematics/ng-add/constants/modules.ts
@@ -21,9 +21,9 @@ export const DIALOG_MODULES: ReadonlyArray<ImportingModule> = [
     },
 ];
 
-export const NOTIFICATION_MODULES: ReadonlyArray<ImportingModule> = [
+export const ALERT_MODULES: ReadonlyArray<ImportingModule> = [
     {
-        name: 'TuiNotificationsModule',
+        name: 'TuiAlertModule',
         packageName: '@taiga-ui/core',
     },
 ];

--- a/projects/cdk/schematics/ng-add/schema.json
+++ b/projects/cdk/schematics/ng-add/schema.json
@@ -29,7 +29,7 @@
                 "type": "confirmation"
             }
         },
-        "addNotificationsModule": {
+        "addAlertModule": {
             "description": "Setting up alerts module",
             "type": "boolean",
             "default": true,

--- a/projects/cdk/schematics/ng-add/schema.json
+++ b/projects/cdk/schematics/ng-add/schema.json
@@ -30,11 +30,11 @@
             }
         },
         "addNotificationsModule": {
-            "description": "Setting up notifications module",
+            "description": "Setting up alerts module",
             "type": "boolean",
             "default": true,
             "x-prompt": {
-                "message": "Do you want to use Taiga UI notifications?",
+                "message": "Do you want to use Taiga UI alerts?",
                 "type": "confirmation"
             }
         },

--- a/projects/cdk/schematics/ng-add/schema.ts
+++ b/projects/cdk/schematics/ng-add/schema.ts
@@ -1,7 +1,7 @@
 export interface Schema {
     readonly project: string;
     readonly addons: ReadonlyArray<string>;
-    readonly addNotificationsModule: boolean;
+    readonly addAlertModule: boolean;
     readonly addDialogsModule: boolean;
     readonly addSanitizer: boolean;
 }

--- a/projects/cdk/schematics/ng-add/steps/add-taiga-modules.ts
+++ b/projects/cdk/schematics/ng-add/steps/add-taiga-modules.ts
@@ -46,7 +46,7 @@ function addTuiModules(
     const modules = [
         ...MAIN_MODULES,
         ...(options.addDialogsModule ? DIALOG_MODULES : []),
-        ...(options.addNotificationsModule ? ALERT_MODULES : []),
+        ...(options.addAlertModule ? ALERT_MODULES : []),
     ];
 
     const mainModulePath = mainModule.getSourceFile().getFilePath();

--- a/projects/cdk/schematics/ng-add/steps/add-taiga-modules.ts
+++ b/projects/cdk/schematics/ng-add/steps/add-taiga-modules.ts
@@ -13,9 +13,9 @@ import {
 import {getProject} from '../../utils/get-project';
 import {getProjectTargetOptions} from '../../utils/get-project-target-options';
 import {
+    ALERT_MODULES,
     DIALOG_MODULES,
     MAIN_MODULES,
-    NOTIFICATION_MODULES,
     SANITIZER_MODULES,
 } from '../constants/modules';
 import {Schema} from '../schema';
@@ -46,7 +46,7 @@ function addTuiModules(
     const modules = [
         ...MAIN_MODULES,
         ...(options.addDialogsModule ? DIALOG_MODULES : []),
-        ...(options.addNotificationsModule ? NOTIFICATION_MODULES : []),
+        ...(options.addNotificationsModule ? ALERT_MODULES : []),
     ];
 
     const mainModulePath = mainModule.getSourceFile().getFilePath();

--- a/projects/cdk/schematics/ng-add/tests/schematic-ng-add.spec.ts
+++ b/projects/cdk/schematics/ng-add/tests/schematic-ng-add.spec.ts
@@ -181,12 +181,12 @@ describe('ng-add', () => {
         expect(tree.readContent('test/app/app.module.ts')).toEqual(
             `import { NgDompurifySanitizer } from "@tinkoff/ng-dompurify";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { TuiRootModule, TuiDialogModule, TuiNotificationsModule, TUI_SANITIZER } from "@taiga-ui/core";
+import { TuiRootModule, TuiDialogModule, TuiAlertModule, TUI_SANITIZER } from "@taiga-ui/core";
 import {NgModule} from '@angular/core';
 import {AppComponent} from './app.component';
 
 @NgModule({declarations: [AppComponent],
-        imports: [TuiRootModule, BrowserAnimationsModule, TuiDialogModule, TuiNotificationsModule],
+        imports: [TuiRootModule, BrowserAnimationsModule, TuiDialogModule, TuiAlertModule],
         providers: [{provide: TUI_SANITIZER, useClass: NgDompurifySanitizer}]
     })
 export class AppModule {}

--- a/projects/cdk/schematics/ng-add/tests/schematic-ng-add.spec.ts
+++ b/projects/cdk/schematics/ng-add/tests/schematic-ng-add.spec.ts
@@ -42,7 +42,7 @@ describe('ng-add', () => {
         const options: Schema = {
             addSanitizer: false,
             addDialogsModule: false,
-            addNotificationsModule: false,
+            addAlertModule: false,
             addons: [],
             project: '',
         };
@@ -66,7 +66,7 @@ describe('ng-add', () => {
         const options: Schema = {
             addSanitizer: true,
             addDialogsModule: false,
-            addNotificationsModule: false,
+            addAlertModule: false,
             addons: ['addon-doc', 'addon-mobile'],
             project: '',
         };
@@ -170,7 +170,7 @@ describe('ng-add', () => {
         const options: Schema = {
             addSanitizer: true,
             addDialogsModule: true,
-            addNotificationsModule: true,
+            addAlertModule: true,
             addons: [],
             project: '',
         };

--- a/projects/taiga-schematics/schematics/ng-add/constants/modules.ts
+++ b/projects/taiga-schematics/schematics/ng-add/constants/modules.ts
@@ -21,9 +21,9 @@ export const DIALOG_MODULES: ReadonlyArray<ImportingModule> = [
     },
 ];
 
-export const NOTIFICATION_MODULES: ReadonlyArray<ImportingModule> = [
+export const ALERT_MODULES: ReadonlyArray<ImportingModule> = [
     {
-        name: 'TuiNotificationsModule',
+        name: 'TuiAlertModule',
         packageName: '@taiga-ui/core',
     },
 ];

--- a/projects/taiga-schematics/schematics/ng-add/schema.json
+++ b/projects/taiga-schematics/schematics/ng-add/schema.json
@@ -29,7 +29,7 @@
                 "type": "confirmation"
             }
         },
-        "addNotificationsModule": {
+        "addAlertModule": {
             "description": "Setting up alerts module",
             "type": "boolean",
             "default": true,

--- a/projects/taiga-schematics/schematics/ng-add/schema.json
+++ b/projects/taiga-schematics/schematics/ng-add/schema.json
@@ -30,11 +30,11 @@
             }
         },
         "addNotificationsModule": {
-            "description": "Setting up notifications module",
+            "description": "Setting up alerts module",
             "type": "boolean",
             "default": true,
             "x-prompt": {
-                "message": "Do you want to use Taiga UI notifications?",
+                "message": "Do you want to use Taiga UI alerts?",
                 "type": "confirmation"
             }
         },

--- a/projects/taiga-schematics/schematics/ng-add/schema.ts
+++ b/projects/taiga-schematics/schematics/ng-add/schema.ts
@@ -1,7 +1,7 @@
 export interface Schema {
     readonly project: string;
     readonly addons: ReadonlyArray<string>;
-    readonly addNotificationsModule: boolean;
+    readonly addAlertModule: boolean;
     readonly addDialogsModule: boolean;
     readonly addSanitizer: boolean;
 }

--- a/projects/taiga-schematics/schematics/ng-add/steps/add-taiga-modules.ts
+++ b/projects/taiga-schematics/schematics/ng-add/steps/add-taiga-modules.ts
@@ -16,9 +16,9 @@ import {
 import {getProject} from '../../utils/get-project';
 import {getProjectTargetOptions} from '../../utils/get-project-target-options';
 import {
+    ALERT_MODULES,
     DIALOG_MODULES,
     MAIN_MODULES,
-    NOTIFICATION_MODULES,
     SANITIZER_MODULES,
 } from '../constants/modules';
 import {Schema} from '../schema';
@@ -48,7 +48,7 @@ function addTuiModules(
     const modules = [
         ...MAIN_MODULES,
         ...(options.addDialogsModule ? DIALOG_MODULES : []),
-        ...(options.addNotificationsModule ? NOTIFICATION_MODULES : []),
+        ...(options.addNotificationsModule ? ALERT_MODULES : []),
     ];
 
     const mainModulePath = mainModule.getSourceFile().getFilePath();

--- a/projects/taiga-schematics/schematics/ng-add/steps/add-taiga-modules.ts
+++ b/projects/taiga-schematics/schematics/ng-add/steps/add-taiga-modules.ts
@@ -48,7 +48,7 @@ function addTuiModules(
     const modules = [
         ...MAIN_MODULES,
         ...(options.addDialogsModule ? DIALOG_MODULES : []),
-        ...(options.addNotificationsModule ? ALERT_MODULES : []),
+        ...(options.addAlertModule ? ALERT_MODULES : []),
     ];
 
     const mainModulePath = mainModule.getSourceFile().getFilePath();

--- a/projects/taiga-schematics/schematics/ng-add/tests/ng-add.spec.ts
+++ b/projects/taiga-schematics/schematics/ng-add/tests/ng-add.spec.ts
@@ -181,12 +181,12 @@ describe('ng-add', () => {
         expect(tree.readContent('test/app/app.module.ts')).toEqual(
             `import { NgDompurifySanitizer } from "@tinkoff/ng-dompurify";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { TuiRootModule, TuiDialogModule, TuiNotificationsModule, TUI_SANITIZER } from "@taiga-ui/core";
+import { TuiRootModule, TuiDialogModule, TuiAlertModule, TUI_SANITIZER } from "@taiga-ui/core";
 import {NgModule} from '@angular/core';
 import {AppComponent} from './app.component';
 
 @NgModule({declarations: [AppComponent],
-        imports: [TuiRootModule, BrowserAnimationsModule, TuiDialogModule, TuiNotificationsModule],
+        imports: [TuiRootModule, BrowserAnimationsModule, TuiDialogModule, TuiAlertModule],
         providers: [{provide: TUI_SANITIZER, useClass: NgDompurifySanitizer}]
     })
 export class AppModule {}

--- a/projects/taiga-schematics/schematics/ng-add/tests/ng-add.spec.ts
+++ b/projects/taiga-schematics/schematics/ng-add/tests/ng-add.spec.ts
@@ -42,7 +42,7 @@ describe('ng-add', () => {
         const options: Schema = {
             addSanitizer: false,
             addDialogsModule: false,
-            addNotificationsModule: false,
+            addAlertModule: false,
             addons: [],
             project: '',
         };
@@ -66,7 +66,7 @@ describe('ng-add', () => {
         const options: Schema = {
             addSanitizer: true,
             addDialogsModule: false,
-            addNotificationsModule: false,
+            addAlertModule: false,
             addons: ['addon-doc', 'addon-mobile'],
             project: '',
         };
@@ -170,7 +170,7 @@ describe('ng-add', () => {
         const options: Schema = {
             addSanitizer: true,
             addDialogsModule: true,
-            addNotificationsModule: true,
+            addAlertModule: true,
             addons: [],
             project: '',
         };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
1. Type command:
```
ng add taiga-ui
```

2. Agree to add notifications
<img width="1341" alt="ngAddAlerts" src="https://user-images.githubusercontent.com/35179038/168596607-1a02f7a4-a6bf-4682-bf88-eb8989528899.png">

3. Schematic adds deprecated module.

## What is the new behavior?
Use not-deprecated module

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
