### PR TITLE
chore(demo): `Changelog` update description of `3.0.0`-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,217 +7,75 @@ All notable changes to this project will be documented in this file. See
 
 ### ⚠ BREAKING CHANGES
 
-- **cdk:** rename `TuiAbstractTextfieldHost` to `AbstractTuiTextfieldHost` (#2492)
-- **core:** remove `tuiExpandContent` directive (#2501)
-- **kit:** `Action` better customization + new API (#2505)
-- **cdk:** `Let` directive can possibility emit `null` (#2496)
-- **core:** `HintDescribe` add new directive (#2495)
-- remove autofill enums (#2500)
-- **core:** `HintController` remove separate module (#2484)
-- remove legacy directives from textfield controller (#2410)
-- delete `tui-palette.less` (`data-tui-background` and `data-tui-color` states) (#2473)
-- **kit:** `Action` refactor to `button[tuiAction], a[tuiAction]` (#2479)
-- **cdk:** add configuration to `tuiGetClosestFocusableElement` (#2436)
-- **cdk:** add configuration to `tuiGetClosestFocusableElement` (#2436)
-- `Stepper` rename `state` input to avoid collision with `routerLink` (#2437)
-- **core:** `Dropdown` refactor dropdowns completely (#2389)
-- **core:** new names of css breakpoints (#2393)
-- update supported browser versions (bump supported `Safari` to `12.1+`) (#2391)
-- add `@taiga-ui/styles` (#2320)
-- `AlertComponent` use new context (#2362)
-- remove deprecations (#2327)
-- drop support of legacy not-chromium Edge (EdgeHTML)
-- **core:** `tuiFormatNumber(value, configs)` new function signature (#2309)
-- **kit:** `DataListDropdownManager` move into separate module (#2317)
-- **kit:** `Slider[keySteps]` update control value on `input` event (+ delete `keyStepsInput`)
-- **cdk:** `PortalService` switch to using `PolymorpheusComponent`
-- remove deprecated entities (#2296)
-- move some i18n tokens to secondary package
-- move all color-converter utils (`addon-editor` / `addon-doc` => `cdk`) (#2280)
-- replace `setNativeFocused(el)` with `el.focus()` (#2276)
-- remove redundant export of providers' factories (#2278)
-- remove some deprecations (#2272)
-- remove deprecated functions without `tui`-prefix
-- remove deprecated functions without `tui`-prefix
-- remove redundant exports of internal functions (reduction of public API) (#2253)
-- **kit:** `Range` remove all deprecated API (#2243)
-- remove deprecated pluralize (#2222)
-- **kit:** `Slider` | `InputSlider` | `Range` | `InputRange` use strict version of `TuiKeySteps` (#2220)
-- **kit:** `InputRange` remove all deprecated API (#2215)
-- remove deprecated core-enums, TuiColor, colorFallback, DEFAULT_COLORS, TuiColorHandler (#2158)
-- **kit:** `InputSlider` remove all deprecated API (#2207)
-- `Range` remove deprecated API for labels of segments (#2200)
-- delete legacy `<tui-slider />` (#2184)
-- remove date-time related deprecations, EMPTY_VALIDATOR (#2164)
-- move fonts to separate file (#2132)
-- remove deprecated properties from `AbstractTuiInteractive` (#2124)
-- update to Angular 12 (#2110)
-- remove tui-wrapper, tui-group, table-mode, field-error component, tui-breadcrumb items (#2121)
-- remove deprecated entities (#2108)
-- **addon-commerce, addon-chart:** remove deprecated enums (#2095)
-- update to Angular 11 (#2097)
-- **kit:** remove deprecated TUI_MOBILE_AWARE (#2099)
-- **kit,cdk:** remove deprecated enums, input-file (#2087)
-- remove TuiPortalService, PreviewDialogService and open method in TuiCodeEditor (#2079)
-- exported from the top-level library entrypoint for compat ivy renderer (#2086)
-- update to Angular 10 (#2080)
-- enable ivy by default (#2076)
-- replace deprecated directives with universal `tuiItem`-directive (#2069)
-- **cdk,core:** allow passing icons at both sides simultaneously in textfield components (#2037)
-- remove deprecated `tuiCustomEvents`, `tuiPadStart`, `getClosestElement`, `fallbackValue` (#2074)
-
-### Features
-
-- `Range` remove deprecated API for labels of segments ([#2200](https://github.com/tinkoff/taiga-ui/issues/2200))
-  ([5c02bdf](https://github.com/tinkoff/taiga-ui/commit/5c02bdfac1942de098eb97709e20cc6f7a0c8341))
-- add `@taiga-ui/styles` ([#2320](https://github.com/tinkoff/taiga-ui/issues/2320))
-  ([d1a40a5](https://github.com/tinkoff/taiga-ui/commit/d1a40a5c1a0f1b52a023d653ce2053294ec6e4a0))
-- **cdk,core:** allow passing icons at both sides simultaneously in textfield components
-  ([#2037](https://github.com/tinkoff/taiga-ui/issues/2037))
-  ([0ee6ebb](https://github.com/tinkoff/taiga-ui/commit/0ee6ebb5146983943e47fb0a4cb570ff02755b46))
-- **cdk:** `PortalService` switch to using `PolymorpheusComponent`
-  ([87f85a7](https://github.com/tinkoff/taiga-ui/commit/87f85a796bd2e43680c65d1993a3b6c775b4ff6b))
-- **cdk:** add configuration to `tuiGetClosestFocusableElement`
-  ([#2436](https://github.com/tinkoff/taiga-ui/issues/2436))
-  ([a9dfb27](https://github.com/tinkoff/taiga-ui/commit/a9dfb2775bc26b736abf274c13d66cec0d687e31))
-- **cdk:** add configuration to `tuiGetClosestFocusableElement`
-  ([#2436](https://github.com/tinkoff/taiga-ui/issues/2436))
-  ([26eec2c](https://github.com/tinkoff/taiga-ui/commit/26eec2cc96e6bf17550abc12aabbece97b3397d4))
-- **cdk:** rename `TuiAbstractTextfieldHost` to `AbstractTuiTextfieldHost`
-  ([#2492](https://github.com/tinkoff/taiga-ui/issues/2492))
-  ([11d6e75](https://github.com/tinkoff/taiga-ui/commit/11d6e75f63a766aa27ac59c584ca57acc3bfef32))
-- **core:** `Dropdown` refactor dropdowns completely ([#2389](https://github.com/tinkoff/taiga-ui/issues/2389))
-  ([d3c9deb](https://github.com/tinkoff/taiga-ui/commit/d3c9deb7b1061e50d98691d36b75c092c900e282))
-- **core:** `Hint` add context input ([#2273](https://github.com/tinkoff/taiga-ui/issues/2273))
-  ([433b2a5](https://github.com/tinkoff/taiga-ui/commit/433b2a50a3e56a1311a5eb1ee9f9622a756f8e8f))
-- **core:** `Hint` support 12 directions ([#2256](https://github.com/tinkoff/taiga-ui/issues/2256))
-  ([b81a213](https://github.com/tinkoff/taiga-ui/commit/b81a21332ec1fa2dc8415942e1c318a489b24644))
-- **core:** `HintDescribe` add new directive ([#2495](https://github.com/tinkoff/taiga-ui/issues/2495))
-  ([78f090b](https://github.com/tinkoff/taiga-ui/commit/78f090b6c126ecbc34937ca74613bc0af5f093c1))
-- **core:** new names of css breakpoints ([#2393](https://github.com/tinkoff/taiga-ui/issues/2393))
-  ([f6b1efa](https://github.com/tinkoff/taiga-ui/commit/f6b1efa61c85e365838c55be64b6c6a7bb975374))
+- Update to Angular 12 ([#2080](https://github.com/tinkoff/taiga-ui/issues/2080),
+  [#2097](https://github.com/tinkoff/taiga-ui/issues/2097), [#2110](https://github.com/tinkoff/taiga-ui/issues/2110)).
+  Enable `Ivy` by default ([#2076](https://github.com/tinkoff/taiga-ui/issues/2076)). Drop legacy `View Engine`-support.
+- Migrate to [Polymorpheus](https://github.com/Tinkoff/ng-polymorpheus) 4.x.x
+  ([#2165](https://github.com/tinkoff/taiga-ui/issues/2165)).
+- Update supported browser versions. Drop support of legacy not-chromium Edge (EdgeHTML)
+  ([#2318](https://github.com/tinkoff/taiga-ui/issues/2318)). Bump supported `Safari` to `12.1+`
+  ([#2391](https://github.com/tinkoff/taiga-ui/issues/2391)).
+- All exported entities without `tui`-prefix was renamed to the same one with prefix: functions, constants, pipes,
+  classes, etc.
+- **styles:** move all global styles from `@taiga-ui/core` to new optional package `@taiga-ui/styles`
+  ([#2320](https://github.com/tinkoff/taiga-ui/issues/2320)). Delete `tui-palette.less` (`data-tui-background` and
+  `data-tui-color` global states) ([#2473](https://github.com/tinkoff/taiga-ui/issues/2473)).
+- **core:** `Dropdown` refactor dropdowns completely ([#2389](https://github.com/tinkoff/taiga-ui/issues/2389)).
+- **kit:** remove legacy `InputFile` component ([#2087](https://github.com/tinkoff/taiga-ui/issues/2087)). Use new
+  `InputFiles` component instead.
+- **core:** `Hint` support 12 directions ([#2256](https://github.com/tinkoff/taiga-ui/issues/2256)). Add context input
+  ([#2273](https://github.com/tinkoff/taiga-ui/issues/2273)). Add new directive `HintDescribe`
+  ([#2495](https://github.com/tinkoff/taiga-ui/issues/2495)). `HintController` remove separate module (move inside
+  `TuiHintModule`) ([#2484](https://github.com/tinkoff/taiga-ui/issues/2484)).
+- **core:** `TuiTextfieldController` delete `tuiTextfieldAutocomplete`, `tuiTextfieldExampleText`,
+  `tuiTextfieldInputMode`, `tuiTextfieldMaxLength`, `tuiTextfieldType`
+  ([#2410](https://github.com/tinkoff/taiga-ui/issues/2410)) in favor of native input alternatives. Allow passing icons
+  at both sides simultaneously in textfield components ([#2037](https://github.com/tinkoff/taiga-ui/issues/2037)).
+- **kit:** `Slider` | `InputSlider` | `Range` | `InputRange` drop all deprecated API
+  ([#2200](https://github.com/tinkoff/taiga-ui/issues/2200), [#2207](https://github.com/tinkoff/taiga-ui/issues/2207),
+  [#2215](https://github.com/tinkoff/taiga-ui/issues/2215), [#2243](https://github.com/tinkoff/taiga-ui/issues/2243)).
+  Use strict version of `TuiKeySteps` ([#2220](https://github.com/tinkoff/taiga-ui/issues/2220)). Delete legacy
+  `<tui-slider />` ([#2184](https://github.com/tinkoff/taiga-ui/issues/2184)).
+- **kit:** `Action` new selector `button[tuiAction], a[tuiAction]`
+  ([#2479](https://github.com/tinkoff/taiga-ui/issues/2479)). Better customization + new API
+  ([#2505](https://github.com/tinkoff/taiga-ui/issues/2505))
+- **kit:** `Stepper` rename `state` input (=> `stepState`) to avoid collision with `routerLink`
+  ([#2437](https://github.com/tinkoff/taiga-ui/issues/2437)).
 - **core:** remove `tuiExpandContent` directive ([#2501](https://github.com/tinkoff/taiga-ui/issues/2501))
-  ([8ef2214](https://github.com/tinkoff/taiga-ui/commit/8ef2214529664c06a1ab48050aa662f743ae6220))
-- delete `tui-palette.less` (`data-tui-background` and `data-tui-color` states)
-  ([#2473](https://github.com/tinkoff/taiga-ui/issues/2473))
-  ([09067a2](https://github.com/tinkoff/taiga-ui/commit/09067a2d9ed92e2bdbb866d4a88b5c6c82066794))
-- delete legacy `<tui-slider />` ([#2184](https://github.com/tinkoff/taiga-ui/issues/2184))
-  ([92fbd92](https://github.com/tinkoff/taiga-ui/commit/92fbd92207b624a822d6819bd9c419803209fa8e))
-- drop support of legacy not-chromium Edge (EdgeHTML)
-  ([d7ac492](https://github.com/tinkoff/taiga-ui/commit/d7ac492c4bcb80bb06c66deba49bccd23a563d13))
-- enable ivy by default ([#2076](https://github.com/tinkoff/taiga-ui/issues/2076))
-  ([6f93455](https://github.com/tinkoff/taiga-ui/commit/6f93455cb72d57d4c2a3fa4671f05fcc890812a1))
-- **kit:** `Action` better customization + new API ([#2505](https://github.com/tinkoff/taiga-ui/issues/2505))
-  ([669a49d](https://github.com/tinkoff/taiga-ui/commit/669a49dbdedebca876999e433872d9ea2e62ef2e))
 - **kit:** `DataListDropdownManager` move into separate module
   ([#2317](https://github.com/tinkoff/taiga-ui/issues/2317))
-  ([2d4620f](https://github.com/tinkoff/taiga-ui/commit/2d4620ffbe12a0884df2b2702d3dbc283501b162))
-- **kit:** `InputRange` remove all deprecated API ([#2215](https://github.com/tinkoff/taiga-ui/issues/2215))
-  ([81430fe](https://github.com/tinkoff/taiga-ui/commit/81430fee88f6295748e2b35521353dac4817ebd7))
-- **kit:** `InputSlider` remove all deprecated API ([#2207](https://github.com/tinkoff/taiga-ui/issues/2207))
-  ([7e37604](https://github.com/tinkoff/taiga-ui/commit/7e37604cc785bcdf611af7ef2da0b3378605b7f4))
-- **kit:** `Range` remove all deprecated API ([#2243](https://github.com/tinkoff/taiga-ui/issues/2243))
-  ([a990c64](https://github.com/tinkoff/taiga-ui/commit/a990c6426da1a5e1ce6e18f249844b9401141cd5))
-- **kit:** `Slider` | `InputSlider` | `Range` | `InputRange` use strict version of `TuiKeySteps`
-  ([#2220](https://github.com/tinkoff/taiga-ui/issues/2220))
-  ([4ab3922](https://github.com/tinkoff/taiga-ui/commit/4ab3922013b6e9e6d7bc63367e143278ddb574a3))
-- migrate to polymorpheus 4 and update other deps ([#2165](https://github.com/tinkoff/taiga-ui/issues/2165))
-  ([cb86c77](https://github.com/tinkoff/taiga-ui/commit/cb86c77502cf9abdfdb87b598efc94cc2be1e9f0))
-- move all color-converter utils (`addon-editor` / `addon-doc` => `cdk`)
-  ([#2280](https://github.com/tinkoff/taiga-ui/issues/2280))
-  ([6637417](https://github.com/tinkoff/taiga-ui/commit/663741723af53b247bb847540b4482afc3c65124))
-- replace deprecated directives with universal `tuiItem`-directive
+- **cdk:** `Let` directive can emit `null` ([#2496](https://github.com/tinkoff/taiga-ui/issues/2496))
+- **cdk:** remove deprecated `setNativeFocused`,`tuiCustomEvents`, `tuiPadStart`, `getClosestElement`, `fallbackValue`
+  ([#2074](https://github.com/tinkoff/taiga-ui/issues/2074), [#2276](https://github.com/tinkoff/taiga-ui/issues/2276)).
+  Use native alternatives.
+- **core:** `tuiFormatNumber(value, configs)` new function signature
+  ([#2309](https://github.com/tinkoff/taiga-ui/issues/2309))
+- **cdk:** `tuiGetClosestFocusableElement(configs)` new function signature
+  ([#2436](https://github.com/tinkoff/taiga-ui/issues/2436))
+- **core:** new names of css breakpoints ([#2393](https://github.com/tinkoff/taiga-ui/issues/2393)).
+- **core:** remove deprecated pluralize ([#2222](https://github.com/tinkoff/taiga-ui/issues/2222)). Use Angular built-in
+  [I18nPluralPipe](https://angular.io/api/common/I18nPluralPipe).
+- **core:** move fonts to separate file `taiga-ui-fonts.less` ([#2132](https://github.com/tinkoff/taiga-ui/issues/2132))
+- Replace deprecated directives (`*tuiTab`, `*tuiBreadcrumb`,`[tuiToolbarTool]`) with universal `tuiItem`-directive
   ([#2069](https://github.com/tinkoff/taiga-ui/issues/2069))
-  ([d806829](https://github.com/tinkoff/taiga-ui/commit/d806829d58085933d80ed75029f8dd8280b01b42))
-- update supported browser versions (bump supported `Safari` to `12.1+`)
-  ([#2391](https://github.com/tinkoff/taiga-ui/issues/2391))
-  ([7bf6e2a](https://github.com/tinkoff/taiga-ui/commit/7bf6e2afa4d6d4ea76993686fa519be837711446))
-- update to Angular 10 ([#2080](https://github.com/tinkoff/taiga-ui/issues/2080))
-  ([176c70d](https://github.com/tinkoff/taiga-ui/commit/176c70d67d150fed44038b0fa5c067bca19fd66a))
-- update to Angular 11 ([#2097](https://github.com/tinkoff/taiga-ui/issues/2097))
-  ([a698286](https://github.com/tinkoff/taiga-ui/commit/a69828616be4fd3dd9711ca8a7ee107c924baf62))
-- update to Angular 12 ([#2110](https://github.com/tinkoff/taiga-ui/issues/2110))
-  ([6f57462](https://github.com/tinkoff/taiga-ui/commit/6f5746229fc2888d7e6e7478c56b314a5c2b6317))
+- Move all color-converter utils (`addon-editor` / `addon-doc` => `cdk`)
+  ([#2280](https://github.com/tinkoff/taiga-ui/issues/2280))
+- Remove `tui-wrapper`, `tui-group`, `table-mode`, `field-error` component, `tui-breadcrumb` items
+  ([#2121](https://github.com/tinkoff/taiga-ui/issues/2121)).
+- **kit:** remove deprecated `TUI_MOBILE_AWARE` ([#2099](https://github.com/tinkoff/taiga-ui/issues/2099)).
+- **core:** `AlertComponent` use new context ([#2362](https://github.com/tinkoff/taiga-ui/issues/2362))
+- **cdk:** `PortalService` switch to using `PolymorpheusComponent`
+- **addon-commerce, addon-chart:** remove deprecated enums ([#2095](https://github.com/tinkoff/taiga-ui/issues/2095))
+- remove deprecated core-enums, `TuiColor`, `colorFallback`, `DEFAULT_COLORS`, `TuiColorHandler`
+  ([#2158](https://github.com/tinkoff/taiga-ui/issues/2158))
+- remove date-time related deprecations, `EMPTY_VALIDATOR` ([#2164](https://github.com/tinkoff/taiga-ui/issues/2164))
+- remove deprecated properties from `AbstractTuiInteractive` ([#2124](https://github.com/tinkoff/taiga-ui/issues/2124))
+- remove autofill enums ([#2500](https://github.com/tinkoff/taiga-ui/issues/2500)).
 
 ### Bug Fixes
 
-- **cdk:** `Let` directive can possibility emit `null` ([#2496](https://github.com/tinkoff/taiga-ui/issues/2496))
-  ([ca6af75](https://github.com/tinkoff/taiga-ui/commit/ca6af75112dc9bf9960842d3a8cc7069a6938a69))
 - **core:** prevent injection conflict with CSS global interface
   ([#2508](https://github.com/tinkoff/taiga-ui/issues/2508))
-  ([60bd130](https://github.com/tinkoff/taiga-ui/commit/60bd13052d9dfb33057326b1e4f02961518ea3cd))
-- exported from the top-level library entrypoint for compat ivy renderer
-  ([#2086](https://github.com/tinkoff/taiga-ui/issues/2086))
-  ([95e0d22](https://github.com/tinkoff/taiga-ui/commit/95e0d221b948327f9b984493ce6c3dcf0fe03097))
-
-### refactor
-
-- `AlertComponent` use new context ([#2362](https://github.com/tinkoff/taiga-ui/issues/2362))
-  ([12ada74](https://github.com/tinkoff/taiga-ui/commit/12ada74caeec111d4f330c40b7ae889b36d0f020))
-- `Stepper` rename `state` input to avoid collision with `routerLink`
-  ([#2437](https://github.com/tinkoff/taiga-ui/issues/2437))
-  ([84ce535](https://github.com/tinkoff/taiga-ui/commit/84ce535e94cb2192d3fb2e7524f02a3e8bb08268))
-- **addon-commerce, addon-chart:** remove deprecated enums ([#2095](https://github.com/tinkoff/taiga-ui/issues/2095))
-  ([cc4fac4](https://github.com/tinkoff/taiga-ui/commit/cc4fac403bcb5d6274c12e375a48f18767543afb))
-- **core:** `HintController` remove separate module ([#2484](https://github.com/tinkoff/taiga-ui/issues/2484))
-  ([ab6881f](https://github.com/tinkoff/taiga-ui/commit/ab6881f2cd53e1942c8ed6b102e29548f3e5ce1b))
-- **core:** `tuiFormatNumber(value, configs)` new function signature
-  ([#2309](https://github.com/tinkoff/taiga-ui/issues/2309))
-  ([6a8422e](https://github.com/tinkoff/taiga-ui/commit/6a8422ef69df8cdeda252fac176ca62ebd99bad1))
-- **kit,cdk:** remove deprecated enums, input-file ([#2087](https://github.com/tinkoff/taiga-ui/issues/2087))
-  ([ac273d0](https://github.com/tinkoff/taiga-ui/commit/ac273d058ca29f48e1ec6ca41bc943733a61acb6))
-- **kit:** `Action` refactor to `button[tuiAction], a[tuiAction]`
-  ([#2479](https://github.com/tinkoff/taiga-ui/issues/2479))
-  ([059d7af](https://github.com/tinkoff/taiga-ui/commit/059d7af3a2536705ba21ad8adcd4f53627b62e77))
-- **kit:** `Slider[keySteps]` update control value on `input` event (+ delete `keyStepsInput`)
-  ([5944fa3](https://github.com/tinkoff/taiga-ui/commit/5944fa35743fcfe41d284419b2dced1426d8b0f7))
-- **kit:** remove deprecated TUI_MOBILE_AWARE ([#2099](https://github.com/tinkoff/taiga-ui/issues/2099))
-  ([9bc7a08](https://github.com/tinkoff/taiga-ui/commit/9bc7a089e1adad0ef477ccf450c924736b3fb43b))
-- move fonts to separate file ([#2132](https://github.com/tinkoff/taiga-ui/issues/2132))
-  ([3fb34b2](https://github.com/tinkoff/taiga-ui/commit/3fb34b2b29ba09bbd6ab28e8cf3395d565ef3e9c))
-- move some i18n tokens to secondary package
-  ([f51c380](https://github.com/tinkoff/taiga-ui/commit/f51c380fc20d374b633cba77e3d1159ec66a1eb9))
-- remove autofill enums ([#2500](https://github.com/tinkoff/taiga-ui/issues/2500))
-  ([7e6bd9f](https://github.com/tinkoff/taiga-ui/commit/7e6bd9f6db1281be99fdd25bd84a1ec6edf39140))
-- remove date-time related deprecations, EMPTY_VALIDATOR ([#2164](https://github.com/tinkoff/taiga-ui/issues/2164))
-  ([c75985a](https://github.com/tinkoff/taiga-ui/commit/c75985a757c6ad30fb71aa35c7bf0670d7b7399b))
-- remove deprecated `tuiCustomEvents`, `tuiPadStart`, `getClosestElement`, `fallbackValue`
-  ([#2074](https://github.com/tinkoff/taiga-ui/issues/2074))
-  ([9ecc696](https://github.com/tinkoff/taiga-ui/commit/9ecc69693f8e9f66ef4d22cf9ad6cca039f2e0e9))
-- remove deprecated core-enums, TuiColor, colorFallback, DEFAULT_COLORS, TuiColorHandler
-  ([#2158](https://github.com/tinkoff/taiga-ui/issues/2158))
-  ([5146c71](https://github.com/tinkoff/taiga-ui/commit/5146c711578db1eee383fda8f2dcfef4d626fc8b))
-- remove deprecated entities ([#2108](https://github.com/tinkoff/taiga-ui/issues/2108))
-  ([dfe13a8](https://github.com/tinkoff/taiga-ui/commit/dfe13a8afb56f452dc68a06d097551ab394ee86b))
-- remove deprecated entities ([#2296](https://github.com/tinkoff/taiga-ui/issues/2296))
-  ([1d4d867](https://github.com/tinkoff/taiga-ui/commit/1d4d867af4e93b5e0b51275c0fa1b127bd9e2a1a))
-- remove deprecated functions without `tui`-prefix
-  ([e8f7860](https://github.com/tinkoff/taiga-ui/commit/e8f78609ca33673edd350595889711cc32208a14))
-- remove deprecated functions without `tui`-prefix
-  ([bc05f71](https://github.com/tinkoff/taiga-ui/commit/bc05f7132fafcd5f70993351cde01fa5426ef563))
-- remove deprecated pluralize ([#2222](https://github.com/tinkoff/taiga-ui/issues/2222))
-  ([bc7ae3d](https://github.com/tinkoff/taiga-ui/commit/bc7ae3df9e052584715fa66f416c9bcdda45d0b7))
-- remove deprecated properties from `AbstractTuiInteractive` ([#2124](https://github.com/tinkoff/taiga-ui/issues/2124))
-  ([7b814e7](https://github.com/tinkoff/taiga-ui/commit/7b814e76b612662220e5f901fdfbf59380da9cee))
-- remove deprecations ([#2327](https://github.com/tinkoff/taiga-ui/issues/2327))
-  ([1d5a1e4](https://github.com/tinkoff/taiga-ui/commit/1d5a1e4ac5294cde7c9f2575cc12cd83af49e6f4))
-- remove legacy directives from textfield controller ([#2410](https://github.com/tinkoff/taiga-ui/issues/2410))
-  ([b36c38b](https://github.com/tinkoff/taiga-ui/commit/b36c38b30a066958f89633f4c943b524bec484d9))
-- remove redundant export of providers' factories ([#2278](https://github.com/tinkoff/taiga-ui/issues/2278))
-  ([2e4bc8b](https://github.com/tinkoff/taiga-ui/commit/2e4bc8b2ec03378ec3a1ff752a246f11cb833e77))
-- remove redundant exports of internal functions (reduction of public API)
-  ([#2253](https://github.com/tinkoff/taiga-ui/issues/2253))
-  ([80becef](https://github.com/tinkoff/taiga-ui/commit/80becef86a5fa662af29c061aa268d58da2ebf2a))
-- remove some deprecations ([#2272](https://github.com/tinkoff/taiga-ui/issues/2272))
-  ([8e9d85f](https://github.com/tinkoff/taiga-ui/commit/8e9d85fecb04415574ccf1dd0ac9a8ba480e1161))
-- remove tui-wrapper, tui-group, table-mode, field-error component, tui-breadcrumb items
-  ([#2121](https://github.com/tinkoff/taiga-ui/issues/2121))
-  ([d404684](https://github.com/tinkoff/taiga-ui/commit/d404684664e93497e5ebaba5f3080fd7d03c9b4c))
-- remove TuiPortalService, PreviewDialogService and open method in TuiCodeEditor
-  ([#2079](https://github.com/tinkoff/taiga-ui/issues/2079))
-  ([39da3cd](https://github.com/tinkoff/taiga-ui/commit/39da3cd20842e24d84441910e1807ecf84d4e740))
-- replace `setNativeFocused(el)` with `el.focus()` ([#2276](https://github.com/tinkoff/taiga-ui/issues/2276))
-  ([841060b](https://github.com/tinkoff/taiga-ui/commit/841060b3204df55d17a5dc33090b0ec31d01900e))
 
 ### [2.62.1](https://github.com/tinkoff/taiga-ui/compare/v2.62.0...v2.62.1) (2022-08-29)
 


### PR DESCRIPTION
## [3.0.0](https://github.com/tinkoff/taiga-ui/compare/v2.62.1...v3.0.0) (2022-08-30)

### ⚠ BREAKING CHANGES

- Update to Angular 12 ([#2080](https://github.com/tinkoff/taiga-ui/issues/2080),
  [#2097](https://github.com/tinkoff/taiga-ui/issues/2097), [#2110](https://github.com/tinkoff/taiga-ui/issues/2110)).
  Enable `Ivy` by default ([#2076](https://github.com/tinkoff/taiga-ui/issues/2076)). Drop legacy `View Engine`-support.
- Migrate to [Polymorpheus](https://github.com/Tinkoff/ng-polymorpheus) 4.x.x
  ([#2165](https://github.com/tinkoff/taiga-ui/issues/2165)).
- Update supported browser versions. Drop support of legacy not-chromium Edge (EdgeHTML)
  ([#2318](https://github.com/tinkoff/taiga-ui/issues/2318)). Bump supported `Safari` to `12.1+`
  ([#2391](https://github.com/tinkoff/taiga-ui/issues/2391)).
- All exported entities without `tui`-prefix was renamed to the same one with prefix: functions, constants, pipes,
  classes, etc.
- **styles:** move all global styles from `@taiga-ui/core` to new optional package `@taiga-ui/styles`
  ([#2320](https://github.com/tinkoff/taiga-ui/issues/2320)). Delete `tui-palette.less` (`data-tui-background` and
  `data-tui-color` global states) ([#2473](https://github.com/tinkoff/taiga-ui/issues/2473)).
- **core:** `Dropdown` refactor dropdowns completely ([#2389](https://github.com/tinkoff/taiga-ui/issues/2389)).
- **kit:** remove legacy `InputFile` component ([#2087](https://github.com/tinkoff/taiga-ui/issues/2087)). Use new
  `InputFiles` component instead.
- **core:** `Hint` support 12 directions ([#2256](https://github.com/tinkoff/taiga-ui/issues/2256)). Add context input
  ([#2273](https://github.com/tinkoff/taiga-ui/issues/2273)). Add new directive `HintDescribe`
  ([#2495](https://github.com/tinkoff/taiga-ui/issues/2495)). `HintController` remove separate module (move inside
  `TuiHintModule`) ([#2484](https://github.com/tinkoff/taiga-ui/issues/2484)).
- **core:** `TuiTextfieldController` delete `tuiTextfieldAutocomplete`, `tuiTextfieldExampleText`,
  `tuiTextfieldInputMode`, `tuiTextfieldMaxLength`, `tuiTextfieldType`
  ([#2410](https://github.com/tinkoff/taiga-ui/issues/2410)) in favor of native input alternatives. Allow passing icons
  at both sides simultaneously in textfield components ([#2037](https://github.com/tinkoff/taiga-ui/issues/2037)).
- **kit:** `Slider` | `InputSlider` | `Range` | `InputRange` drop all deprecated API
  ([#2200](https://github.com/tinkoff/taiga-ui/issues/2200), [#2207](https://github.com/tinkoff/taiga-ui/issues/2207),
  [#2215](https://github.com/tinkoff/taiga-ui/issues/2215), [#2243](https://github.com/tinkoff/taiga-ui/issues/2243)).
  Use strict version of `TuiKeySteps` ([#2220](https://github.com/tinkoff/taiga-ui/issues/2220)). Delete legacy
  `<tui-slider />` ([#2184](https://github.com/tinkoff/taiga-ui/issues/2184)).
- **kit:** `Action` new selector `button[tuiAction], a[tuiAction]`
  ([#2479](https://github.com/tinkoff/taiga-ui/issues/2479)). Better customization + new API
  ([#2505](https://github.com/tinkoff/taiga-ui/issues/2505))
- **kit:** `Stepper` rename `state` input (=> `stepState`) to avoid collision with `routerLink`
  ([#2437](https://github.com/tinkoff/taiga-ui/issues/2437)).
- **core:** remove `tuiExpandContent` directive ([#2501](https://github.com/tinkoff/taiga-ui/issues/2501))
- **kit:** `DataListDropdownManager` move into separate module
  ([#2317](https://github.com/tinkoff/taiga-ui/issues/2317))
- **cdk:** `Let` directive can emit `null` ([#2496](https://github.com/tinkoff/taiga-ui/issues/2496))
- **cdk:** remove deprecated `setNativeFocused`,`tuiCustomEvents`, `tuiPadStart`, `getClosestElement`, `fallbackValue`
  ([#2074](https://github.com/tinkoff/taiga-ui/issues/2074), [#2276](https://github.com/tinkoff/taiga-ui/issues/2276)).
  Use native alternatives.
- **core:** `tuiFormatNumber(value, configs)` new function signature
  ([#2309](https://github.com/tinkoff/taiga-ui/issues/2309))
- **cdk:** `tuiGetClosestFocusableElement(configs)` new function signature
  ([#2436](https://github.com/tinkoff/taiga-ui/issues/2436))
- **core:** new names of css breakpoints ([#2393](https://github.com/tinkoff/taiga-ui/issues/2393)).
- **core:** remove deprecated pluralize ([#2222](https://github.com/tinkoff/taiga-ui/issues/2222)). Use Angular built-in
  [I18nPluralPipe](https://angular.io/api/common/I18nPluralPipe).
- **core:** move fonts to separate file `taiga-ui-fonts.less` ([#2132](https://github.com/tinkoff/taiga-ui/issues/2132))
- Replace deprecated directives (`*tuiTab`, `*tuiBreadcrumb`,`[tuiToolbarTool]`) with universal `tuiItem`-directive
  ([#2069](https://github.com/tinkoff/taiga-ui/issues/2069))
- Move all color-converter utils (`addon-editor` / `addon-doc` => `cdk`)
  ([#2280](https://github.com/tinkoff/taiga-ui/issues/2280))
- Remove `tui-wrapper`, `tui-group`, `table-mode`, `field-error` component, `tui-breadcrumb` items
  ([#2121](https://github.com/tinkoff/taiga-ui/issues/2121)).
- **kit:** remove deprecated `TUI_MOBILE_AWARE` ([#2099](https://github.com/tinkoff/taiga-ui/issues/2099)).
- **core:** `AlertComponent` use new context ([#2362](https://github.com/tinkoff/taiga-ui/issues/2362))
- **cdk:** `PortalService` switch to using `PolymorpheusComponent`
- **addon-commerce, addon-chart:** remove deprecated enums ([#2095](https://github.com/tinkoff/taiga-ui/issues/2095))
- remove deprecated core-enums, `TuiColor`, `colorFallback`, `DEFAULT_COLORS`, `TuiColorHandler`
  ([#2158](https://github.com/tinkoff/taiga-ui/issues/2158))
- remove date-time related deprecations, `EMPTY_VALIDATOR` ([#2164](https://github.com/tinkoff/taiga-ui/issues/2164))
- remove deprecated properties from `AbstractTuiInteractive` ([#2124](https://github.com/tinkoff/taiga-ui/issues/2124))
- remove autofill enums ([#2500](https://github.com/tinkoff/taiga-ui/issues/2500)).

### Bug Fixes

- **core:** prevent injection conflict with CSS global interface
  ([#2508](https://github.com/tinkoff/taiga-ui/issues/2508))