### PR TITLE
feat: add tokens for customizing different dialogs that extend `AbstractTuiDialogService`

### DIFF
--- a/projects/addon-mobile/components/mobile-dialog/index.ts
+++ b/projects/addon-mobile/components/mobile-dialog/index.ts
@@ -1,4 +1,5 @@
 export * from './mobile-dialog.component';
 export * from './mobile-dialog.module';
 export * from './mobile-dialog.service';
+export * from './mobile-dialog.tokens';
 export * from './mobile-dialog-options';

--- a/projects/addon-mobile/components/mobile-dialog/mobile-dialog.service.ts
+++ b/projects/addon-mobile/components/mobile-dialog/mobile-dialog.service.ts
@@ -1,16 +1,13 @@
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {AbstractTuiDialogService, TuiBaseDialogContext} from '@taiga-ui/cdk';
 import {PolymorpheusComponent, PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {Observable} from 'rxjs';
 
 import {TuiMobileDialogComponent} from './mobile-dialog.component';
+import {TUI_MOBILE_DIALOG_OPTIONS} from './mobile-dialog.tokens';
 import {TuiMobileDialogOptions} from './mobile-dialog-options';
 
 const DIALOG = new PolymorpheusComponent(TuiMobileDialogComponent);
-const DEFAULT_OPTIONS = {
-    label: ``,
-    actions: [`OK`],
-} as const;
 
 @Injectable({
     providedIn: `root`,
@@ -20,8 +17,10 @@ export class TuiMobileDialogService extends AbstractTuiDialogService<
     number
 > {
     protected readonly component = DIALOG;
-    protected readonly defaultOptions: TuiMobileDialogOptions<any> =
-        DEFAULT_OPTIONS as any;
+    protected readonly defaultOptions: TuiMobileDialogOptions<any> = {
+        ...inject(TUI_MOBILE_DIALOG_OPTIONS),
+        data: undefined,
+    };
 
     override open(
         content: PolymorpheusContent<

--- a/projects/addon-mobile/components/mobile-dialog/mobile-dialog.template.html
+++ b/projects/addon-mobile/components/mobile-dialog/mobile-dialog.template.html
@@ -1,5 +1,6 @@
 <h2
     *ngIf="!!context.label"
+    automation-id="tui-mobile-dialog__label"
     class="t-heading"
     [id]="context.id"
 >

--- a/projects/addon-mobile/components/mobile-dialog/mobile-dialog.tokens.ts
+++ b/projects/addon-mobile/components/mobile-dialog/mobile-dialog.tokens.ts
@@ -1,0 +1,27 @@
+import {InjectionToken, ValueProvider} from '@angular/core';
+
+import {TuiMobileDialogOptions} from './mobile-dialog-options';
+
+type TuiMobileDialogDefaultOptions = Omit<TuiMobileDialogOptions<unknown>, 'data'>;
+
+export const TUI_MOBILE_DIALOG_DEFAULT_OPTIONS: TuiMobileDialogDefaultOptions = {
+    label: ``,
+    actions: [`OK`],
+};
+
+export const TUI_MOBILE_DIALOG_OPTIONS =
+    new InjectionToken<TuiMobileDialogDefaultOptions>(
+        `[TUI_MOBILE_DIALOG_OPTIONS]: Default parameters for mobile dialog component`,
+        {
+            factory: () => TUI_MOBILE_DIALOG_DEFAULT_OPTIONS,
+        },
+    );
+
+export function tuiMobileDialogOptionsProvider(
+    options: Partial<TuiMobileDialogDefaultOptions>,
+): ValueProvider {
+    return {
+        provide: TUI_MOBILE_DIALOG_OPTIONS,
+        useValue: {...TUI_MOBILE_DIALOG_DEFAULT_OPTIONS, ...options},
+    };
+}

--- a/projects/addon-mobile/components/mobile-dialog/test/mobile-dialog.component.spec.ts
+++ b/projects/addon-mobile/components/mobile-dialog/test/mobile-dialog.component.spec.ts
@@ -1,0 +1,62 @@
+import {Component, DebugElement} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {TuiIdService} from '@taiga-ui/cdk';
+import {TuiRootModule} from '@taiga-ui/core';
+import {configureTestSuite, TuiPageObject} from '@taiga-ui/testing';
+
+import {TuiMobileDialogModule} from '../mobile-dialog.module';
+import {TuiMobileDialogService} from '../mobile-dialog.service';
+import {tuiMobileDialogOptionsProvider} from '../mobile-dialog.tokens';
+
+describe(`Mobile Dialog with TUI_MOBILE_DIALOG_OPTIONS`, () => {
+    @Component({
+        template: `
+            <tui-root></tui-root>
+        `,
+    })
+    class TestComponent {}
+
+    const label = `Test`;
+
+    let fixture: ComponentFixture<TestComponent>;
+    let tuiMobileDialogService: TuiMobileDialogService;
+    let pageObject: TuiPageObject<TestComponent>;
+
+    function getLabelElement(): DebugElement {
+        return pageObject.getByAutomationId(`tui-mobile-dialog__label`)!;
+    }
+
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule, TuiRootModule, TuiMobileDialogModule],
+            declarations: [TestComponent],
+            providers: [
+                tuiMobileDialogOptionsProvider({label}),
+                {
+                    provide: TuiMobileDialogService,
+                    useFactory: () =>
+                        new TuiMobileDialogService(TestBed.inject(TuiIdService)),
+                },
+            ],
+        });
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        tuiMobileDialogService = TestBed.inject(TuiMobileDialogService);
+        pageObject = new TuiPageObject(fixture);
+    });
+
+    describe(`label`, () => {
+        it(`correctly shows label option data`, () => {
+            tuiMobileDialogService.open(`Test`).subscribe();
+            fixture.detectChanges();
+
+            const labelElement = getLabelElement();
+
+            expect(labelElement).toBeTruthy();
+            expect(labelElement.nativeElement.textContent.trim()).toBe(label);
+        });
+    });
+});

