### PR TITLE
chore: target `cdk:test-schematics` dependsOn `cdk:build`

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -400,7 +400,13 @@
                             "tsc -p ./projects/cdk/schematics/tsconfig.spec.json --tsBuildInfoFile null",
                             "jasmine ./dist/cdk/schematics/**/*.spec.js"
                         ]
-                    }
+                    },
+                    "dependsOn": [
+                        {
+                            "target": "build",
+                            "projects": "self"
+                        }
+                    ]
                 },
                 "publish": {
                     "builder": "@nrwl/workspace:run-commands",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
To run schematics tests we need to run:
```sh
nx build cdk & nx test-schematics cdk 
```

## What is the new behavior?
Nx knows that before testing of schematics it should build `cdk`-package.

Now to test schematics we should just run
```sh
nx test-schematics cdk 
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
