### PR TITLE
feat(testing): introduce more type safety for harness

### DIFF
--- a/projects/testing/core/button/button.harness.ts
+++ b/projects/testing/core/button/button.harness.ts
@@ -1,9 +1,9 @@
-import {TuiComponentHarness } from '@taiga-ui/testing/utils';
+import {TuiComponentHarness} from '@taiga-ui/testing/utils';
 
 import {TuiLoaderHarness} from '../loader/loader.harness';
 
-export class TuiButtonHarness extends TuiComponentHarness  {
-    static hostSelector = `[tuiButton]`
+export class TuiButtonHarness extends TuiComponentHarness {
+    static hostSelector = `[tuiButton]`;
     private readonly loader = this.locatorForOptional(TuiLoaderHarness);
 
     async isLoading(): Promise<boolean> {

--- a/projects/testing/core/button/button.harness.ts
+++ b/projects/testing/core/button/button.harness.ts
@@ -1,9 +1,9 @@
-import {tuiHarnessWith, tuiWithPredicate} from '@taiga-ui/testing/utils';
+import {TuiComponentHarness } from '@taiga-ui/testing/utils';
 
 import {TuiLoaderHarness} from '../loader/loader.harness';
 
-@tuiWithPredicate
-export class TuiButtonHarness extends tuiHarnessWith<TuiButtonHarness>(`[tuiButton]`) {
+export class TuiButtonHarness extends TuiComponentHarness  {
+    static hostSelector = `[tuiButton]`
     private readonly loader = this.locatorForOptional(TuiLoaderHarness);
 
     async isLoading(): Promise<boolean> {

--- a/projects/testing/utils/helpers.ts
+++ b/projects/testing/utils/helpers.ts
@@ -41,3 +41,12 @@ export function tuiHarnessWith<T>(
         with: (options?: BaseHarnessFilters) => HarnessPredicate<ComponentHarness>;
     };
 }
+
+export class TuiComponentHarness extends ComponentHarness {
+    static with<T extends ComponentHarness>(
+        this: ComponentHarnessConstructor<T>,
+        options: BaseHarnessFilters,
+    ): HarnessPredicate<T> {
+        return new HarnessPredicate(this, options);
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
If we use static method `with` on `TuiButtonHarness`, it loses type information. e.g:
```
 const harness = await loader.getHarness(TuiButtonHarness); // TuiButtonHarness
 const harness = await loader.getHarness(TuiButtonHarness.with({selector:'.class'})); //  ComponentHarness
```
then we can not read methods defined in `TuiButtonHarness`.

Partially implements https://github.com/Tinkoff/taiga-ui/issues/476

## What is the new behavior?
If `TuiButtonHarnes` is extended from `TuiComponentHarness` class, type safety is there and no monkey-patching is needed using decorators.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
