### PR TITLE
deprecate(kit): `InputTag` deprecate property `[allowSpaces]`

### DIFF
--- a/projects/cdk/schematics/ng-update/constants/templates.ts
+++ b/projects/cdk/schematics/ng-update/constants/templates.ts
@@ -290,4 +290,10 @@ export const TEMPLATE_COMMENTS = [
         comment:
             'This legacy component was replaced by 3 new ones (https://taiga-ui.dev/components/progress-bar | https://taiga-ui.dev/components/progress-circle | https://taiga-ui.dev/components/progress-segmented ) ',
     },
+    {
+        tag: 'tui-input-tag',
+        withAttr: 'allowSpaces',
+        comment:
+            'Use property [separator] to forbid spaces. See example: https://taiga-ui.dev/components/input-tag#forbid-spaces',
+    },
 ] as const;

--- a/projects/cdk/schematics/ng-update/constants/templates.ts
+++ b/projects/cdk/schematics/ng-update/constants/templates.ts
@@ -294,6 +294,6 @@ export const TEMPLATE_COMMENTS = [
         tag: 'tui-input-tag',
         withAttr: 'allowSpaces',
         comment:
-            'Use property [separator] to forbid spaces. See example: https://taiga-ui.dev/components/input-tag#forbid-spaces',
+            'Use property [separator] to forbid spaces. See example: https://taiga-ui.dev/components/input-tag#no-spaces-inside-tags',
     },
 ] as const;

--- a/projects/demo-integrations/cypress/tests/kit/input-tag/input-tag.spec.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-tag/input-tag.spec.ts
@@ -38,4 +38,21 @@ describe(`InputTag`, () => {
                 cy.wrap($el).matchImageSnapshot(`01-night-mode-${index}`);
             });
     });
+
+    it(`allows to forbid spaces via property [separator]`, () => {
+        cy.get(`#forbid-spaces`)
+            .findByAutomationId(EXAMPLE_ID)
+            .should(`be.visible`)
+            .as(`wrapper`);
+
+        cy.get(`@wrapper`)
+            .tuiScrollIntoView()
+            .findByAutomationId(`tui-input-tag__native`)
+            .type(`taiga ui library `);
+
+        cy.get(`@wrapper`).find(`tui-tag`).should(`have.length`, 6);
+        cy.get(`@wrapper`)
+            .find(`tui-input-tag`)
+            .matchImageSnapshot(`04-input-tag-forbidden-spaces`, {padding: 5});
+    });
 });

--- a/projects/demo-integrations/cypress/tests/kit/input-tag/input-tag.spec.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-tag/input-tag.spec.ts
@@ -39,8 +39,8 @@ describe(`InputTag`, () => {
             });
     });
 
