### PR TITLE
feat(kit): add document:keydown.esc listener to close a pdf viewer

### DIFF
--- a/projects/kit/components/pdf-viewer/pdf-viewer.component.ts
+++ b/projects/kit/components/pdf-viewer/pdf-viewer.component.ts
@@ -1,5 +1,11 @@
 import {AnimationOptions} from '@angular/animations';
-import {ChangeDetectionStrategy, Component, HostBinding, Inject} from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    HostBinding,
+    HostListener,
+    Inject,
+} from '@angular/core';
 import {TuiDialog} from '@taiga-ui/cdk';
 import {
     TUI_ANIMATION_OPTIONS,
@@ -30,4 +36,9 @@ export class TuiPdfViewerComponent<I, O> {
         @Inject(POLYMORPHEUS_CONTEXT)
         readonly context: TuiDialog<TuiPdfViewerOptions<I>, O>,
     ) {}
+
+    @HostListener('document:keydown.esc')
+    onKeyDownEsc(): void {
+        this.context.$implicit.complete();
+    }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #1700

## What is the new behavior?

It's possible to close a PdfViewer component on esc key.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
