### PR TITLE
chore: fix flaky cypress test

### DIFF
--- a/projects/demo-integrations/cypress/support/wait-code-highlight.ts
+++ b/projects/demo-integrations/cypress/support/wait-code-highlight.ts
@@ -1,3 +1,9 @@
+import {DEFAULT_TIMEOUT_BEFORE_ACTION} from './shared.entities';
+
 export function tuiWaitCodeHighlight(selector = 'code'): void {
-    cy.get(selector).should('has.class', 'hljs');
+    cy.get(selector)
+        .should('has.class', 'hljs')
+        .find('.hljs-ln-numbers')
+        .should('exist')
+        .wait(DEFAULT_TIMEOUT_BEFORE_ACTION);
 }


### PR DESCRIPTION
Successful runs of `E2E tests / addon-doc` - job:

- [x] 1
- [x] 2
- [x] 3
- [x] 4
- [x] 5
