### PR TITLE
feat(core)!: remove `tuiExpandContent` directive

### DIFF
--- a/projects/addon-doc/src/components/demo/demo.template.html
+++ b/projects/addon-doc/src/components/demo/demo.template.html
@@ -119,7 +119,7 @@
                 class="t-expand"
                 [expanded]="expanded"
             >
-                <ng-template tuiExpandContent>
+                <ng-template>
                     <pre class="t-value">Form data: {{ testForm.value | json }}</pre>
                     <div
                         tuiGroup

--- a/projects/cdk/schematics/ng-update/constants/templates.ts
+++ b/projects/cdk/schematics/ng-update/constants/templates.ts
@@ -496,6 +496,10 @@ export const INPUTS_TO_REMOVE: InputToRemove[] = [
         inputName: 'tuiLabel',
         tags: ['label'],
     },
+    {
+        inputName: 'tuiExpandContent',
+        tags: ['ng-template'],
+    },
 ];
 
 export const TAGS_TO_REPLACE: ReplacementTags[] = [

--- a/projects/cdk/schematics/ng-update/tests/schematic-replace-html.spec.ts
+++ b/projects/cdk/schematics/ng-update/tests/schematic-replace-html.spec.ts
@@ -30,6 +30,12 @@ export class TestComponent {}
 `;
 
 const TEMPLATE_BEFORE = `
+<tui-expand [expanded]="expanded">
+    <ng-template tuiExpandContent>
+        <p>NOBODY expects the Spanish Inquisition!</p>
+    </ng-template>
+</tui-expand>
+
 <button
     tuiButton
     type="button"
@@ -189,6 +195,12 @@ const TEMPLATE_BEFORE = `
 `;
 
 const TEMPLATE_AFTER = `<!-- TODO: (Taiga UI migration) tuiFormatNumber pipe has new API. See https://taiga-ui.dev/pipes/format-number -->
+<tui-expand [expanded]="expanded">
+    <ng-template >
+        <p>NOBODY expects the Spanish Inquisition!</p>
+    </ng-template>
+</tui-expand>
+
 <button
     tuiButton
     type="button"

--- a/projects/core/components/expand/expand-content.directive.ts
+++ b/projects/core/components/expand/expand-content.directive.ts
@@ -1,7 +1,0 @@
-import {Directive} from '@angular/core';
-
-// @bad TODO: 3.0 Replace with PolymorpheusContent
-@Directive({
-    selector: `[tuiExpandContent]`,
-})
-export class TuiExpandContentDirective {}

--- a/projects/core/components/expand/expand.component.ts
+++ b/projects/core/components/expand/expand.component.ts
@@ -15,9 +15,7 @@ import {
 import {tuiDefaultProp, tuiIsCurrentTarget, tuiRequiredSetter} from '@taiga-ui/cdk';
 import {TUI_EXPAND_LOADED} from '@taiga-ui/core/constants';
 
-import {TuiExpandContentDirective} from './expand-content.directive';
-
-enum State {
+const enum State {
     Idle,
     Loading,
     Prepared,
@@ -29,8 +27,8 @@ const LOADER_HEIGHT = 48;
 @Component({
     selector: `tui-expand`,
     templateUrl: `./expand.template.html`,
-    changeDetection: ChangeDetectionStrategy.OnPush,
     styleUrls: [`./expand.style.less`],
+    changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TuiExpandComponent {
     @ViewChild(`wrapper`)
@@ -62,7 +60,7 @@ export class TuiExpandComponent {
         this.retrigger(this.async && expanded ? State.Loading : State.Animated);
     }
 
-    @ContentChild(TuiExpandContentDirective, {read: TemplateRef})
+    @ContentChild(TemplateRef)
     content: TemplateRef<NgIfContext<boolean>> | null = null;
 
     @HostBinding(`class._expanded`)

--- a/projects/core/components/expand/expand.module.ts
+++ b/projects/core/components/expand/expand.module.ts
@@ -3,11 +3,10 @@ import {NgModule} from '@angular/core';
 import {TuiLoaderModule} from '@taiga-ui/core/components/loader';
 
 import {TuiExpandComponent} from './expand.component';
-import {TuiExpandContentDirective} from './expand-content.directive';
 
 @NgModule({
     imports: [CommonModule, TuiLoaderModule],
-    declarations: [TuiExpandComponent, TuiExpandContentDirective],
-    exports: [TuiExpandComponent, TuiExpandContentDirective],
+    declarations: [TuiExpandComponent],
+    exports: [TuiExpandComponent],
 })
 export class TuiExpandModule {}

--- a/projects/core/components/expand/index.ts
+++ b/projects/core/components/expand/index.ts
@@ -1,3 +1,2 @@
 export * from './expand.component';
 export * from './expand.module';
-export * from './expand-content.directive';

--- a/projects/core/components/expand/test/expand.component.spec.ts
+++ b/projects/core/components/expand/test/expand.component.spec.ts
@@ -12,7 +12,7 @@ describe(`expand`, () => {
                 [async]="async"
                 [expanded]="expanded"
             >
-                <ng-template tuiExpandContent>
+                <ng-template>
                     <div #content>content</div>
                 </ng-template>
             </tui-expand>

--- a/projects/demo/src/modules/components/expand/examples/1/index.html
+++ b/projects/demo/src/modules/components/expand/examples/1/index.html
@@ -10,7 +10,7 @@
     Show/Hide
 </button>
 <tui-expand [expanded]="expanded">
-    <ng-template tuiExpandContent>
+    <ng-template>
         <p>NOBODY expects the Spanish Inquisition!</p>
     </ng-template>
 </tui-expand>

--- a/projects/demo/src/modules/components/expand/examples/import/insert-template.md
+++ b/projects/demo/src/modules/components/expand/examples/import/insert-template.md
@@ -1,5 +1,5 @@
 ```html
 <tui-expand [expanded]="expanded">
-  <ng-template tuiExpandContent>...</ng-template>
+  <ng-template>...</ng-template>
 </tui-expand>
 ```

--- a/projects/demo/src/modules/components/expand/expand.template.html
+++ b/projects/demo/src/modules/components/expand/expand.template.html
@@ -23,7 +23,7 @@
             [expanded]="expanded"
             [async]="async"
         >
-            <ng-template tuiExpandContent>
+            <ng-template>
                 <div *ngIf="!delayed">
                     <p>Luke's father.</p>
                     <p class="tooltip">

--- a/projects/kit/components/accordion/accordion-item/accordion-item.template.html
+++ b/projects/kit/components/accordion/accordion-item/accordion-item.template.html
@@ -34,13 +34,7 @@
         [async]="async"
         [expanded]="open"
     >
-        <div
-            *ngIf="eagerContent"
-            class="t-content"
-        >
-            <ng-content select="[tuiAccordionItemContent]"></ng-content>
-        </div>
-        <ng-template tuiExpandContent>
+        <ng-template>
             <div
                 *ngIf="lazyContent"
                 automation-id="tui-accordion__item-content"
@@ -51,5 +45,11 @@
                 </ng-container>
             </div>
         </ng-template>
+        <div
+            *ngIf="eagerContent"
+            class="t-content"
+        >
+            <ng-content select="[tuiAccordionItemContent]"></ng-content>
+        </div>
     </tui-expand>
 </div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #2497

## What is the new behavior?

```html
<tui-expand [expanded]="expanded">
  <!-- 
    By default, the expansion panel content will be initialized 
    even when the panel is closed.  
  -->
  Hello world
</tui-expand>

<tui-expand [expanded]="expanded">
  <!-- 
     To instead defer initialization until the panel is open, 
     the content should be provided as an ng-template:
   -->
  <ng-template>Hello world</ng-template>
</tui-expand>
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