-    it(`allows to forbid spaces via property [separator]`, () => {
-        cy.get(`#forbid-spaces`)
+    it(`allows to forbid spaces inside tags via property [separator]`, () => {
+        cy.get(`#no-spaces-inside-tags`)
             .findByAutomationId(EXAMPLE_ID)
             .should(`be.visible`)
             .as(`wrapper`);

--- a/projects/demo/src/modules/components/input-tag/examples/5/index.less
+++ b/projects/demo/src/modules/components/input-tag/examples/5/index.less
@@ -1,5 +1,5 @@
 .input {
-    width: 20rem;
+    max-width: 20rem;
     direction: rtl;
     text-align: right;
 }

--- a/projects/demo/src/modules/components/input-tag/examples/6/index.less
+++ b/projects/demo/src/modules/components/input-tag/examples/6/index.less
@@ -1,3 +1,3 @@
 .input {
-    width: 20rem;
+    max-width: 20rem;
 }

--- a/projects/demo/src/modules/components/input-tag/examples/7/index.html
+++ b/projects/demo/src/modules/components/input-tag/examples/7/index.html
@@ -1,0 +1,6 @@
+<tui-input-tag
+    class="b-form"
+    [separator]="customSeparator"
+    [tuiTextfieldLabelOutside]="true"
+    [(ngModel)]="value"
+></tui-input-tag>

--- a/projects/demo/src/modules/components/input-tag/examples/7/index.ts
+++ b/projects/demo/src/modules/components/input-tag/examples/7/index.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+
+@Component({
+    selector: `tui-input-tag-example-7`,
+    templateUrl: `./index.html`,
+    changeDetection,
+    encapsulation,
+})
+export class TuiInputTagExample7 {
+    value = [`Use`, `space`, `button`];
+    customSeparator = /[\s,]/; // Use space or comma to create new tag
+}

--- a/projects/demo/src/modules/components/input-tag/input-tag.component.ts
+++ b/projects/demo/src/modules/components/input-tag/input-tag.component.ts
@@ -60,6 +60,11 @@ export class ExampleTuiInputTagComponent extends AbstractExampleTuiControl {
         LESS: import(`!!raw-loader!./examples/6/index.less`),
     };
 
+    readonly example7: TuiDocExample = {
+        TypeScript: import(`!!raw-loader!./examples/7/index.ts`),
+        HTML: import(`!!raw-loader!./examples/7/index.html`),
+    };
+
     readonly control = new FormControl(
         [`John Cleese`, `Eric Idle`, `Michael Palin`],
         Validators.required,
@@ -73,7 +78,7 @@ export class ExampleTuiInputTagComponent extends AbstractExampleTuiControl {
 
     uniqueTags = true;
 
-    readonly separatorVariants = [`,`, `;`, /[\d]/];
+    readonly separatorVariants = [`,`, `;`, /[\d]/, /[\s,]/];
 
     separator = this.separatorVariants[0];
 

--- a/projects/demo/src/modules/components/input-tag/input-tag.module.ts
+++ b/projects/demo/src/modules/components/input-tag/input-tag.module.ts
@@ -24,6 +24,7 @@ import {TuiInputTagExample3} from './examples/3';
 import {TuiInputTagExample4} from './examples/4';
 import {TuiInputTagExample5} from './examples/5';
 import {TuiInputTagExample6} from './examples/6';
+import {TuiInputTagExample7} from './examples/7';
 import {ExampleTuiInputTagComponent} from './input-tag.component';
 
 @NgModule({
@@ -52,6 +53,7 @@ import {ExampleTuiInputTagComponent} from './input-tag.component';
         TuiInputTagExample4,
         TuiInputTagExample5,
         TuiInputTagExample6,
+        TuiInputTagExample7,
     ],
     exports: [ExampleTuiInputTagComponent],
 })

--- a/projects/demo/src/modules/components/input-tag/input-tag.template.html
+++ b/projects/demo/src/modules/components/input-tag/input-tag.template.html
@@ -65,6 +65,21 @@
         >
             <tui-input-tag-example-6></tui-input-tag-example-6>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="forbid-spaces"
+            i18n-heading
+            heading="Forbid spaces"
+            [content]="example7"
+            [description]="forbidSpacesDescription"
+        >
+            <ng-template #forbidSpacesDescription>
+                Use power of RegExp to forbid spaces via property
+                <code>[separator]</code>
+                .
+            </ng-template>
+            <tui-input-tag-example-7></tui-input-tag-example-7>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>
@@ -133,9 +148,31 @@
                 documentationPropertyName="allowSpaces"
                 documentationPropertyType="boolean"
                 documentationPropertyMode="input"
+                [documentationPropertyDeprecated]="true"
                 [(documentationPropertyValue)]="allowSpaces"
             >
-                Allow spaces inside tag
+                Allow spaces inside tag.
+
+                <p>In next major release spaces are always allowed by default.</p>
+
+                <p>
+                    <strong>
+                        Use property
+                        <code>[separator]</code>
+                        to forbid spaces.
+                    </strong>
+                </p>
+                <p>
+                    See this
+                    <a
+                        tuiLink
+                        routerLink="/components/input-tag"
+                        fragment="forbid-spaces"
+                    >
+                        example
+                    </a>
+                    .
+                </p>
             </ng-template>
             <ng-template
                 i18n

--- a/projects/demo/src/modules/components/input-tag/input-tag.template.html
+++ b/projects/demo/src/modules/components/input-tag/input-tag.template.html
@@ -67,14 +67,14 @@
         </tui-doc-example>
 
         <tui-doc-example
-            id="forbid-spaces"
+            id="no-spaces-inside-tags"
             i18n-heading
-            heading="Forbid spaces"
+            heading="No spaces inside tags"
             [content]="example7"
             [description]="forbidSpacesDescription"
         >
             <ng-template #forbidSpacesDescription>
-                Use power of RegExp to forbid spaces via property
+                Use power of RegExp to forbid spaces inside tags via property
                 <code>[separator]</code>
                 .
             </ng-template>
@@ -167,7 +167,7 @@
                     <a
                         tuiLink
                         routerLink="/components/input-tag"
-                        fragment="forbid-spaces"
+                        fragment="no-spaces-inside-tags"
                     >
                         example
                     </a>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Deprecate property`[allowSpaces]`.

## What is the new behavior?
Use property `[separator]` to forbid spaces.

New screenshot test produces:
![04-input-tag-forbidden-spaces snap](https://user-images.githubusercontent.com/35179038/183053098-4c1d8aa6-20c1-4d2b-90f1-6c823aa53dc7.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
