### PR TITLE
chore: fix `npm start`-command

### DIFF
--- a/projects/demo/project.json
+++ b/projects/demo/project.json
@@ -176,7 +176,7 @@
             "builder": "@angular-builders/custom-webpack:dev-server",
             "dependsOn": [
                 {
-                    "target": "prebuild",
+                    "target": "i18n",
                     "projects": "self"
                 }
             ],
@@ -250,7 +250,7 @@
             },
             "dependsOn": [
                 {
-                    "target": "prebuild",
+                    "target": "i18n",
                     "projects": "self"
                 }
             ],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Run `npm start`.

```console
Build at: 2022-09-02T14:03:58.693Z - Hash: 0ff811a357f41cb99c07 - Time: 87906ms

./projects/demo/src/modules/app/app.providers.ts:103:15-106:50 -
Error: Module not found:
Error: Can't resolve 'dist/i18n/esm2015/languages' in '/Users/n.barsukov/WebstormProjects/taiga-ui/projects/demo/src/modules/app'

** Angular Live Development Server is listening on localhost:3333, open your browser on http://localhost:3333/ **

✖ Failed to compile.
```

https://github.com/Tinkoff/taiga-ui/pull/2567

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
