### PR TITLE
ci: support `no-array-method-this-argument`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
         'unicorn/new-for-builtins': 'error',
         'unicorn/no-useless-spread': 'error',
         'unicorn/escape-case': 'error',
+        'unicorn/no-array-method-this-argument': 'error',
         'unicorn/filename-case': [
             'error',
             {

--- a/projects/demo/src/modules/components/input-tag/examples/4/index.ts
+++ b/projects/demo/src/modules/components/input-tag/examples/4/index.ts
@@ -42,11 +42,11 @@ export class TuiInputTagExample4 {
     readonly control = new FormControl([], createControlValidator(tagValidator));
 
     get filtered(): readonly string[] {
-        return this.filter(this.search, this.control.value);
+        return this.filterBy(this.search, this.control.value);
     }
 
     @tuiPure
-    private filter(search: string, value: readonly string[]): readonly string[] {
+    private filterBy(search: string, value: readonly string[]): readonly string[] {
         return ITEMS.filter(
             item => TUI_DEFAULT_MATCHER(item, search) && !value.includes(item),
         );


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [x] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?

Disallow using the this argument in array methods
✅ This rule is part of the [recommended](https://github.com/sindresorhus/eslint-plugin-unicorn#recommended-config) config.

🔧💡 This rule is [auto-fixable](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) and provides [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).

The rule disallows using the thisArg argument in array methods:

If the callback is an arrow function or a bound function, the thisArg won't affect it.
If you intent to use a custom this in the callback, it's better to use the variable directly or use callback.bind(thisArg).
This rule checks following array methods accepts thisArg:

[Array#every()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Array/every)
[Array#filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Array/filter)
[Array#find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Array/find)
[Array#findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Array/findIndex)
[Array#flatMap()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Array/flatMap)
[Array#forEach()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Array/forEach)
[Array#map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Array/map)
[Array#some()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Array/some)
This rule is fixable when the callback is an arrow function and the thisArg argument has no side effect.
