### PR TITLE
docs(kit): rename documentation property name `onReject` to `reject` for InputFiles

### DIFF
--- a/projects/demo/src/modules/components/input-files/input-files.template.html
+++ b/projects/demo/src/modules/components/input-files/input-files.template.html
@@ -168,7 +168,7 @@
             </ng-template>
             <ng-template
                 i18n
-                documentationPropertyName="onReject"
+                documentationPropertyName="reject"
                 documentationPropertyMode="output"
                 documentationPropertyType="TuiFileLike"
             >


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [x] Documentation content changes

## What is the current behavior?

Output is `reject` while in the documentation it's `onReject`.

![image](https://user-images.githubusercontent.com/22116465/180272651-a0e3286d-8d2d-4381-870d-19cb80847b62.png)
![image](https://user-images.githubusercontent.com/22116465/180273058-70af7f0c-f22b-481e-995e-ceae60acbdba.png)

## What is the new behavior?

Rename `onReject` to `reject`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