--- a/projects/core/components/dialog/dialog.service.ts
+++ b/projects/core/components/dialog/dialog.service.ts
@@ -1,24 +1,20 @@
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {AbstractTuiDialogService} from '@taiga-ui/cdk';
-import {TuiDialogOptions} from '@taiga-ui/core/interfaces';
+import type {TuiDialogOptions} from '@taiga-ui/core/interfaces';
 import {PolymorpheusComponent} from '@tinkoff/ng-polymorpheus';
 
 import {TuiDialogComponent} from './dialog.component';
+import {TUI_DIALOG_OPTIONS} from './dialog.tokens';
 
 const DIALOG = new PolymorpheusComponent(TuiDialogComponent);
-const DEFAULT_OPTIONS = {
-    size: `m`,
-    required: false,
-    closeable: true,
-    dismissible: true,
-    label: ``,
-    header: ``,
-} as const;
 
 @Injectable({
     providedIn: `root`,
 })
 export class TuiDialogService extends AbstractTuiDialogService<TuiDialogOptions<any>> {
     protected readonly component = DIALOG;
-    protected readonly defaultOptions: TuiDialogOptions<any> = DEFAULT_OPTIONS as any;
+    protected readonly defaultOptions: TuiDialogOptions<any> = {
+        ...inject(TUI_DIALOG_OPTIONS),
+        data: undefined,
+    };
 }

--- a/projects/core/components/dialog/dialog.tokens.ts
+++ b/projects/core/components/dialog/dialog.tokens.ts
@@ -1,0 +1,29 @@
+import {InjectionToken, ValueProvider} from '@angular/core';
+import type {TuiDialogOptions} from '@taiga-ui/core/interfaces';
+
+type TuiDialogDefaultOptions = Omit<TuiDialogOptions<unknown>, 'data'>;
+
+export const TUI_DIALOG_DEFAULT_OPTIONS: TuiDialogDefaultOptions = {
+    size: `m`,
+    required: false,
+    closeable: true,
+    dismissible: true,
+    label: ``,
+    header: ``,
+};
+
+export const TUI_DIALOG_OPTIONS = new InjectionToken<TuiDialogDefaultOptions>(
+    `[TUI_DIALOG_OPTIONS]: Default parameters for dialog component`,
+    {
+        factory: () => TUI_DIALOG_DEFAULT_OPTIONS,
+    },
+);
+
+export function tuiDialogOptionsProvider(
+    options: Partial<TuiDialogDefaultOptions>,
+): ValueProvider {
+    return {
+        provide: TUI_DIALOG_OPTIONS,
+        useValue: {...TUI_DIALOG_DEFAULT_OPTIONS, ...options},
+    };
+}

--- a/projects/core/components/dialog/index.ts
+++ b/projects/core/components/dialog/index.ts
@@ -3,3 +3,4 @@ export * from './dialog.directive';
 export * from './dialog.module';
 export * from './dialog.providers';
 export * from './dialog.service';
+export * from './dialog.tokens';

