### PR TITLE
fix(kit): `InputSlider` incorrect vertical alignment of slider

### DIFF
--- a/projects/demo/src/modules/components/input-slider/examples/5/index.html
+++ b/projects/demo/src/modules/components/input-slider/examples/5/index.html
@@ -1,5 +1,23 @@
+<section class="control">
+    <tui-input-slider
+        new
+        tuiTextfieldSize="m"
+        [min]="min"
+        [max]="max"
+        [segments]="2"
+        [valueContent]="customLabel"
+        [formControl]="controlWithMinLabel"
+    ></tui-input-slider>
+
+    <div class="slider-ticks-labels">
+        <span></span>
+        <span>Other custom label</span>
+        <span></span>
+    </div>
+</section>
+
 <tui-input-slider
-    class="control tui-space_bottom-7"
+    class="control"
     [min]="min"
     [max]="max"
     [valueContent]="customLabel"
@@ -7,13 +25,3 @@
 >
     How much do you love Taiga UI?
 </tui-input-slider>
-
-<tui-input-slider
-    new
-    tuiTextfieldSize="m"
-    class="control"
-    [min]="min"
-    [max]="max"
-    [valueContent]="customLabel"
-    [formControl]="controlWithMinLabel"
-></tui-input-slider>

--- a/projects/demo/src/modules/components/input-slider/examples/5/index.less
+++ b/projects/demo/src/modules/components/input-slider/examples/5/index.less
@@ -1,9 +1,18 @@
 @import 'taiga-ui-local';
 
-.control {
-    width: 50%;
+:host {
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 3rem;
+    row-gap: 1rem;
+}
 
-    @media @mobile {
-        width: 100%;
-    }
+.control {
+    flex: 1;
+    min-width: 17rem;
+}
+
+.slider-ticks-labels {
+    .tui-slider-ticks-labels();
+    margin-top: 0.25rem;
 }

--- a/projects/demo/src/modules/components/input-slider/input-slider.template.html
+++ b/projects/demo/src/modules/components/input-slider/input-slider.template.html
@@ -114,7 +114,22 @@
             i18n-heading
             heading="With min and max labels"
             [content]="example5"
+            [description]="valueContentDescription"
         >
+            <ng-template #valueContentDescription>
+                <p>
+                    Pass
+                    <a
+                        tuiLink
+                        href="https://github.com/tinkoff/ng-polymorpheus"
+                    >
+                        PolymorpheusContent
+                    </a>
+                    into property
+                    <code>[valueContent]</code>
+                    to create custom label for selected value.
+                </p>
+            </ng-template>
             <tui-input-slider-example-5></tui-input-slider-example-5>
         </tui-doc-example>
     </ng-template>

--- a/projects/kit/components/input-slider/input-slider.style.less
+++ b/projects/kit/components/input-slider/input-slider.style.less
@@ -3,6 +3,7 @@
 :host {
     .createStackingContext();
     display: block;
+    height: max-content;
 
     &._segmented._show-ticks-labels {
         // TODO: remove in v3.0


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
The bug happens when users use `display: flex` and do not set `align-items`-property (it uses `normal` as default).
```html
<div style="display: flex; ...">
    <tui-input-slider .../>
    <span />
</div>
```
![](https://user-images.githubusercontent.com/35179038/174315173-3acd8a92-99f1-4920-8d11-29985427c649.png)

The user, of course, can set `align-items` to any other value to fix this bug.
But now it is not compulsory.

`height: max-content` does work on ancient browsers. [See here](https://caniuse.com/mdn-css_properties_height_max-content).
But this fix is just to be on the safe side (user can set `align-items`), that is why we neglect ancient browsers.

Closes #1947

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
