### PR TITLE
fix(kit): `tui-text-area` label alignment on IOS

### DIFF
--- a/projects/kit/components/text-area/text-area.style.less
+++ b/projects/kit/components/text-area/text-area.style.less
@@ -186,12 +186,15 @@
         padding: 0 1rem;
     }
 
-    :host._ios & {
-        padding-left: 0.8125rem; // compensation of unkillable padding in mobile safari
-    }
-
     :host[data-mode='onDark']._disabled & {
         color: var(--tui-text-03-night);
+    }
+
+    /* Safari 9+, < 13.1 */
+    @supports (-webkit-marquee-repetition: infinite) and (object-fit: fill) {
+        :host._ios & {
+            padding-left: 0.8125rem; // compensation of unkillable padding in mobile safari
+        }
     }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

On Safari 13+ versions label is not aligned with inner textarea  

Closes #2291 

## What is the new behavior?

Now it's broken only on 13.0 – 13.3 ios versions (Safari 13.0). All other versions Safari 10+ is working perfectly. Label is aligned with inner textarea

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