--- a/projects/core/components/dialog/test/dialog.component.spec.ts
+++ b/projects/core/components/dialog/test/dialog.component.spec.ts
@@ -1,0 +1,58 @@
+import {Component, DebugElement} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {TuiIdService} from '@taiga-ui/cdk';
+import {configureTestSuite, TuiPageObject} from '@taiga-ui/testing';
+
+import {TuiRootModule} from '../../root/root.module';
+import {TuiDialogModule} from '../dialog.module';
+import {TuiDialogService} from '../dialog.service';
+import {tuiDialogOptionsProvider} from '../dialog.tokens';
+
+describe(`Dialog with TUI_DIALOG_OPTIONS`, () => {
+    @Component({
+        template: `
+            <tui-root></tui-root>
+        `,
+    })
+    class TestComponent {}
+
+    const closeable = false;
+
+    let fixture: ComponentFixture<TestComponent>;
+    let tuiDialogService: TuiDialogService;
+    let pageObject: TuiPageObject<TestComponent>;
+
+    function getCloseButton(): DebugElement {
+        return pageObject.getByAutomationId(`tui-dialog__close`)!;
+    }
+
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule, TuiRootModule, TuiDialogModule],
+            declarations: [TestComponent],
+            providers: [
+                tuiDialogOptionsProvider({closeable}),
+                {
+                    provide: TuiDialogService,
+                    useFactory: () => new TuiDialogService(TestBed.inject(TuiIdService)),
+                },
+            ],
+        });
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        tuiDialogService = TestBed.inject(TuiDialogService);
+        pageObject = new TuiPageObject(fixture);
+    });
+
+    describe(`close button`, () => {
+        it(`when closeable = false is absent`, () => {
+            tuiDialogService.open(`Test`).subscribe();
+            fixture.detectChanges();
+
+            expect(getCloseButton()).toBeNull();
+        });
+    });
+});

--- a/projects/kit/components/pdf-viewer/index.ts
+++ b/projects/kit/components/pdf-viewer/index.ts
@@ -2,4 +2,5 @@ export * from './pdf-viewer.component';
 export * from './pdf-viewer.directive';
 export * from './pdf-viewer.module';
 export * from './pdf-viewer.service';
+export * from './pdf-viewer.tokens';
 export * from './pdf-viewer-options';

