### PR TITLE
feat(addon-doc): new token `TUI_DOC_PAGE_LOADED` to fix anchor links (scroll to examples)

### DIFF
--- a/projects/addon-doc/src/components/navigation/navigation.component.ts
+++ b/projects/addon-doc/src/components/navigation/navigation.component.ts
@@ -10,13 +10,14 @@ import {
 import {Title} from '@angular/platform-browser';
 import {ActivatedRoute, Router} from '@angular/router';
 import {TuiSidebarDirective} from '@taiga-ui/addon-mobile';
-import {tuiPure, uniqBy} from '@taiga-ui/cdk';
+import {TuiDestroyService, tuiPure, uniqBy} from '@taiga-ui/cdk';
 import {TuiBrightness, TuiModeDirective} from '@taiga-ui/core';
 import {Observable} from 'rxjs';
-import {map, startWith} from 'rxjs/operators';
+import {filter, map, startWith, take, takeUntil} from 'rxjs/operators';
 
 import {TuiDocPage} from '../../interfaces/page';
 import {TUI_DOC_SEARCH_TEXT} from '../../tokens/i18n';
+import {TUI_DOC_PAGE_LOADED} from '../../tokens/page-loaded';
 import {TuiDocPages} from '../../types/pages';
 import {transliterateKeyboardLayout} from '../../utils/transliterate-keyboard-layout';
 import {
@@ -25,8 +26,6 @@ import {
     NAVIGATION_PROVIDERS,
     NAVIGATION_TITLE,
 } from './navigation.providers';
-
-const SCROLL_INTO_VIEW_DELAY = 200;
 
 // @dynamic
 @Component({
@@ -67,6 +66,9 @@ export class TuiDocNavigationComponent {
         @Inject(TUI_DOC_SEARCH_TEXT) readonly searchText: string,
         @Inject(Router) private readonly router: Router,
         @Inject(ActivatedRoute) private readonly activatedRoute: ActivatedRoute,
+        @Inject(TuiDestroyService) private readonly destroy$: Observable<void>,
+        @Inject(TUI_DOC_PAGE_LOADED)
+        private readonly readyToScroll$: Observable<boolean>,
     ) {
         // Angular can't navigate no anchor links
         // https://stackoverflow.com/questions/36101756/angular2-routing-with-hashtag-to-page-anchor
@@ -163,9 +165,11 @@ export class TuiDocNavigationComponent {
     }
 
     private handleAnchorLink(hash: string): void {
-        setTimeout(() => {
-            this.navigateToAnchorLink(hash);
-        }, SCROLL_INTO_VIEW_DELAY);
+        this.readyToScroll$
+            .pipe(filter(Boolean), take(1), takeUntil(this.destroy$))
+            .subscribe(() => {
+                this.navigateToAnchorLink(hash);
+            });
     }
 
     private openActivePageGroup(): void {

--- a/projects/addon-doc/src/components/navigation/navigation.component.ts
+++ b/projects/addon-doc/src/components/navigation/navigation.component.ts
@@ -167,9 +167,7 @@ export class TuiDocNavigationComponent {
     private handleAnchorLink(hash: string): void {
         this.readyToScroll$
             .pipe(filter(Boolean), take(1), takeUntil(this.destroy$))
-            .subscribe(() => {
-                this.navigateToAnchorLink(hash);
-            });
+            .subscribe(() => this.navigateToAnchorLink(hash));
     }
 
     private openActivePageGroup(): void {

--- a/projects/addon-doc/src/public-api.ts
+++ b/projects/addon-doc/src/public-api.ts
@@ -42,6 +42,7 @@ export * from './tokens/default-tabs';
 export * from './tokens/example-content-processor';
 export * from './tokens/i18n';
 export * from './tokens/logo';
+export * from './tokens/page-loaded';
 export * from './tokens/pages';
 export * from './tokens/see-also';
 export * from './tokens/source-code';

--- a/projects/addon-doc/src/tokens/page-loaded.ts
+++ b/projects/addon-doc/src/tokens/page-loaded.ts
@@ -3,6 +3,6 @@ import {defer, Observable, of, timer} from 'rxjs';
 import {switchMapTo} from 'rxjs/operators';
 
 export const TUI_DOC_PAGE_LOADED = new InjectionToken<Observable<boolean>>(
-    'Stream that emits if loading of page is over (for example, to begin scrollIntoView)',
+    '[TUI_DOC_PAGE_LOADED] Stream that emits if loading of page is over (for example, to begin scrollIntoView)',
     {factory: () => defer(() => timer(200).pipe(switchMapTo(of(true))))},
 );

--- a/projects/addon-doc/src/tokens/page-loaded.ts
+++ b/projects/addon-doc/src/tokens/page-loaded.ts
@@ -1,0 +1,8 @@
+import {InjectionToken} from '@angular/core';
+import {defer, Observable, of, timer} from 'rxjs';
+import {switchMapTo} from 'rxjs/operators';
+
+export const TUI_DOC_PAGE_LOADED = new InjectionToken<Observable<boolean>>(
+    'Stream that emits if loading of page is over (for example, to begin scrollIntoView)',
+    {factory: () => defer(() => timer(200).pipe(switchMapTo(of(true))))},
+);

--- a/projects/demo-integrations/cypress/tests/addon-doc/navigation.spec.ts
+++ b/projects/demo-integrations/cypress/tests/addon-doc/navigation.spec.ts
@@ -20,4 +20,15 @@ describe('Navigation', () => {
             .wait(DEFAULT_TIMEOUT_BEFORE_ACTION)
             .matchImageSnapshot('02-tui-doc-navigation-night-mode');
     });
+
+    it(
+        'anchor links navigation works (scroll to example)',
+        {scrollBehavior: false},
+        () => {
+            cy.tuiVisit('/components/input#table');
+
+            cy.wait(2000) // wait shake animation + scroll
+                .matchImageSnapshot('anchor-link-navigation', {capture: 'viewport'});
+        },
+    );
 });

--- a/projects/demo/src/modules/app/app.component.ts
+++ b/projects/demo/src/modules/app/app.component.ts
@@ -1,5 +1,6 @@
 import {
     Component,
+    ElementRef,
     Inject,
     InjectFlags,
     Injector,
@@ -9,18 +10,21 @@ import {
 import {NavigationEnd, Router} from '@angular/router';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {LOCAL_STORAGE} from '@ng-web-apis/common';
+import {TUI_DOC_PAGE_LOADED} from '@taiga-ui/addon-doc';
 import {
     TUI_IS_ANDROID,
     TUI_IS_CYPRESS,
     TUI_IS_IOS,
     TuiDestroyService,
     tuiPure,
+    TuiResizeService,
 } from '@taiga-ui/cdk';
 import {Metrika} from 'ng-yandex-metrika';
 import {Observable} from 'rxjs';
 import {distinctUntilChanged, filter, map, takeUntil} from 'rxjs/operators';
 
 import {environment} from '../../environments/environment';
+import {readyToScrollFactory} from './utils/ready-to-scroll-factory';
 
 // @dynamic
 @Component({
@@ -29,7 +33,15 @@ import {environment} from '../../environments/environment';
     styleUrls: ['./app.style.less'],
     host: {'[class._is-cypress-mode]': 'isCypress'},
     encapsulation: ViewEncapsulation.None,
-    providers: [TuiDestroyService],
+    providers: [
+        TuiDestroyService,
+        TuiResizeService,
+        {
+            provide: TUI_DOC_PAGE_LOADED,
+            deps: [ElementRef, TuiResizeService],
+            useFactory: readyToScrollFactory,
+        },
+    ],
     changeDetection,
 })
 export class AppComponent implements OnInit {

--- a/projects/demo/src/modules/app/utils/ready-to-scroll-factory.ts
+++ b/projects/demo/src/modules/app/utils/ready-to-scroll-factory.ts
@@ -1,0 +1,18 @@
+import {ElementRef} from '@angular/core';
+import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+export function readyToScrollFactory(
+    hostElement: ElementRef<HTMLElement>,
+    resize$: Observable<unknown>,
+): Observable<boolean> {
+    return resize$.pipe(
+        map(() => {
+            const exampleElements = Array.from(
+                hostElement.nativeElement.querySelectorAll('tui-doc-example'),
+            );
+
+            return exampleElements.every(el => el.querySelector('.t-example'));
+        }),
+    );
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [X] Documentation content changes

## What is the current behavior?
* Try go to https://taiga-ui.dev/components/input#table
* It should scroll to example "Table" 
* **But**:

https://user-images.githubusercontent.com/35179038/176679073-aa4593f1-a902-4bc7-a202-c00dd7e49f4c.mov

## What is the new behavior?

https://user-images.githubusercontent.com/35179038/176679218-3d12725c-b9a7-4cf8-b53c-478c615ef4ad.mov

**You can try by yourself:**
https://taiga-ui--pr2031-fix-scroll-to-exampl-50r2a996.web.app/components/input#table


**Screenshot diff:**
<img height=300 src="https://user-images.githubusercontent.com/35179038/176691002-cdb8773f-cda8-4673-8dc7-30879754a347.png" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
