### PR TITLE
fix(kit): `ComboBox` throws `ExpressionChangedAfterItHasBeenCheckedError`

### DIFF
--- a/projects/kit/components/select-option/select-option.component.ts
+++ b/projects/kit/components/select-option/select-option.component.ts
@@ -50,9 +50,18 @@ export class TuiSelectOptionComponent<T> implements OnInit {
     }
 
     ngOnInit(): void {
-        if (isPresent(this.option.value) && this.host.checkOption) {
-            this.host.checkOption(this.option.value);
-        }
+        /**
+         * This would cause changes inside already checked parent component (during the same change detection cycle),
+         * and it might cause ExpressionChanged error due to potential HostBinding
+         * (for example, inside {@link https://github.com/angular/angular/blob/main/packages/forms/src/directives/ng_control_status.ts#L99 NgControlStatus}).
+         * Microtask keeps it in the same frame but allows change detection to run.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        Promise.resolve().then(() => {
+            if (isPresent(this.option.value) && this.host.checkOption) {
+                this.host.checkOption(this.option.value);
+            }
+        });
     }
 
     protected get selected(): boolean {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
#### Simplified version of the bug’s reproduction:

<details>
  <summary>HTML</summary>

```html
<tui-root>
  <tui-combo-box
    [ngModel]="selectedProcedure"
    [stringify]="stringify"
    (searchChange)="onSearchProcedureChange()"
  >
    Type "1"

    <tui-data-list-wrapper
      *tuiDataList
      [items]="procedures$ | async"
    ></tui-data-list-wrapper>
  </tui-combo-box>
</tui-root>
```
</details>

<details>
  <summary>Typescript</summary>

```ts
import { Component } from '@angular/core';
import { BehaviorSubject } from 'rxjs';


@Component({
  selector: 'my-app',
  templateUrl: './app.component.html',
})
export class ExampleComponent {
  procedures$ = new BehaviorSubject<any[]>([]);
  selectedProcedure: any = null;

 onSearchProcedureChange(): void {
    this.procedures$.next([
      { id: '1', name: 'one' },
      { id: '2', name: 'two' },
    ]);
  }

  stringify(procedure: any): string {
    return procedure?.id;
  }
}

```
</details>

#### What's happening
1. When we type "1", this function is triggered:
https://github.com/Tinkoff/taiga-ui/blob/d82ab19a9598ec47469b0d218b514c4ddd78263e/projects/kit/components/combo-box/combo-box.component.ts#L181-L198

Controller is not changed (it was `null` and after this function it is still `null`). It is still pristine.

No item is selected because `procedures$` (inside our `ExampleComponent`) is empty. After that function `onSearchProcedureChange` (inside our `ExampleComponent`) is triggered and fills `procedures$` with two new items (prop `[items]` inside `<tui-data-list-wrapper />` changes).

2. **Tick happens!** (all next steps happens in the same tick).

3.  Angular evaluates `pristine`-status as `true` inside this [built-in form-controller directive](https://github.com/angular/angular/blob/main/packages/forms/src/directives/ng_control_status.ts#L99).

4. Angular renders new `SelectOption`-s and their `ngOnInit` were triggered:
https://github.com/Tinkoff/taiga-ui/blob/68ab06940351262f9468165d5c4a3aa1046d5696/projects/kit/components/select-option/select-option.component.ts#L52-L56

They invoke `checkOption`-functions of the parent component.
https://github.com/Tinkoff/taiga-ui/blob/d82ab19a9598ec47469b0d218b514c4ddd78263e/projects/kit/components/combo-box/combo-box.component.ts#L148-L155

And `this.updateValue(option)` makes control `dirty`.

5. Angular starts its  next digest cycle with checks (dev-mode only). At the start of the change-detection cycle `pristine` was `true` but at the end it is `false`. Angular throws error.

Closes #1643

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
