### PR TITLE
chore(demo-integrations): page should be loaded before scroll+screenshot

### DIFF
--- a/projects/demo-integrations/cypress/support/visit.ts
+++ b/projects/demo-integrations/cypress/support/visit.ts
@@ -112,6 +112,8 @@ export function tuiVisit(path: string, options: TuiVisitOptions = {}): void {
 
     cy.wait(DEFAULT_TIMEOUT_AFTER_PAGE_REDIRECTION);
 
+    // cy.get('app._loaded').should('exist'); // uncomment when next-app will have this class
+
     if (hideHeader) {
         cy.tuiHideHeader();
     }

--- a/projects/demo-integrations/cypress/tests/addon-icons/customization-icons.spec.ts
+++ b/projects/demo-integrations/cypress/tests/addon-icons/customization-icons.spec.ts
@@ -1,10 +1,11 @@
-import {DEFAULT_TIMEOUT_BEFORE_ACTION} from '../../support/shared.entities';
+import {DEFAULT_TIMEOUT_BEFORE_ACTION, EXAMPLE_ID} from '../../support/shared.entities';
 
 describe('Icons', () => {
     it('display icons that are easily customizable', () => {
         cy.tuiVisit('icons/SVG_Processing');
 
-        cy.get('tui-doc-page')
+        cy.get('#base')
+            .findByAutomationId(EXAMPLE_ID)
             .wait(DEFAULT_TIMEOUT_BEFORE_ACTION)
             .matchImageSnapshot('customize-icons8');
     });

--- a/projects/demo/src/modules/app/app.component.ts
+++ b/projects/demo/src/modules/app/app.component.ts
@@ -31,7 +31,11 @@ import {readyToScrollFactory} from './utils/ready-to-scroll-factory';
     selector: 'app',
     templateUrl: './app.template.html',
     styleUrls: ['./app.style.less'],
-    host: {'[class._is-cypress-mode]': 'isCypress'},
+    host: {
+        '[class._is-cypress-mode]': 'isCypress',
+        '[$.class._loaded]': 'pageLoaded$',
+        '($.class._loaded)': '0',
+    },
     encapsulation: ViewEncapsulation.None,
     providers: [
         TuiDestroyService,
@@ -58,6 +62,7 @@ export class AppComponent implements OnInit {
         @Inject(TUI_IS_CYPRESS) readonly isCypress: boolean,
         @Inject(TuiDestroyService) private readonly destroy$: Observable<void>,
         private readonly injector: Injector,
+        @Inject(TUI_DOC_PAGE_LOADED) readonly pageLoaded$: Observable<boolean>,
     ) {}
 
     async ngOnInit(): Promise<void> {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Sometimes page can be scrolled before all page's content is ready.
It can produce this flaky screenshots:
<img height="300" src="https://user-images.githubusercontent.com/35179038/178730710-25096eda-d7b6-4d39-b07d-8ec73bd2ac02.png" />

____

Also, fix the following flaky test:
<img height="300" src="https://user-images.githubusercontent.com/35179038/178732035-2c35fa0b-1a9b-455e-967e-0244a52e0fe1.png" />
⏬ 
![customize-icons8 snap](https://user-images.githubusercontent.com/35179038/178732283-4097c0fd-fb00-483e-a06e-4a245eb072e0.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
