### PR TITLE
fix(kit): `InputNumber` prefix is overlapped by value

### DIFF
--- a/projects/core/components/primitive-textfield/value-decoration/value-decoration.component.ts
+++ b/projects/core/components/primitive-textfield/value-decoration/value-decoration.component.ts
@@ -7,12 +7,13 @@ import {
     ViewChild,
 } from '@angular/core';
 import {MutationObserverDirective} from '@ng-web-apis/mutation-observer';
+import {TuiResizeService} from '@taiga-ui/cdk';
 import {
     TUI_TEXTFIELD_WATCHED_CONTROLLER,
     TuiTextfieldController,
 } from '@taiga-ui/core/directives';
 import {TuiAppearance} from '@taiga-ui/core/enums';
-import {defer, EMPTY} from 'rxjs';
+import {defer, EMPTY, merge, Observable} from 'rxjs';
 import {distinctUntilChanged, map, startWith} from 'rxjs/operators';
 
 import {TuiPrimitiveTextfieldComponent} from '../primitive-textfield.component';
@@ -21,6 +22,7 @@ import {TuiPrimitiveTextfieldComponent} from '../primitive-textfield.component';
     selector: 'tui-value-decoration',
     templateUrl: 'value-decoration.template.html',
     styleUrls: ['value-decoration.style.less'],
+    providers: [TuiResizeService],
     // It follows Change Detection of PrimitiveTextfield
     changeDetection: ChangeDetectionStrategy.Default,
 })
