### PR TITLE
chore: `Changelog` add section `Deprecations`

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,14 @@
-module.exports = {extends: ['@commitlint/config-conventional']};
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        'type-enum': async () =>
+            import('@commitlint/config-conventional')
+                .then(m => m.default)
+                .then(({rules}) => {
+                    // https://commitlint.js.org/#/reference-rules?id=rules
+                    const [level, applicable, types] = rules['type-enum'];
+
+                    return [level, applicable, [...types, 'deprecate']];
+                }),
+    },
+};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,14 +1,20 @@
 module.exports = {
     extends: ['@commitlint/config-conventional'],
     rules: {
-        'type-enum': async () =>
-            import('@commitlint/config-conventional')
-                .then(m => m.default)
-                .then(({rules}) => {
-                    // https://commitlint.js.org/#/reference-rules?id=rules
-                    const [level, applicable, types] = rules['type-enum'];
+        'scope-enum': () => {
+            const {readdirSync, statSync} = require('fs');
+            const dir = 'projects';
+            const projectsNames = readdirSync(dir).filter(entity =>
+                statSync(`${dir}/${entity}`).isDirectory(),
+            );
 
-                    return [level, applicable, [...types, 'deprecate']];
-                }),
+            return [2, 'always', projectsNames];
+        },
+        'type-enum': () => {
+            const [level, applicable, types] = require('@commitlint/config-conventional')
+                .rules['type-enum'];
+
+            return [level, applicable, [...types, 'deprecate']];
+        },
     },
 };

--- a/package.json
+++ b/package.json
@@ -143,6 +143,20 @@
         "scripts": {
             "postchangelog": "npm run exec -- ./scripts/postchangelog.ts",
             "postbump": "npm run exec -- ./scripts/postbump.ts"
-        }
+        },
+        "types": [
+            {
+                "type": "feat",
+                "section": "Features"
+            },
+            {
+                "type": "fix",
+                "section": "Bug Fixes"
+            },
+            {
+                "type": "deprecate",
+                "section": "Deprecations"
+            }
+        ]
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
See [default preset](https://github.com/conventional-changelog/conventional-changelog/blob/bfe3bf1c49d4a125474b398b2d304749fd3b56c7/packages/conventional-changelog-conventionalcommits/writer-opts.js#L179-L192):
```js
[
    { type: 'feat', section: 'Features' },
    { type: 'feature', section: 'Features' },
    { type: 'fix', section: 'Bug Fixes' },
    { type: 'perf', section: 'Performance Improvements' },
    { type: 'revert', section: 'Reverts' },
    { type: 'docs', section: 'Documentation', hidden: true },
    { type: 'style', section: 'Styles', hidden: true },
    { type: 'chore', section: 'Miscellaneous Chores', hidden: true },
    { type: 'refactor', section: 'Code Refactoring', hidden: true },
    { type: 'test', section: 'Tests', hidden: true },
    { type: 'build', section: 'Build System', hidden: true },
    { type: 'ci', section: 'Continuous Integration', hidden: true }
  ]
```

## What is the new behavior?
#### 1. New section "Deprecations"
Run
```
npm run exec -- ./scripts/release.ts --ci-mode --dry-run true  
```
It generates changelog with `Deprecations`-section (if there are commits with `deprecate`-type).
Example:
<img width="1741" alt="deprecate" src="https://user-images.githubusercontent.com/35179038/183391431-25a26c63-8676-4375-abb3-cb72c3fcdf55.png">

#### 2. Strict checks for scope of conventional commit
```sh
git commit -m "feat(abbon-mobile): debug" 

⧗   input: feat(abbon-mobile): debug
✖   scope must be one of [
    addon-charts,
    addon-commerce,
    addon-doc,
    addon-editor,
    addon-mobile,
    addon-preview,
    addon-table,
    addon-tablebars,
    cdk,
    core,
    demo,
    demo-integrations,
    i18n,
    icons,
    kit,
    taiga-schematics,
    testing
][scope-enum]
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
