### PR TITLE
chore: fix cypress tests (`hint-manual` error)

### DIFF
--- a/projects/demo-integrations/cypress/tests/core/hint/hint.spec.ts
+++ b/projects/demo-integrations/cypress/tests/core/hint/hint.spec.ts
@@ -17,9 +17,9 @@ describe(`TuiHint`, () => {
     });
 
     it(`Manual hint works`, () => {
-        cy.tuiVisit(`/directives/manual-hint/API?tuiMode=null&tuiManualHintShow=true`);
+        cy.tuiVisit(`/directives/hint-manual/API?tuiHintManual=true`);
 
-        cy.get(`tui-hint-box`)
+        cy.get(`tui-hint`)
             .first()
             .wait(WAIT_BEFORE_SCREENSHOT)
             .matchImageSnapshot(`manual-hint`);

--- a/projects/demo-integrations/cypress/tests/core/primitive-textfield/primitive-textfield.spec.ts
+++ b/projects/demo-integrations/cypress/tests/core/primitive-textfield/primitive-textfield.spec.ts
@@ -11,7 +11,7 @@ describe(`TuiPrimitiveTextfield`, () => {
             .first()
             .click()
             .wait(500)
-            .get(`tui-hint-box`)
+            .get(`tui-hint`)
             .click();
         cy.matchImageSnapshot(`hint`, {capture: `viewport`});
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
```
1) TuiHint
        Manual hint works:
      AssertionError:
            Timed out retrying after 10000ms:
            expected 
            'http://localhost:3333/?tuiMode=null&tuiManualHintShow=true'
            to include
            '/directives/manual-hint/API?tuiMode=null&tuiManualHintShow=true'
      at Context.eval (http://localhost:3333/__cypress/tests?p=cypress/support/e2e.ts:1156:22)
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
