### PR TITLE
fix: problem with invalid rxjs-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40218,13 +40218,15 @@
             "version": "2.49.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@angular-devkit/schematics": "^9.1.12",
                 "@ng-web-apis/common": "^1.12.1",
                 "@ng-web-apis/mutation-observer": "^1.1.0",
                 "@ng-web-apis/resize-observer": "^1.0.3",
                 "@tinkoff/ng-event-plugins": "^2.5.1",
                 "@tinkoff/ng-polymorpheus": "^3.1.12",
-                "@types/resize-observer-browser": "^0.1.7",
+                "@types/resize-observer-browser": "^0.1.7"
+            },
+            "devDependencies": {
+                "@angular-devkit/schematics": "^9.1.12",
                 "ng-morph": "^2.0.0",
                 "parse5": "^6.0.1"
             },

--- a/projects/cdk/package.json
+++ b/projects/cdk/package.json
@@ -15,13 +15,15 @@
     "repository": "https://github.com/tinkoff/taiga-ui",
     "license": "Apache-2.0",
     "dependencies": {
-        "@angular-devkit/schematics": "^9.1.12",
         "@ng-web-apis/common": "^1.12.1",
         "@ng-web-apis/mutation-observer": "^1.1.0",
         "@ng-web-apis/resize-observer": "^1.0.3",
         "@tinkoff/ng-event-plugins": "^2.5.1",
         "@tinkoff/ng-polymorpheus": "^3.1.12",
-        "@types/resize-observer-browser": "^0.1.7",
+        "@types/resize-observer-browser": "^0.1.7"
+    },
+    "devDependencies": {
+        "@angular-devkit/schematics": "^9.1.12",
         "ng-morph": "^2.0.0",
         "parse5": "^6.0.1"
     },


### PR DESCRIPTION
# WARNING!
It just the temporary solution to fix the bug with rxjs-types:
![rxjsBug](https://user-images.githubusercontent.com/35179038/174039683-f195b089-f956-4a4a-bedf-9d5c1b8b7a66.jpg)

We should investigate this problem and try to find better solution!
This solution fixes `cdk` package but breaks schematics (see [PR](https://github.com/Tinkoff/taiga-ui/pull/1880)):

<img width="570" alt="schematicsProblem" src="https://user-images.githubusercontent.com/35179038/174039783-ef28eb89-ed9b-4fe3-b5e2-f1a690b2336c.png">

