### PR TITLE
fix(kit): `InputSlider` props `[prefix]`/`[postfix]` + `[valueContent]` overlaps each other on blur

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/input-slider/input-slider.spec.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-slider/input-slider.spec.ts
@@ -1,19 +1,20 @@
-import {INPUT_SLIDER_PAGE_URL} from '../../../support/shared.entities';
+import {
+    DEFAULT_TIMEOUT_BEFORE_ACTION,
+    EXAMPLE_ID,
+    INPUT_SLIDER_PAGE_URL,
+} from '../../../support/shared.entities';
 
 describe(`InputSlider`, () => {
     describe(`examples page`, () => {
         beforeEach(() => {
-            cy.viewport(`macbook-13`);
+            cy.viewport(`iphone-x`);
             cy.tuiVisit(`${INPUT_SLIDER_PAGE_URL}`);
         });
 
         it(`typing new value inside text input also change slider position`, () => {
             const exampleId = `#base`;
 
-            cy.get(`${exampleId} input[type="range"]`).should(`be.visible`).as(`slider`);
-            cy.get(`${exampleId} tui-input-slider tui-input-number input`)
-                .should(`be.visible`)
-                .as(`textInput`);
+            initializeAliases(`${exampleId} tui-input-slider`);
 
             const valueToSliderStep = [
                 {value: 5, step: 0},
@@ -26,17 +27,16 @@ describe(`InputSlider`, () => {
             for (const {value, step} of valueToSliderStep) {
                 cy.get(`@textInput`).clear().type(`${value}`);
                 cy.get(`@slider`).should(`have.value`, step);
-                cy.get(exampleId).matchImageSnapshot(`1-slider-check-${value}-${step}`);
+                cy.get(exampleId)
+                    .findByAutomationId(EXAMPLE_ID)
+                    .matchImageSnapshot(`1-slider-check-${value}-${step}`);
             }
         });
 
         it(`pressing ArrowUp/ArrowDown change textInput value and slider position`, () => {
             const exampleId = `#right-label`;
 
-            cy.get(`${exampleId} input[type="range"]`).should(`be.visible`).as(`slider`);
-            cy.get(`${exampleId} tui-input-slider tui-input-number input`)
-                .should(`be.visible`)
-                .as(`textInput`);
+            initializeAliases(`${exampleId} tui-input-slider`);
 
             cy.get(`@textInput`).clear().type(`0`);
 
@@ -45,7 +45,9 @@ describe(`InputSlider`, () => {
                 cy.get(`@textInput`).should(`have.value`, i);
                 cy.get(`@slider`).should(`have.value`, i);
 
-                cy.get(exampleId).matchImageSnapshot(`2-arrow-up-checks-${i}`);
+                cy.get(exampleId)
+                    .findByAutomationId(EXAMPLE_ID)
+                    .matchImageSnapshot(`2-0-arrow-up-checks-${i}`);
             }
 
             for (let i = 9; i >= 0; i--) {
@@ -53,8 +55,47 @@ describe(`InputSlider`, () => {
                 cy.get(`@textInput`).should(`have.value`, i);
                 cy.get(`@slider`).should(`have.value`, i);
 
-                cy.get(exampleId).matchImageSnapshot(`2-arrow-down-checks-${i}`);
+                cy.get(exampleId)
+                    .findByAutomationId(EXAMPLE_ID)
+                    .matchImageSnapshot(`2-1-arrow-down-checks-${i}`);
             }
         });
     });
+
+    describe(`[valueContent] prop`, () => {
+        beforeEach(() => {
+            cy.viewport(`iphone-x`);
+        });
+
+        it(`hide [valueContent] when input is focused`, () => {
+            cy.tuiVisit(
+                `${INPUT_SLIDER_PAGE_URL}/API?valueContent=TOP-SECRET&postfix=things&prefix=$`,
+            );
+
+            initializeAliases(`#demoContent tui-input-slider`);
+
+            cy.get(`@textInput`).focus().wait(DEFAULT_TIMEOUT_BEFORE_ACTION);
+
+            cy.get(`#demoContent`).matchImageSnapshot(`3-value-content-hide-on-focus`);
+        });
+
+        it(`[valueContent] is not overlapped by [prefix]/[postfix] (input is NOT focused)`, () => {
+            cy.tuiVisit(
+                `${INPUT_SLIDER_PAGE_URL}/API?valueContent=TOP-SECRET&postfix=things&prefix=$`,
+            );
+
+            cy.get(`#demoContent`)
+                .should(`be.visible`)
+                .matchImageSnapshot(`4-value-content-not-overlapped`);
+        });
+    });
 });
+
+function initializeAliases(inputSliderSelector: string): void {
+    cy.get(`${inputSliderSelector} input[type="range"]`)
+        .should(`be.visible`)
+        .as(`slider`);
+    cy.get(`${inputSliderSelector} tui-input-number input`)
+        .should(`exist`)
+        .as(`textInput`);
+}

--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -177,6 +177,10 @@ export class TuiInputSliderComponent
         return this.precision ? `not-zero` : `never`;
     }
 
+    get showValueContent(): boolean {
+        return Boolean(this.computedValueContent && !this.focused);
+    }
+
     /**
      * TODO remove old property `size` in v3.0
      */

--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -1,3 +1,4 @@
+import {I18nPluralPipe} from '@angular/common';
 import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
@@ -69,6 +70,7 @@ export class TuiNewInputSliderDirective {}
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
+        I18nPluralPipe,
         {
             provide: TUI_FOCUSABLE_ITEM_ACCESSOR,
             useExisting: forwardRef(() => TuiInputSliderComponent),
@@ -148,6 +150,7 @@ export class TuiInputSliderComponent
         @Optional()
         @Inject(TuiNewInputSliderDirective)
         readonly isNew: TuiNewInputSliderDirective | null,
+        @Inject(I18nPluralPipe) readonly i18nPlural: I18nPluralPipe,
     ) {
         super(control, changeDetectorRef);
     }
@@ -294,17 +297,23 @@ function legacyMinMaxLabel({
     max,
     minLabel,
     maxLabel,
+    i18nPlural,
+    pluralizeMap,
 }: TuiInputSliderComponent): (
     context: TuiContextWithImplicit<number>,
 ) => string | number {
     return ({$implicit: value}: TuiContextWithImplicit<number>) => {
+        const valueWithPlural = `${value} ${
+            pluralizeMap ? i18nPlural.transform(value, pluralizeMap) : ``
+        }`;
+
         switch (value) {
             case min:
-                return minLabel || value;
+                return minLabel || valueWithPlural;
             case max:
-                return maxLabel || value;
+                return maxLabel || valueWithPlural;
             default:
-                return value;
+                return valueWithPlural;
         }
     };
 }

--- a/projects/kit/components/input-slider/input-slider.template.html
+++ b/projects/kit/components/input-slider/input-slider.template.html
@@ -3,8 +3,8 @@
     [max]="max"
     [precision]="precision"
     [decimal]="decimal"
-    [prefix]="prefix"
-    [postfix]="postfix || (value | i18nPlural: pluralizeMap || pluralizeMapFallback)"
+    [prefix]="showValueContent ? '' : prefix"
+    [postfix]="showValueContent ? '' : postfix || (value | i18nPlural: pluralizeMap || pluralizeMapFallback)"
     [tuiTextfieldCustomContent]="controller.customContent || deprecatedSecondary"
     [tuiTextfieldSize]="computedSize"
     [tuiTextfieldLabelOutside]="computedSize !== 'l'"
@@ -23,7 +23,7 @@
 >
     <ng-content></ng-content>
     <div
-        *ngIf="computedValueContent && !focused"
+        *ngIf="showValueContent"
         polymorpheus-outlet
         automation-id="tui-input-slider__value-content"
         [content]="computedValueContent"

--- a/projects/kit/components/input-slider/test/input-slider-new.component.spec.ts
+++ b/projects/kit/components/input-slider/test/input-slider-new.component.spec.ts
@@ -17,6 +17,8 @@ import {configureTestSuite, TuiNativeInputPO, TuiPageObject} from '@taiga-ui/tes
                 [quantum]="quantum"
                 [steps]="steps"
                 [valueContent]="valueContent"
+                [prefix]="prefix"
+                [postfix]="postfix"
                 [tuiTextfieldCustomContent]="textfieldCustomContent"
             ></tui-input-slider>
 
@@ -39,6 +41,8 @@ class TestComponent {
     steps = 0;
     valueContent: unknown = ``;
     textfieldCustomContent: unknown = ``;
+    prefix = `$`;
+    postfix = `things`;
 
     get percent(): number {
         return Math.round((this.control.value / (this.max - this.min)) * 100);
@@ -56,6 +60,10 @@ const testContext = {
 
     get customContentAutoId() {
         return `tui-primitive-textfield__custom-content`;
+    },
+
+    get valueDecorationAutoId() {
+        return `tui-primitive-textfield__value-decoration`;
     },
 };
 
@@ -309,6 +317,8 @@ describe(`InputSlider[new]`, () => {
             await fixture.whenStable();
 
             expect(testComponent.control.value).toBe(value);
+            expect(getValueDecoration()).not.toContain(testComponent.prefix);
+            expect(getValueDecoration()).not.toContain(testComponent.postfix);
             expect(getTextInputCustomValue()).toBe(expectedContent);
         };
 
@@ -541,6 +551,13 @@ function getTextInputCustomValue(): string {
 function getTextfieldCustomContent(): string {
     return (
         pageObject.getByAutomationId(testContext.customContentAutoId)?.nativeElement
+            .textContent || ``
+    );
+}
+
+function getValueDecoration(): string {
+    return (
+        pageObject.getByAutomationId(testContext.valueDecorationAutoId)?.nativeElement
             .textContent || ``
     );
 }

--- a/projects/kit/components/input-slider/test/input-slider.component.spec.ts
+++ b/projects/kit/components/input-slider/test/input-slider.component.spec.ts
@@ -129,8 +129,11 @@ describe(`InputSlider[legacy props]`, () => {
     });
 
     describe(`Labels`, () => {
-        it(`valueContent not shown (max > value > min)`, () => {
-            expect(aid(testContext.valueContentAutoId).textContent.trim()).toBe(``);
+        it(`valueDecoration (postfix/prefix) not shown (max > value > min; no focus)`, () => {
+            expect(aid(testContext.valueDecorationAutoId).textContent.trim()).toBe(`0`);
+            expect(aid(testContext.valueContentAutoId).textContent.trim()).toMatch(
+                /^0\s+лет$/,
+            );
         });
 
         it(`valueContent is missing on focus (value = min)`, () => {
@@ -153,7 +156,7 @@ describe(`InputSlider[legacy props]`, () => {
 
         describe(`legacy props checks`, () => {
             it(`Plural signature is present (legacy \`pluralize\` prop)`, () => {
-                expect(aid(testContext.valueDecorationAutoId).textContent.trim()).toMatch(
+                expect(aid(testContext.valueContentAutoId).textContent.trim()).toMatch(
                     /0\s+лет/,
                 );
             });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
<img width="300" src="https://user-images.githubusercontent.com/35179038/181471714-a0a39091-1aa2-4acb-867e-16af286ccce6.png" />


Closes #2221

## What is the new behavior?
<img height="300" src="https://user-images.githubusercontent.com/35179038/181471437-dfc723db-d05a-4712-a792-f53f1c86b3e0.png" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
