### PR TITLE
fix(cdk): `parse5` & `ng-morph` move `dependencies` => `optionalDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4823,6 +4823,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "devOptional": true,
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -4835,6 +4836,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "devOptional": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -4843,6 +4845,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "devOptional": true,
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -7303,6 +7306,7 @@
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.9.2.tgz",
             "integrity": "sha512-IPyg+c3Am0EBoa63W0f/AKeLrJhvzMzQ4BIvD1baxLopmiHOj1HFTXYxC6e8iTZ+UYtN+/WFM9UyGRnoA20b8g==",
+            "optional": true,
             "dependencies": {
                 "fast-glob": "^3.2.5",
                 "minimatch": "^3.0.4",
@@ -9023,6 +9027,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
             "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+            "optional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9077,6 +9082,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -10086,6 +10092,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "devOptional": true,
             "dependencies": {
                 "fill-range": "^7.0.1"
             },
@@ -11236,7 +11243,8 @@
         "node_modules/code-block-writer": {
             "version": "10.1.1",
             "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
-            "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw=="
+            "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+            "optional": true
         },
         "node_modules/code-point-at": {
             "version": "1.1.0",
@@ -17792,6 +17800,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
             "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+            "devOptional": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -17841,6 +17850,7 @@
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
             "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+            "devOptional": true,
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -17979,6 +17989,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "devOptional": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -19540,6 +19551,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "devOptional": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -21190,6 +21202,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "devOptional": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -23805,7 +23818,8 @@
         "node_modules/jsonc-parser": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "devOptional": true
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
@@ -26468,6 +26482,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "devOptional": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -26485,6 +26500,7 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
             "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "devOptional": true,
             "dependencies": {
                 "braces": "^3.0.2",
                 "picomatch": "^2.3.1"
@@ -26785,6 +26801,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "devOptional": true,
             "bin": {
                 "mkdirp": "bin/cmd.js"
             },
@@ -26884,6 +26901,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
             "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
+            "optional": true,
             "dependencies": {
                 "@types/minimatch": "^3.0.3",
                 "array-differ": "^3.0.0",
@@ -26901,12 +26919,14 @@
         "node_modules/multimatch/node_modules/@types/minimatch": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+            "optional": true
         },
         "node_modules/multimatch/node_modules/arrify": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
             "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+            "optional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -27054,6 +27074,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/ng-morph/-/ng-morph-2.1.0.tgz",
             "integrity": "sha512-jn34Ter6HlY7E3yOoMhfk3cnUwjLlvcGTsAJ7jS0pZ3SAGi3hzqlf3oyUQO6fNfbFnydc33yNqQtUIrbHKCtNA==",
+            "optional": true,
             "dependencies": {
                 "jsonc-parser": "3.0.0",
                 "minimatch": "3.0.4",
@@ -28934,7 +28955,8 @@
         "node_modules/path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "optional": true
         },
         "node_modules/path-dirname": {
             "version": "1.0.2",
@@ -29028,6 +29050,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "devOptional": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -32009,6 +32032,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -33150,6 +33174,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "devOptional": true,
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -33342,6 +33367,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -37418,6 +37444,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "devOptional": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -37653,6 +37680,7 @@
             "version": "10.0.2",
             "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-10.0.2.tgz",
             "integrity": "sha512-TVuIfEqtr9dW25K3Jajqpqx7t/zLRFxKu2rXQZSDjTm4MO4lfmuj1hn8WEryjeDDBFcNOCi+yOmYUYR4HucrAg==",
+            "optional": true,
             "dependencies": {
                 "@ts-morph/common": "~0.9.0",
                 "code-block-writer": "^10.1.1"
@@ -40385,8 +40413,8 @@
                 "@angular/common": ">=9.0.0",
                 "@angular/core": ">=9.0.0",
                 "@ng-web-apis/common": ">=2.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/core": ">=3.0.0",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/core": ">=3.0.1",
                 "@tinkoff/ng-polymorpheus": ">=4.0.0"
             }
         },
@@ -40402,9 +40430,9 @@
                 "@angular/core": ">=9.0.0",
                 "@angular/forms": ">=9.0.0",
                 "@ng-web-apis/common": ">=2.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/core": ">=3.0.0",
-                "@taiga-ui/i18n": ">=3.0.0",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/core": ">=3.0.1",
+                "@taiga-ui/i18n": ">=3.0.1",
                 "@tinkoff/ng-polymorpheus": ">=4.0.0",
                 "angular2-text-mask": ">=9.0.0",
                 "rxjs": ">=6.0.0"
@@ -40431,10 +40459,10 @@
                 "@angular/forms": ">=9.0.0",
                 "@angular/router": ">=9.0.0",
                 "@ng-web-apis/common": ">=2.0.0",
-                "@taiga-ui/addon-mobile": ">=3.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/core": ">=3.0.0",
-                "@taiga-ui/kit": ">=3.0.0",
+                "@taiga-ui/addon-mobile": ">=3.0.1",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/core": ">=3.0.1",
+                "@taiga-ui/kit": ">=3.0.1",
                 "@tinkoff/ng-polymorpheus": ">=4.0.0"
             }
         },
@@ -40480,10 +40508,10 @@
                 "@angular/forms": ">=9.0.0",
                 "@angular/platform-browser": ">=9.0.0",
                 "@ng-web-apis/common": ">=2.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/core": ">=3.0.0",
-                "@taiga-ui/i18n": ">=3.0.0",
-                "@taiga-ui/kit": ">=3.0.0",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/core": ">=3.0.1",
+                "@taiga-ui/i18n": ">=3.0.1",
+                "@taiga-ui/kit": ">=3.0.1",
                 "rxjs": ">=6.0.0"
             }
         },
@@ -40499,9 +40527,9 @@
                 "@angular/common": ">=9.0.0",
                 "@angular/core": ">=9.0.0",
                 "@ng-web-apis/common": ">=2.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/core": ">=3.0.0",
-                "@taiga-ui/kit": ">=3.0.0",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/core": ">=3.0.1",
+                "@taiga-ui/kit": ">=3.0.1",
                 "@tinkoff/ng-polymorpheus": ">=4.0.0",
                 "rxjs": ">=6.0.0"
             }
@@ -40517,11 +40545,11 @@
                 "@angular/common": ">=9.0.0",
                 "@angular/core": ">=9.0.0",
                 "@ng-web-apis/mutation-observer": ">=2.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/core": ">=3.0.0",
-                "@taiga-ui/i18n": ">=3.0.0",
-                "@taiga-ui/icons": ">=3.0.0",
-                "@taiga-ui/kit": ">=3.0.0",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/core": ">=3.0.1",
+                "@taiga-ui/i18n": ">=3.0.1",
+                "@taiga-ui/icons": ">=3.0.1",
+                "@taiga-ui/kit": ">=3.0.1",
                 "@tinkoff/ng-polymorpheus": ">=4.0.0",
                 "rxjs": ">=6.0.0"
             }
@@ -40538,9 +40566,9 @@
                 "@angular/common": ">=9.0.0",
                 "@angular/core": ">=9.0.0",
                 "@ng-web-apis/intersection-observer": ">=3.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/core": ">=3.0.0",
-                "@taiga-ui/i18n": ">=3.0.0",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/core": ">=3.0.1",
+                "@taiga-ui/i18n": ">=3.0.1",
                 "@tinkoff/ng-polymorpheus": ">=4.0.0",
                 "rxjs": ">=6.0.0"
             }
@@ -40555,8 +40583,8 @@
             "peerDependencies": {
                 "@angular/common": ">=9.0.0",
                 "@angular/core": ">=9.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/core": ">=3.0.0",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/core": ">=3.0.1",
                 "@tinkoff/ng-polymorpheus": ">=4.0.0",
                 "rxjs": ">=6.0.0"
             }
@@ -40571,9 +40599,11 @@
                 "@ng-web-apis/resize-observer": "2.0.0",
                 "@tinkoff/ng-event-plugins": "3.0.0",
                 "@tinkoff/ng-polymorpheus": "4.0.6",
-                "ng-morph": "^2.0.0",
-                "parse5": "^6.0.1",
                 "tslib": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "ng-morph": "^2.1.0",
+                "parse5": "^6.0.1"
             },
             "peerDependencies": {
                 "@angular/animations": ">=9.0.0",
@@ -40600,8 +40630,8 @@
                 "@angular/router": ">=9.0.0",
                 "@ng-web-apis/common": ">=2.0.0",
                 "@ng-web-apis/mutation-observer": ">=2.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/i18n": ">=3.0.0",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/i18n": ">=3.0.1",
                 "@tinkoff/ng-event-plugins": ">=3.0.0",
                 "@tinkoff/ng-polymorpheus": ">=4.0.0",
                 "rxjs": ">=6.0.0"
@@ -40701,9 +40731,9 @@
                 "@angular/router": ">=9.0.0",
                 "@ng-web-apis/common": ">=2.0.0",
                 "@ng-web-apis/mutation-observer": ">=2.0.0",
-                "@taiga-ui/cdk": ">=3.0.0",
-                "@taiga-ui/core": ">=3.0.0",
-                "@taiga-ui/i18n": ">=3.0.0",
+                "@taiga-ui/cdk": ">=3.0.1",
+                "@taiga-ui/core": ">=3.0.1",
+                "@taiga-ui/i18n": ">=3.0.1",
                 "@tinkoff/ng-polymorpheus": ">=4.0.0",
                 "rxjs": ">=6.0.0"
             }
@@ -44215,6 +44245,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "devOptional": true,
             "requires": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -44223,12 +44254,14 @@
         "@nodelib/fs.stat": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "devOptional": true
         },
         "@nodelib/fs.walk": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "devOptional": true,
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -45619,7 +45652,7 @@
                 "@ng-web-apis/resize-observer": "2.0.0",
                 "@tinkoff/ng-event-plugins": "3.0.0",
                 "@tinkoff/ng-polymorpheus": "4.0.6",
-                "ng-morph": "^2.0.0",
+                "ng-morph": "^2.1.0",
                 "parse5": "^6.0.1",
                 "tslib": "^2.0.0"
             }
@@ -46107,6 +46140,7 @@
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.9.2.tgz",
             "integrity": "sha512-IPyg+c3Am0EBoa63W0f/AKeLrJhvzMzQ4BIvD1baxLopmiHOj1HFTXYxC6e8iTZ+UYtN+/WFM9UyGRnoA20b8g==",
+            "optional": true,
             "requires": {
                 "fast-glob": "^3.2.5",
                 "minimatch": "^3.0.4",
@@ -47496,7 +47530,8 @@
         "array-differ": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="
+            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+            "optional": true
         },
         "array-find": {
             "version": "1.0.0",
@@ -47538,7 +47573,8 @@
         "array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "devOptional": true
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -48315,6 +48351,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "devOptional": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -49205,7 +49242,8 @@
         "code-block-writer": {
             "version": "10.1.1",
             "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
-            "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw=="
+            "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+            "optional": true
         },
         "code-point-at": {
             "version": "1.1.0",
@@ -54115,6 +54153,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
             "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+            "devOptional": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -54158,6 +54197,7 @@
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
             "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+            "devOptional": true,
             "requires": {
                 "reusify": "^1.0.4"
             }
@@ -54274,6 +54314,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "devOptional": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -55512,6 +55553,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "devOptional": true,
             "requires": {
                 "is-glob": "^4.0.1"
             }
@@ -56753,7 +56795,8 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "devOptional": true
         },
         "is-number-like": {
             "version": "1.0.8",
@@ -58753,7 +58796,8 @@
         "jsonc-parser": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "devOptional": true
         },
         "jsonfile": {
             "version": "6.1.0",
@@ -60885,7 +60929,8 @@
         "merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "devOptional": true
         },
         "methods": {
             "version": "1.1.2",
@@ -60897,6 +60942,7 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
             "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "devOptional": true,
             "requires": {
                 "braces": "^3.0.2",
                 "picomatch": "^2.3.1"
@@ -61117,7 +61163,8 @@
         "mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "devOptional": true
         },
         "modify-values": {
             "version": "1.0.1",
@@ -61198,6 +61245,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
             "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
+            "optional": true,
             "requires": {
                 "@types/minimatch": "^3.0.3",
                 "array-differ": "^3.0.0",
@@ -61209,12 +61257,14 @@
                 "@types/minimatch": {
                     "version": "3.0.5",
                     "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-                    "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+                    "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+                    "optional": true
                 },
                 "arrify": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+                    "optional": true
                 }
             }
         },
@@ -61344,6 +61394,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/ng-morph/-/ng-morph-2.1.0.tgz",
             "integrity": "sha512-jn34Ter6HlY7E3yOoMhfk3cnUwjLlvcGTsAJ7jS0pZ3SAGi3hzqlf3oyUQO6fNfbFnydc33yNqQtUIrbHKCtNA==",
+            "optional": true,
             "requires": {
                 "jsonc-parser": "3.0.0",
                 "minimatch": "3.0.4",
@@ -62780,7 +62831,8 @@
         "path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "optional": true
         },
         "path-dirname": {
             "version": "1.0.2",
@@ -62858,7 +62910,8 @@
         "picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "devOptional": true
         },
         "pify": {
             "version": "2.3.0",
@@ -65086,7 +65139,8 @@
         "queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "devOptional": true
         },
         "quick-lru": {
             "version": "4.0.1",
@@ -65989,7 +66043,8 @@
         "reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "devOptional": true
         },
         "rfdc": {
             "version": "1.3.0",
@@ -66135,6 +66190,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "devOptional": true,
             "requires": {
                 "queue-microtask": "^1.2.2"
             }
@@ -69391,6 +69447,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "devOptional": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -69573,6 +69630,7 @@
             "version": "10.0.2",
             "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-10.0.2.tgz",
             "integrity": "sha512-TVuIfEqtr9dW25K3Jajqpqx7t/zLRFxKu2rXQZSDjTm4MO4lfmuj1hn8WEryjeDDBFcNOCi+yOmYUYR4HucrAg==",
+            "optional": true,
             "requires": {
                 "@ts-morph/common": "~0.9.0",
                 "code-block-writer": "^10.1.1"

--- a/projects/cdk/package.json
+++ b/projects/cdk/package.json
@@ -20,8 +20,6 @@
         "@ng-web-apis/resize-observer": "2.0.0",
         "@tinkoff/ng-event-plugins": "3.0.0",
         "@tinkoff/ng-polymorpheus": "4.0.6",
-        "ng-morph": "^2.0.0",
-        "parse5": "^6.0.1",
         "tslib": "^2.0.0"
     },
     "peerDependencies": {
@@ -30,6 +28,10 @@
         "@angular/core": ">=9.0.0",
         "@angular/forms": ">=9.0.0",
         "rxjs": ">=6.0.0"
+    },
+    "optionalDependencies": {
+        "ng-morph": "^2.1.0",
+        "parse5": "^6.0.1"
     },
     "ng-update": {
         "migrations": "./schematics/migration.json",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #2569

## What is the new behavior?
`parse5` & `ng-morph` can be dropped now via this command:
```console
npm ci --no-optional
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