@@ -31,7 +33,9 @@ export class TuiValueDecorationComponent {
     @ViewChild(MutationObserverDirective, {static: true})
     private readonly directive?: MutationObserverDirective;
 
-    readonly pre$ = defer(() => this.directive?.waMutationObserver ?? EMPTY).pipe(
+    readonly pre$ = defer(() =>
+        merge(this.directive?.waMutationObserver ?? EMPTY, this.resize$),
+    ).pipe(
         map(() => this.pre?.nativeElement.offsetWidth ?? 0),
         startWith(0),
         distinctUntilChanged(),
@@ -42,6 +46,8 @@ export class TuiValueDecorationComponent {
         private readonly textfield: TuiPrimitiveTextfieldComponent,
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         private readonly controller: TuiTextfieldController,
+        @Inject(TuiResizeService)
+        readonly resize$: Observable<unknown>,
     ) {}
 
     @HostBinding('class._table')

--- a/projects/demo/src/modules/components/input-number/examples/1/index.html
+++ b/projects/demo/src/modules/components/input-number/examples/1/index.html
@@ -1,41 +1,23 @@
-<form [formGroup]="testForm">
-    <div class="tui-row">
-        <tui-input-number
-            formControlName="testValue"
-            class="tui-col_md-4"
-            [postfix]="'UGX' | tuiCurrency"
-        >
-            Type a sum
-        </tui-input-number>
-        <tui-input-number
-            formControlName="testValue"
-            class="tui-col_md-4"
-            [postfix]="'EUR' | tuiCurrency"
-        >
-            Type a sum
-        </tui-input-number>
-        <tui-input-number
-            formControlName="testValue"
-            class="tui-col_md-4"
-            [postfix]="'840' | tuiCurrency"
-        >
-            Type a sum
-        </tui-input-number>
-    </div>
-    <div class="tui-row tui-space_top-2">
-        <tui-input-number
-            formControlName="testValue"
-            class="tui-col_md-4"
-            [postfix]="826 | tuiCurrency"
-        >
-            Type a sum
-        </tui-input-number>
-        <tui-input-number
-            formControlName="testValue"
-            class="tui-col_md-4"
-            [postfix]="null | tuiCurrency"
-        >
-            Type a sum
-        </tui-input-number>
-    </div>
-</form>
+<tui-input-number
+    tuiHintContent="Dollar sign is commonly placed BEFORE the amount. Use [prefix]."
+    [formControl]="control"
+    [prefix]="'USD' | tuiCurrency"
+>
+    Type a sum
+</tui-input-number>
+
+<tui-input-number
+    tuiHintContent="Euro sign (numeric code 978) is commonly placed AFTER the amount. Use [postfix]."
+    [formControl]="control"
+    [postfix]="'978' | tuiCurrency"
+>
+    Type a sum
+</tui-input-number>
+
+<tui-input-number
+    tuiHintContent="Pound sign (numeric code 826) is commonly placed BEFORE the amount. Use [prefix]."
+    [formControl]="control"
+    [prefix]="826 | tuiCurrency"
+>
+    Type a sum
+</tui-input-number>

--- a/projects/demo/src/modules/components/input-number/examples/1/index.less
+++ b/projects/demo/src/modules/components/input-number/examples/1/index.less
@@ -1,0 +1,7 @@
+tui-input-number {
+    max-width: 20rem;
+
+    &:not(:last-child) {
+        margin-bottom: 1rem;
+    }
+}

--- a/projects/demo/src/modules/components/input-number/examples/1/index.ts
+++ b/projects/demo/src/modules/components/input-number/examples/1/index.ts
@@ -1,16 +1,15 @@
 import {Component} from '@angular/core';
-import {FormControl, FormGroup} from '@angular/forms';
+import {FormControl} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 
 @Component({
     selector: 'tui-input-number-example-1',
     templateUrl: './index.html',
+    styleUrls: ['./index.less'],
     changeDetection,
     encapsulation,
 })
 export class TuiInputNumberExample1 {
-    readonly testForm = new FormGroup({
-        testValue: new FormControl(),
-    });
+    readonly control = new FormControl(100);
 }

--- a/projects/demo/src/modules/components/input-number/input-number.component.ts
+++ b/projects/demo/src/modules/components/input-number/input-number.component.ts
@@ -25,8 +25,9 @@ export class ExampleTuiInputNumberComponent extends AbstractExampleTuiControl {
     readonly exampleHtml = import('!!raw-loader!./examples/import/insert-template.txt');
 
     readonly example1: TuiDocExample = {
-        TypeScript: import('!!raw-loader!./examples/1/index.ts'),
         HTML: import('!!raw-loader!./examples/1/index.html'),
+        TypeScript: import('!!raw-loader!./examples/1/index.ts'),
+        LESS: import('!!raw-loader!./examples/1/index.less'),
     };
 
     readonly example2: TuiDocExample = {

--- a/projects/demo/src/modules/components/input-number/input-number.module.ts
+++ b/projects/demo/src/modules/components/input-number/input-number.module.ts
@@ -7,6 +7,7 @@ import {generateRoutes, TuiAddonDocModule} from '@taiga-ui/addon-doc';
 import {
     TuiButtonModule,
     TuiHintControllerModule,
+    TuiHintModule,
     TuiLinkModule,
     TuiNotificationModule,
     TuiSvgModule,
@@ -37,6 +38,7 @@ import {ExampleTuiInputNumberComponent} from './input-number.component';
         TuiNotificationModule,
         TuiAddonDocModule,
         InheritedDocumentationModule,
+        TuiHintModule,
         RouterModule.forChild(generateRoutes(ExampleTuiInputNumberComponent)),
     ],
     declarations: [

--- a/projects/demo/src/modules/components/input-number/input-number.template.html
+++ b/projects/demo/src/modules/components/input-number/input-number.template.html
@@ -11,37 +11,50 @@
             A component to input numbers. Control value is also of number type.
         </div>
 
-        <p i18n>
-            Component can be used to input money if you choose a currency symbol
-            as a postfix or prefix (see
-            <code>Currency</code>
-            pipe samples).
-        </p>
-
-        <p i18n>
-            There are also other components to input numbers:
-            <a
-                tuiLink
-                routerLink="/components/input-count"
-            >
-                <code>InputCount</code>
-            </a>
-            for integers,
-            <a
-                tuiLink
-                routerLink="/components/slider"
-            >
-                <code>Slider</code>
-            </a>
-            and
-            <a
-                tuiLink
-                routerLink="/components/input-slider"
-            >
-                <code>InputSlider</code>
-            </a>
-            for inputting with a slider
-        </p>
+        <section i18n>
+            <h3>There are also other components to input numbers:</h3>
+            <ul class="tui-list tui-list_small">
+                <li class="tui-list__item">
+                    <a
+                        tuiLink
+                        routerLink="/components/input-count"
+                    >
+                        <strong>InputCount</strong>
+                    </a>
+                    (integers only)
+                </li>
+                <li class="tui-list__item">
+                    <a
+                        tuiLink
+                        routerLink="/components/slider"
+                    >
+                        <strong>Slider</strong>
+                    </a>
+                </li>
+                <li class="tui-list__item">
+                    <a
+                        tuiLink
+                        routerLink="/components/input-slider"
+                    >
+                        <strong>InputSlider</strong>
+                    </a>
+                    (it uses
+                    <code>InputNumber</code>
+                    inside)
+                </li>
+                <li class="tui-list__item">
+                    <a
+                        tuiLink
+                        routerLink="/components/input-range"
+                    >
+                        <strong>InputRange</strong>
+                    </a>
+                    (it uses
+                    <code>InputNumber</code>
+                    inside)
+                </li>
+            </ul>
+        </section>
 
         <p i18n>
             Number formatting can be customized with
@@ -60,7 +73,24 @@
             i18n-heading
             heading="Currency"
             [content]="example1"
+            [description]="currencyPipeDescription"
         >
+            <ng-template #currencyPipeDescription>
+                <p i18n>
+                    To input money use properties
+                    <code>[postfix]</code>
+                    or
+                    <code>[prefix]</code>
+                    . To get currency symbol use pipe
+                    <a
+                        tuiLink
+                        routerLink="/pipes/currency"
+                    >
+                        tuiCurrency
+                    </a>
+                    .
+                </p>
+            </ng-template>
             <tui-input-number-example-1></tui-input-number-example-1>
         </tui-doc-example>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
![](https://user-images.githubusercontent.com/35179038/171842625-8063ece7-00aa-4b75-a2ee-c4055bd8d400.png)

**Possible reproduction:**
If any textfield-component projected via `<ng-content />` (and this content projection is attached by some async logic), these lines
https://github.com/Tinkoff/taiga-ui/blob/3c7c53b6a707718c9d4441f447991dd79b4f4bba/projects/core/components/primitive-textfield/value-decoration/value-decoration.component.ts#L34-L38
calculates `offsetWidth` as zero (because the component was initialized but it is not attached to the DOM yet). 

Closes #1862

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
