### PR TITLE
chore(cdk): `schematics` error-handling for not-supported angular.json

### DIFF
--- a/projects/cdk/schematics/ng-add/steps/add-taiga-styles.ts
+++ b/projects/cdk/schematics/ng-add/steps/add-taiga-styles.ts
@@ -1,6 +1,6 @@
 import {Rule, Tree} from '@angular-devkit/schematics';
 import {Schema} from '../schema';
-import {addStylesToAngularJson} from '../../utils/add-styles';
+import {addStylesToAngularJson} from '../../utils/angular-json-manipulations';
 import {
     TAIGA_GLOBAL_NEW_STYLE,
     TAIGA_THEME_FONTS,

--- a/projects/cdk/schematics/ng-update/index.ts
+++ b/projects/cdk/schematics/ng-update/index.ts
@@ -1,10 +1,5 @@
 import {chain, Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
-import {
-    addPackageJsonDependency,
-    createProject,
-    saveActiveProject,
-    setActiveProject,
-} from 'ng-morph';
+import {createProject, saveActiveProject, setActiveProject} from 'ng-morph';
 import {getWorkspace} from '@schematics/angular/utility/workspace';
 import {TAIGA_VERSION} from '../ng-add/constants/versions';
 import {replaceEnums} from './steps/replace-enums';
@@ -89,10 +84,6 @@ function addTaigaStyles(options: Schema): Rule {
             from: TAIGA_GLOBAL_OLD_STYLE,
             to: [TAIGA_GLOBAL_NEW_STYLE],
         };
-        addPackageJsonDependency(tree, {
-            name: `@taiga-ui/styles`,
-            version: TAIGA_VERSION,
-        });
 
         const isSupportedAngularJson = await getWorkspace(tree)
             .then(() => true)
@@ -106,7 +97,7 @@ function addTaigaStyles(options: Schema): Rule {
             context.logger.warn(
                 `[WARNING]: Schematics don't support this version of angular.json.\n` +
                     `– Add styles ${taigaStyles.join(',')} to angular.json manually.\n` +
-                    `– Manually replace "${TAIGA_GLOBAL_OLD_STYLE}" with "${TAIGA_GLOBAL_NEW_STYLE}" inside "styles" of angular.json`,
+                    `– Manually replace "${TAIGA_GLOBAL_OLD_STYLE}" with "${TAIGA_GLOBAL_NEW_STYLE}" inside "styles" of angular.json (don't forget to install "@taiga-ui/styles")`,
             );
             return;
         }

--- a/projects/cdk/schematics/utils/angular-json-manipulations.ts
+++ b/projects/cdk/schematics/utils/angular-json-manipulations.ts
@@ -3,10 +3,22 @@ import {Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
 import {getProject} from './get-project';
 import {getProjectTargetOptions} from './get-project-target-options';
 import {JsonArray} from '@angular-devkit/core';
-import {updateWorkspace} from '@schematics/angular/utility/workspace';
+import {getWorkspace, updateWorkspace} from '@schematics/angular/utility/workspace';
 import {addPackageJsonDependency} from 'ng-morph';
 import {TAIGA_VERSION} from '../ng-add/constants/versions';
 import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
+
+export async function isInvalidAngularJson(tree: Tree): Promise<boolean> {
+    return (
+        getWorkspace(tree)
+            .then(() => false)
+            /**
+             * Possible error – "Invalid format version detected - Expected:[ 1 ] Found: [ 2 ]"
+             * @see https://github.com/angular/angular-cli/blob/main/packages/angular_devkit/core/src/workspace/json/reader.ts#L67-L69
+             */
+            .catch(() => true)
+    );
+}
 
 export function addStylesToAngularJson(
     options: Schema,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
```console
An error occured:
Error: Invalid format version detected - Expected:[ 1 ] Found: [ 2 ]
    at Object.readJsonWorkspace (/Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/@angular-devkit/core/src/workspace/json/reader.js:31:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.readWorkspace (/Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/@angular-devkit/core/src/workspace/core.js:90:25)
    at async /Users/n.barsukov/WebstormProjects/taiga-ui/node_modules/@schematics/angular/utility/workspace.js:39:35
```

## What is the new behavior?
<img width="1729" alt="Screenshot 2022-08-25 at 18 42 58" src="https://user-images.githubusercontent.com/35179038/186710129-8519e19b-d390-4fa5-829b-6641f925c70e.png">




## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
