### PR TITLE
chore: fix stackblitz `NG0203`-error (maybe not)

### DIFF
--- a/projects/cdk/directives/auto-focus/autofocus.options.ts
+++ b/projects/cdk/directives/auto-focus/autofocus.options.ts
@@ -1,6 +1,5 @@
 import {
     ElementRef,
-    inject,
     InjectionToken,
     NgZone,
     Optional,
@@ -31,8 +30,9 @@ export function tuiAutofocusHandlerFactory(
     renderer: Renderer2,
     ngZone: NgZone,
     windowRef: Window,
+    isIos: boolean,
 ): TuiAutofocusHandler {
-    return inject(TUI_IS_IOS)
+    return isIos
         ? new TuiIosAutofocusHandler(
               tuiFocusableComponent,
               elementRef,
@@ -59,6 +59,7 @@ export const TUI_AUTOFOCUS_PROVIDERS = [
             Renderer2,
             NgZone,
             WINDOW,
+            TUI_IS_IOS,
         ],
     },
 ];


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
All stackblitz examples do not work.
![hasError](https://user-images.githubusercontent.com/35179038/174309028-d08fa59c-c4fb-4e22-bbb1-a76b90e82985.png)

Error description: https://angular.io/errors/NG0203

The problem appeared in 2.48. Maybe because of this https://github.com/Tinkoff/taiga-ui/pull/1813 (or maybe not; let's check 😄 ).
In 2.47.0 everything works fine.

![no-error](https://user-images.githubusercontent.com/35179038/174309175-6a7a48c7-7d25-4123-9daf-fbadf88e2fa4.png)


## What is the new behavior?
After new release it can be fixed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
