### PR TITLE
fix(kit): `InputSlider` changes focused `InputNumber`'s value on slider's interactions

### DIFF
--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -229,6 +229,11 @@ export class TuiInputSliderComponent
         this.updateTextInputValue(this.valueGuard(value));
     }
 
+    onSliderChange(newValue: number): void {
+        this.safelyUpdateValue(newValue);
+        this.updateTextInputValue(this.value);
+    }
+
     onFocused(focused: boolean): void {
         if (!focused && !this.textInputValue) {
             this.updateTextInputValue(this.safeCurrentValue);

--- a/projects/kit/components/input-slider/input-slider.template.html
+++ b/projects/kit/components/input-slider/input-slider.template.html
@@ -45,7 +45,7 @@
         [keySteps]="computedKeySteps"
         [attr.disabled]="readOnly || disabled || null"
         [ngModel]="value"
-        (keyStepsInput)="safelyUpdateValue($event)"
+        (keyStepsInput)="onSliderChange($event)"
         (click)="focusTextInput()"
     />
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
1. Open mobile version of the browser
2. Open https://taiga-ui.dev/components/input-slider
3. Focus text input inside `InputSlider`
4. Change value via `Slider` (text input should be still focused)
5. No changes inside text input

https://user-images.githubusercontent.com/35179038/170033269-398fc252-ae91-4d91-b86a-3bddd12a6578.MP4

## What is the new behavior?

https://user-images.githubusercontent.com/35179038/170034243-d7318c24-8162-4484-8ab2-ee10f66b3198.MP4

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
