### PR TITLE
feat(core): add TUI_DIALOG_OPTIONS token

### DIFF
--- a/projects/core/components/dialog/dialog.service.ts
+++ b/projects/core/components/dialog/dialog.service.ts
@@ -1,24 +1,24 @@
-import {Injectable} from '@angular/core';
-import {AbstractTuiDialogService} from '@taiga-ui/cdk';
+import {Injectable, Inject} from '@angular/core';
+import {AbstractTuiDialogService, TuiIdService} from '@taiga-ui/cdk';
 import {TuiDialogOptions} from '@taiga-ui/core/interfaces';
+import {TUI_DIALOG_OPTIONS} from '@taiga-ui/core/tokens/dialog-options';
 import {PolymorpheusComponent} from '@tinkoff/ng-polymorpheus';
 
 import {TuiDialogComponent} from './dialog.component';
 
 const DIALOG = new PolymorpheusComponent(TuiDialogComponent);
-const DEFAULT_OPTIONS = {
-    size: `m`,
-    required: false,
-    closeable: true,
-    dismissible: true,
-    label: ``,
-    header: ``,
-} as const;
 
 @Injectable({
     providedIn: `root`,
 })
 export class TuiDialogService extends AbstractTuiDialogService<TuiDialogOptions<any>> {
     protected readonly component = DIALOG;
-    protected readonly defaultOptions: TuiDialogOptions<any> = DEFAULT_OPTIONS as any;
+
+    constructor(
+        @Inject(TUI_DIALOG_OPTIONS) 
+        protected readonly defaultOptions: TuiDialogOptions<any>,
+        @Inject(TuiIdService) idService: TuiIdService,
+    ) {
+        super(idService);
+    }
 }

--- a/projects/core/components/dialog/test/dialog.component.spec.ts
+++ b/projects/core/components/dialog/test/dialog.component.spec.ts
@@ -1,0 +1,52 @@
+import {Component, DebugElement} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {configureTestSuite, TuiPageObject} from '@taiga-ui/testing';
+import {tuiDialogOptionsProvider} from '../../../tokens/dialog-options';
+import {TuiRootModule} from '../../root/root.module';
+import {TuiDialogModule} from '../dialog.module';
+import {TuiDialogService} from '../dialog.service';
+
+describe('Dialog with TUI_DIALOG_OPTIONS', () => {
+    @Component({
+        template: `
+            <tui-root></tui-root>
+        `,
+    })
+    class TestComponent {}
+
+    const closeable = false;
+
+    let fixture: ComponentFixture<TestComponent>;
+    let tuiDialogService: TuiDialogService;
+    let pageObject: TuiPageObject<TestComponent>;
+
+    function getCloseButton(): DebugElement {
+        return pageObject.getByAutomationId('tui-dialog__close')!;
+    }
+
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule, TuiRootModule, TuiDialogModule],
+            declarations: [TestComponent],
+            providers: [
+                tuiDialogOptionsProvider({closeable}),
+            ],
+        });
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        tuiDialogService = TestBed.inject(TuiDialogService);
+        pageObject = new TuiPageObject(fixture);
+    });
+
+    describe('close button', () => {
+        it(`when closeable = false is absent`, () => {
+            tuiDialogService.open('Test').subscribe();
+            fixture.detectChanges();
+
+            expect(getCloseButton()).toBeNull();
+        });
+    });
+});

--- a/projects/core/tokens/dialog-options.ts
+++ b/projects/core/tokens/dialog-options.ts
@@ -1,0 +1,29 @@
+import {InjectionToken, ValueProvider} from '@angular/core';
+import {TuiDialogOptions} from '../interfaces';
+
+export type TuiDialogDefaultOptions = Omit<TuiDialogOptions<unknown>, 'data'>;
+
+export const TUI_DIALOG_DEFAULT_OPTIONS: TuiDialogDefaultOptions = {
+    size: `m`,
+    required: false,
+    closeable: true,
+    dismissible: true,
+    label: ``,
+    header: ``,
+};
+
+export const TUI_DIALOG_OPTIONS = new InjectionToken<TuiDialogDefaultOptions>(
+    'Default parameters for dialog component',
+    {
+        factory: () => TUI_DIALOG_DEFAULT_OPTIONS,
+    },
+);
+
+export function tuiDialogOptionsProvider(
+    options: Partial<TuiDialogDefaultOptions>,
+): ValueProvider {
+    return {
+        provide: TUI_DIALOG_OPTIONS,
+        useValue: {...TUI_DIALOG_DEFAULT_OPTIONS, ...options},
+    };
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Does not exist.

Closes https://github.com/Tinkoff/taiga-ui/issues/2267

## What is the new behavior?
A token is provided so that the user can configure all dialogs, without the need to provide the same configuration each time a new dialog is opened.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
