### PR TITLE
fix(addon-editor): prevent re-attach elements after state changes

### DIFF
--- a/projects/addon-editor/components/editor-socket/editor-socket.component.ts
+++ b/projects/addon-editor/components/editor-socket/editor-socket.component.ts
@@ -27,16 +27,7 @@ import {TUI_SANITIZER} from '@taiga-ui/core';
 export class TuiEditorSocketComponent {
     @Input()
     set content(content: string) {
-        this.renderer.setProperty(
-            this.elementRef.nativeElement,
-            'innerHTML',
-            this.tuiSanitizer
-                ? this.tuiSanitizer.sanitize(
-                      SecurityContext.HTML,
-                      content.replace(/colwidth/g, 'width'),
-                  )
-                : this.sanitizer.sanitize(SecurityContext.HTML, content),
-        );
+        this.setInnerHTML(content);
     }
 
     constructor(
@@ -59,5 +50,18 @@ export class TuiEditorSocketComponent {
         renderer.setAttribute(style, 'data-tui-editor-socket', '');
 
         head.appendChild(style);
+    }
+
+    private setInnerHTML(content: string): void {
+        this.renderer.setProperty(
+            this.elementRef.nativeElement,
+            'innerHTML',
+            this.tuiSanitizer
+                ? this.tuiSanitizer.sanitize(
+                      SecurityContext.HTML,
+                      content.replace(/colwidth/g, 'width'),
+                  )
+                : this.sanitizer.sanitize(SecurityContext.HTML, content),
+        );
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Part of #1646


https://user-images.githubusercontent.com/12021443/169816885-cc16a01f-0e6d-49ec-aa15-6b51c5d5b286.mov


## What is the new behavior?


https://user-images.githubusercontent.com/12021443/169817035-297faee5-f6c4-44ab-8eeb-ead1324fa2bd.mov


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