--- a/projects/kit/components/pdf-viewer/pdf-viewer.service.ts
+++ b/projects/kit/components/pdf-viewer/pdf-viewer.service.ts
@@ -1,14 +1,14 @@
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {SafeResourceUrl} from '@angular/platform-browser';
 import {AbstractTuiDialogService, TuiBaseDialogContext} from '@taiga-ui/cdk';
 import {PolymorpheusComponent, PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {Observable} from 'rxjs';
 
 import {TuiPdfViewerComponent} from './pdf-viewer.component';
+import {TUI_PDF_VIEWER_OPTIONS} from './pdf-viewer.tokens';
 import {TuiPdfViewerOptions} from './pdf-viewer-options';
 
 const DIALOG = new PolymorpheusComponent(TuiPdfViewerComponent);
-const DEFAULT_OPTIONS = {label: ``, actions: ``} as const;
 
 type Content<G> = PolymorpheusContent<
     TuiBaseDialogContext<G> & TuiPdfViewerOptions<unknown>
@@ -21,8 +21,10 @@ export class TuiPdfViewerService extends AbstractTuiDialogService<
     TuiPdfViewerOptions<unknown>
 > {
     protected readonly component = DIALOG;
-    protected readonly defaultOptions: TuiPdfViewerOptions<unknown> =
-        DEFAULT_OPTIONS as TuiPdfViewerOptions<unknown>;
+    protected readonly defaultOptions: TuiPdfViewerOptions<unknown> = {
+        ...inject(TUI_PDF_VIEWER_OPTIONS),
+        data: undefined,
+    };
 
     override open<G>(
         content: SafeResourceUrl | Content<G>,

--- a/projects/kit/components/pdf-viewer/pdf-viewer.template.html
+++ b/projects/kit/components/pdf-viewer/pdf-viewer.template.html
@@ -1,5 +1,10 @@
 <header class="t-header">
-    <h2 class="t-title">{{ context.label }}</h2>
+    <h2
+        automation-id="tui-pdf-viewer__label"
+        class="t-title"
+    >
+        {{ context.label }}
+    </h2>
     <div class="t-actions">
         <!-- TODO: Polymorpheus fix type -->
         <ng-container *polymorpheusOutlet="$any(context.actions) as text; context: context">

--- a/projects/kit/components/pdf-viewer/pdf-viewer.tokens.ts
+++ b/projects/kit/components/pdf-viewer/pdf-viewer.tokens.ts
@@ -1,0 +1,23 @@
+import {InjectionToken, ValueProvider} from '@angular/core';
+
+import {TuiPdfViewerOptions} from './pdf-viewer-options';
+
+type TuiPdfViewerDefaultOptions = Omit<TuiPdfViewerOptions<unknown>, 'data'>;
+
+export const TUI_PDF_VIEWER_DEFAULT_OPTIONS = {label: ``, actions: ``};
+
+export const TUI_PDF_VIEWER_OPTIONS = new InjectionToken<TuiPdfViewerDefaultOptions>(
+    `[TUI_PDF_VIEWER_OPTIONS]: Default parameters for pdf viewer component`,
+    {
+        factory: () => TUI_PDF_VIEWER_DEFAULT_OPTIONS,
+    },
+);
+
+export function tuiPdfViewerOptionsProvider(
+    options: Partial<TuiPdfViewerDefaultOptions>,
+): ValueProvider {
+    return {
+        provide: TUI_PDF_VIEWER_OPTIONS,
+        useValue: {...TUI_PDF_VIEWER_DEFAULT_OPTIONS, ...options},
+    };
+}

--- a/projects/kit/components/pdf-viewer/test/pdf-viewer.component.spec.ts
+++ b/projects/kit/components/pdf-viewer/test/pdf-viewer.component.spec.ts
@@ -1,0 +1,64 @@
+import {Component, DebugElement} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {DomSanitizer} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {TuiIdService} from '@taiga-ui/cdk';
+import {TuiRootModule} from '@taiga-ui/core';
+import {configureTestSuite, TuiPageObject} from '@taiga-ui/testing';
+
+import {TuiPdfViewerModule} from '../pdf-viewer.module';
+import {TuiPdfViewerService} from '../pdf-viewer.service';
+import {tuiPdfViewerOptionsProvider} from '../pdf-viewer.tokens';
+
+describe(`Pdf Viewer with TUI_PDF_VIEWER_OPTIONS`, () => {
+    @Component({
+        template: `
+            <tui-root></tui-root>
+        `,
+    })
+    class TestComponent {}
+
+    const label = `Test`;
+
+    let fixture: ComponentFixture<TestComponent>;
+    let tuiPdfViewerService: TuiPdfViewerService;
+    let pageObject: TuiPageObject<TestComponent>;
+    let sanitizer: DomSanitizer;
+
+    function getLabelElement(): DebugElement {
+        return pageObject.getByAutomationId(`tui-pdf-viewer__label`)!;
+    }
+
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule, TuiRootModule, TuiPdfViewerModule],
+            declarations: [TestComponent],
+            providers: [
+                tuiPdfViewerOptionsProvider({label}),
+                {
+                    provide: TuiPdfViewerService,
+                    useFactory: () =>
+                        new TuiPdfViewerService(TestBed.inject(TuiIdService)),
+                },
+            ],
+        });
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        tuiPdfViewerService = TestBed.inject(TuiPdfViewerService);
+        pageObject = new TuiPageObject(fixture);
+        sanitizer = TestBed.inject(DomSanitizer);
+    });
+
+    describe(`label`, () => {
+        it(`correctly shows label option data`, () => {
+            tuiPdfViewerService
+                .open(sanitizer.bypassSecurityTrustResourceUrl(``))
+                .subscribe();
+            fixture.detectChanges();
+
+            expect(getLabelElement()!.nativeElement.textContent.trim()).toBe(label);
+        });
+    });
+});

--- a/projects/kit/components/push/index.ts
+++ b/projects/kit/components/push/index.ts
@@ -3,5 +3,6 @@ export * from './push.directive';
 export * from './push.module';
 export * from './push.options';
 export * from './push.service';
+export * from './push.tokens';
 export * from './push-alert.component';
 export * from './push-alert.directive';

--- a/projects/kit/components/push/push.options.ts
+++ b/projects/kit/components/push/push.options.ts
@@ -7,13 +7,3 @@ export interface TuiPushOptions {
     readonly iconColor: string;
     readonly buttons: readonly string[];
 }
-
-export const TUI_PUSH_DEFAULT_OPTIONS: TuiPushOptions = {
-    heading: ``,
-    type: ``,
-    timestamp: 0,
-    image: ``,
-    icon: ``,
-    iconColor: ``,
-    buttons: [],
-};

