### PR TITLE
ci: support `new-for-builtins`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,7 @@ module.exports = {
         'unicorn/no-array-push-push': 'error',
         'unicorn/require-number-to-fixed-digits-argument': 'error',
         'unicorn/no-empty-file': 'error',
+        'unicorn/new-for-builtins': 'error',
         'unicorn/filename-case': [
             'error',
             {

--- a/projects/demo/src/modules/charts/legend-item/examples/2/index.ts
+++ b/projects/demo/src/modules/charts/legend-item/examples/2/index.ts
@@ -12,7 +12,7 @@ import {formatNumber, TuiAlertService} from '@taiga-ui/core';
     encapsulation,
 })
 export class TuiLegendItemExample2 {
-    private enabled = Array(5).fill(true);
+    private enabled = new Array(5).fill(true);
 
     readonly data = [13769, 12367, 10172, 3018, 2592];
     readonly sum = sum(...this.data);

--- a/projects/kit/utils/mask/create-date-mask.ts
+++ b/projects/kit/utils/mask/create-date-mask.ts
@@ -1,8 +1,8 @@
 import {tuiAssert, TuiDateMode} from '@taiga-ui/cdk';
 import {TUI_DIGIT_REGEXP, TuiTextMaskList} from '@taiga-ui/core';
 
-const TWO_DIGITS = Array(2).fill(TUI_DIGIT_REGEXP);
-const FOUR_DIGITS = Array(4).fill(TUI_DIGIT_REGEXP);
+const TWO_DIGITS = new Array(2).fill(TUI_DIGIT_REGEXP);
+const FOUR_DIGITS = new Array(4).fill(TUI_DIGIT_REGEXP);
 
 export function tuiCreateDateMask(mode: TuiDateMode, separator: string): TuiTextMaskList {
     tuiAssert.assert(separator.length === 1, 'Separator should consist of only 1 symbol');

--- a/projects/kit/utils/mask/create-time-mask.ts
+++ b/projects/kit/utils/mask/create-time-mask.ts
@@ -8,7 +8,7 @@ function tuiCreateTimePartMask(
     prefix?: string,
 ): Array<string | RegExp> {
     const {length} = String(maxPartValue);
-    const regExp = Array(length).fill(TUI_DIGIT_REGEXP);
+    const regExp = new Array(length).fill(TUI_DIGIT_REGEXP);
 
     if (prefix) {
         regExp.unshift(prefix);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [x] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?

They work the same, but new should be preferred for consistency with other constructors.
This rule is fixable, except new String(), new Number(), and new Boolean(), [they return wrapped object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#String_primitives_and_String_objects).
