### PR TITLE
fix(kit): `InputRange` problem with range interactions on mobile devices

### DIFF
--- a/projects/demo-integrations/cypress/support/visit.ts
+++ b/projects/demo-integrations/cypress/support/visit.ts
@@ -21,6 +21,12 @@ interface TuiVisitOptions {
     noSmoothScroll?: boolean;
     hideHeader?: boolean;
     hideNavigation?: boolean;
+    /**
+     * WARNING: this flag does not provide fully emulation of touch mobile device.
+     * Cypress can't do it (https://docs.cypress.io/faq/questions/general-questions-faq#Do-you-support-native-mobile-apps).
+     * But you can control token `TUI_IS_MOBILE` by this flag.
+     */
+    pseudoMobile?: boolean;
 }
 
 const setBeforeLoadOptions = (
@@ -33,6 +39,9 @@ const setBeforeLoadOptions = (
     }
 };
 
+const MOBILE_USER_AGENT =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1';
+
 export function tuiVisit(path: string, options: TuiVisitOptions = {}): void {
     const {
         inIframe = true,
@@ -43,6 +52,7 @@ export function tuiVisit(path: string, options: TuiVisitOptions = {}): void {
         noSmoothScroll = true,
         hideHeader = true,
         hideNavigation = true,
+        pseudoMobile = false,
     } = options;
 
     stubExternalIcons();
@@ -59,6 +69,12 @@ export function tuiVisit(path: string, options: TuiVisitOptions = {}): void {
 
             window.localStorage.setItem(NEXT_URL_STORAGE_KEY, nextUrl);
             window.localStorage.setItem(NIGHT_THEME_KEY, enableNightMode.toString());
+
+            if (pseudoMobile) {
+                Object.defineProperty(window.navigator, 'userAgent', {
+                    value: MOBILE_USER_AGENT,
+                });
+            }
         },
     }).then(() => cy.url().should('include', path));
 

--- a/projects/demo-integrations/cypress/tests/kit/input-range/input-range.spec.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-range/input-range.spec.ts
@@ -234,6 +234,65 @@ describe('InputRange', () => {
                 .matchImageSnapshot('03-long-placeholder_pluralize');
         });
     });
+
+    describe('Mobile version', () => {
+        beforeEach(() => {
+            cy.viewport('iphone-x');
+            cy.tuiVisit(`${INPUT_RANGE_PAGE_URL}/API?min=-20&max=20&quantum=5`, {
+                pseudoMobile: true,
+            });
+            initializeAliases('#demoContent tui-input-range', [0, 10]);
+        });
+
+        describe('After Range interactions', () => {
+            it('keeps focus if the RIGHT text input was focused before', () => {
+                cy.get('@rightTextInput').focus();
+
+                cy.get('@rightSlider')
+                    .click('right', {force: true})
+                    .should('have.value', 20);
+
+                cy.get('@rightTextInput').should('have.value', 20).should('be.focused');
+            });
+
+            it('keeps focus if the LEFT text input was focused before', () => {
+                cy.get('@leftTextInput').focus();
+
+                cy.get('@leftSlider')
+                    .click('left', {force: true})
+                    .should('have.value', -20);
+
+                cy.get('@leftTextInput').should('have.value', -20).should('be.focused');
+            });
+
+            it('does not focus anything if no text input was focused before', () => {
+                cy.get('@leftTextInput').should('not.be.focused');
+                cy.get('@rightTextInput').should('not.be.focused');
+
+                cy.get('@leftSlider')
+                    .click('left', {force: true})
+                    .should('have.value', -20);
+
+                cy.get('@leftTextInput')
+                    .should('have.value', -20)
+                    .should('not.be.focused');
+                cy.get('@rightTextInput')
+                    .should('have.value', 10)
+                    .should('not.be.focused');
+
+                cy.get('@rightSlider')
+                    .click('right', {force: true})
+                    .should('have.value', 20);
+
+                cy.get('@leftTextInput')
+                    .should('have.value', -20)
+                    .should('not.be.focused');
+                cy.get('@rightTextInput')
+                    .should('have.value', 20)
+                    .should('not.be.focused');
+            });
+        });
+    });
 });
 
 function initializeAliases(

--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -243,9 +243,15 @@ export class TuiInputRangeComponent
         this.safelyUpdateValue([this.value[0], value ?? this.safeCurrentValue[1]]);
     }
 
-    onRangeValue([left, right]: [number, number]): void {
-        this.rangeRef?.nativeFocusableElement?.focus();
-        this.safelyUpdateValue([left, right]);
+    onRangeValue(value: [number, number]): void {
+        this.safelyUpdateValue(value);
+
+        const rightValueChanged = this.lastActiveSide === 'right';
+
+        this.updateTextInputValue(
+            this.value[rightValueChanged ? 1 : 0],
+            rightValueChanged,
+        );
     }
 
     focusToTextInput(): void {
@@ -257,10 +263,6 @@ export class TuiInputRangeComponent
         if (!this.isMobile && element) {
             element.focus();
         }
-    }
-
-    blurRange(): void {
-        this.rangeRef?.nativeFocusableElement?.blur();
     }
 
     onActiveThumbChange(activeThumb: 'right' | 'left'): void {

--- a/projects/kit/components/input-range/input-range.template.html
+++ b/projects/kit/components/input-range/input-range.template.html
@@ -86,7 +86,6 @@
         [ngModel]="value"
         (ngModelChange)="onRangeValue($event)"
         (tuiPressedChange)="focusToTextInput()"
-        (touchend)="blurRange()"
         (activeThumbChange)="onActiveThumbChange($event)"
     ></tui-range>
 </tui-wrapper>

--- a/projects/kit/components/range/range-change.directive.ts
+++ b/projects/kit/components/range/range-change.directive.ts
@@ -54,7 +54,10 @@ export class TuiRangeChangeDirective {
                 tap(({clientX, target}) => {
                     activeThumb = this.detectActiveThumb(clientX, target);
                     this.activeThumbChange.emit(activeThumb);
-                    elementRef.nativeElement.focus();
+
+                    if (this.range.focusable) {
+                        elementRef.nativeElement.focus();
+                    }
                 }),
                 switchMap(event => this.pointerMove$.pipe(startWith(event))),
                 map(({clientX}) => clamp(this.getFractionFromEvents(clientX), 0, 1)),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
1. Use real mobile device
2. Focus text input on any side of `InputRange`
3. Try interact with `Range`

**Actual behaviour:**

https://user-images.githubusercontent.com/35179038/170229324-85663bb7-250f-46a7-a6f7-3a63b3591348.MP4

**Expected behaviour:**
Keyboard should not disappear after range interactions.
It should behaves in the same way as `InputSlider`.


Also, there is problem with focus ring in our proprietary demo:

https://user-images.githubusercontent.com/35179038/170229777-960612c0-67f0-44e2-aaea-0191d0378db3.mov


## What is the new behavior?
Fix all mentioned problem.

https://user-images.githubusercontent.com/35179038/170230507-c007a7ef-1634-4bff-b16a-57d04307c5b7.MP4



## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