--- a/projects/kit/components/push/push.service.ts
+++ b/projects/kit/components/push/push.service.ts
@@ -1,9 +1,10 @@
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {AbstractTuiDialogService, TuiBaseDialogContext} from '@taiga-ui/cdk';
 import {PolymorpheusComponent, PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {Observable} from 'rxjs';
 
-import {TUI_PUSH_DEFAULT_OPTIONS, TuiPushOptions} from './push.options';
+import {TuiPushOptions} from './push.options';
+import {TUI_PUSH_OPTIONS} from './push.tokens';
 // TODO: find the best way for prevent cycle
 // eslint-disable-next-line import/no-cycle
 import {TuiPushAlertComponent} from './push-alert.component';
@@ -11,7 +12,7 @@ import {TuiPushAlertComponent} from './push-alert.component';
 @Injectable({providedIn: `root`})
 export class TuiPushService extends AbstractTuiDialogService<TuiPushOptions, string> {
     protected readonly component = new PolymorpheusComponent(TuiPushAlertComponent);
-    protected readonly defaultOptions = TUI_PUSH_DEFAULT_OPTIONS;
+    protected readonly defaultOptions = inject(TUI_PUSH_OPTIONS);
 
     override open(
         content: PolymorpheusContent<TuiBaseDialogContext<string> & TuiPushOptions>,

--- a/projects/kit/components/push/push.template.html
+++ b/projects/kit/components/push/push.template.html
@@ -19,7 +19,12 @@
         [textContent]="timestamp | tuiFormatDate | async"
     ></span>
 </div>
-<h3 class="t-heading">{{ heading }}</h3>
+<h3
+    automation-id="tui-push__heading"
+    class="t-heading"
+>
+    {{ heading }}
+</h3>
 <div class="t-content">
     <ng-content></ng-content>
 </div>

--- a/projects/kit/components/push/push.tokens.ts
+++ b/projects/kit/components/push/push.tokens.ts
@@ -1,0 +1,27 @@
+import {InjectionToken, ValueProvider} from '@angular/core';
+
+import {TuiPushOptions} from './push.options';
+
+export const TUI_PUSH_DEFAULT_OPTIONS: TuiPushOptions = {
+    heading: ``,
+    type: ``,
+    timestamp: 0,
+    image: ``,
+    icon: ``,
+    iconColor: ``,
+    buttons: [],
+};
+
+export const TUI_PUSH_OPTIONS = new InjectionToken<TuiPushOptions>(
+    `[TUI_PUSH_OPTIONS]: Default parameters for push component`,
+    {
+        factory: () => TUI_PUSH_DEFAULT_OPTIONS,
+    },
+);
+
+export function tuiPushOptionsProvider(options: Partial<TuiPushOptions>): ValueProvider {
+    return {
+        provide: TUI_PUSH_OPTIONS,
+        useValue: {...TUI_PUSH_DEFAULT_OPTIONS, ...options},
+    };
+}

--- a/projects/kit/components/push/test/push.component.spec.ts
+++ b/projects/kit/components/push/test/push.component.spec.ts
@@ -1,0 +1,60 @@
+import {Component, DebugElement} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {TuiIdService} from '@taiga-ui/cdk';
+import {TuiRootModule} from '@taiga-ui/core';
+import {configureTestSuite, TuiPageObject} from '@taiga-ui/testing';
+
+import {TuiPushModule} from '../push.module';
+import {TuiPushService} from '../push.service';
+import {tuiPushOptionsProvider} from '../push.tokens';
+
+describe(`Push with TUI_PUSH_OPTIONS`, () => {
+    @Component({
+        template: `
+            <tui-root></tui-root>
+        `,
+    })
+    class TestComponent {}
+
+    const heading = `Test`;
+
+    let fixture: ComponentFixture<TestComponent>;
+    let tuiPushService: TuiPushService;
+    let pageObject: TuiPageObject<TestComponent>;
+
+    function getLabelElement(): DebugElement {
+        return pageObject.getByAutomationId(`tui-push__heading`)!;
+    }
+
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule, TuiRootModule, TuiPushModule],
+            declarations: [TestComponent],
+            providers: [
+                tuiPushOptionsProvider({heading}),
+                {
+                    provide: TuiPushService,
+                    useFactory: () => new TuiPushService(TestBed.inject(TuiIdService)),
+                },
+            ],
+        });
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        tuiPushService = TestBed.inject(TuiPushService);
+        pageObject = new TuiPageObject(fixture);
+    });
+
+    describe(`heading`, () => {
+        it(`correctly shows heading option data`, () => {
+            tuiPushService.open(`Test`).subscribe();
+            fixture.detectChanges();
+
+            const labelElement = getLabelElement();
+
+            expect(labelElement.nativeElement.textContent.trim()).toBe(heading);
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Does not exist.

Closes https://github.com/Tinkoff/taiga-ui/issues/2267

## What is the new behavior?
A token is provided so that the user can configure all dialogs, without the need to provide the same configuration each time a new dialog is opened.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
