### PR TITLE
fix(addon-table): sort chevron direction to correctly match the sorting state

### DIFF
--- a/projects/addon-table/components/table/th/th.template.html
+++ b/projects/addon-table/components/table/th/th.template.html
@@ -10,7 +10,7 @@
     <tui-svg
         class="t-sort-icon"
         [src]="icon"
-        [class.t-sort-icon_rotated]="isCurrent && table.direction === -1"
+        [class.t-sort-icon_rotated]="isCurrent && table.direction === 1"
     ></tui-svg>
 </button>
 <ng-template #content><ng-content></ng-content></ng-template>


### PR DESCRIPTION
…orting state.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

The sorting chevron is reversed, pointing down for asc and up for desc.

Closes https://github.com/Tinkoff/taiga-ui/issues/2265

## What is the new behavior?

The sorting chevron points up for asc, down for desc.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
