### PR TITLE
docs: remove IconButton from SEE_ALSO_GROUPS

### DIFF
--- a/projects/demo/src/modules/app/app.const.ts
+++ b/projects/demo/src/modules/app/app.const.ts
@@ -16,7 +16,7 @@ export const SEE_ALSO_GROUPS: ReadonlyArray<readonly string[]> = [
     [`Error`, `FieldError`],
     [`InputNumber`, `Money`],
     [`InputPhone`, `InputPhoneInternational`],
-    [`Button`, `IconButton`, `Action`, `Link`],
+    [`Button`, `Action`, `Link`],
     [`CheckboxBlock`, `CheckboxLabeled`, `PrimitiveCheckbox`, `Toggle`, `Checkbox`],
     [`Accordion`, `Expand`],
     [`Radio`, `RadioBlock`, `RadioLabeled`, `RadioList`],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [x] Documentation content changes

## What is the current behavior?

An IconButton link on a Button page navigates to `https://taiga-ui.dev/`.

<img width="1122" alt="Screenshot 2022-08-05 at 13 56 50" src="https://user-images.githubusercontent.com/22116465/183072632-19ace7ed-0ef1-4f35-a38e-acf399de45d7.png">

## What is the new behavior?

An IconButton link is removed from SEE_ALSO_GROUPS array.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
