### PR TITLE
fix(demo): make `Stackblitz` to be compatible with `Taiga UI 3.0`

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/project-files/configs.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/configs.md
@@ -21,7 +21,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.app.json",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/app/styles/taiga-ui-stackblitz.less", "src/styles.less"]
+            "styles": ["src/app/@stackblitz/styles/taiga-ui-stackblitz.less", "src/styles.less"]
           },
           "configurations": {
             "production": {
@@ -64,14 +64,14 @@
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
+    "downlevelIteration": false,
     "experimentalDecorators": true,
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2015",
     "typeRoots": ["node_modules/@types"],
-    "lib": ["es2018", "dom"]
+    "lib": ["esnext", "dom"]
   },
   "angularCompilerOptions": {
     "enableIvy": true,

--- a/projects/demo/src/modules/app/stackblitz/project-files/configs.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/configs.md
@@ -62,14 +62,14 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": false,
     "downlevelIteration": false,
     "experimentalDecorators": true,
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "esnext",
     "typeRoots": ["node_modules/@types"],
     "lib": ["esnext", "dom"]
   },

--- a/projects/demo/src/modules/app/stackblitz/project-files/src/app/@stackblitz/README.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/app/@stackblitz/README.md
@@ -1,0 +1,24 @@
+# `@stackblitz`-folder description
+
+## DON'T USE THIS APPROACH FOR YOUR APPLICATION!
+
+Stackblitz has a lot of limitations. All files inside this folder are a workaround for stackblitz only. They are awful
+and must not exist in real-world applications.
+
+## Problem descriptions
+
+### `styles`-folder
+
+Some our examples use less-imports from `@taiga-ui/core`-package. Unfortunately, Stackblitz can't properly run this file
+
+**app.style.less**:
+
+```less
+@import '~@taiga-ui/core/styles/taiga-ui-local';
+```
+
+### `all-taiga-modules.ts`
+
+We don't have a nice way to import only required modules for every stackblitz-example. That is why we import all of
+them. We understand that it's a bad practice, and we don't recommend you to do the same. But it easy workaround to keep
+all examples up-to-date without time-consuming manual efforts.

--- a/projects/demo/src/modules/app/stackblitz/project-files/src/app/app.module.ts.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/app/app.module.ts.md
@@ -1,41 +1,17 @@
 ```ts
 import {NgModule} from '@angular/core';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {BrowserModule} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {RouterModule} from '@angular/router';
-import * as ADDON_CHARTS from '@taiga-ui/addon-charts';
-import * as ADDON_COMMERCE from '@taiga-ui/addon-commerce';
-import * as ADDON_EDITOR from '@taiga-ui/addon-editor';
-import * as ADDON_MOBILE from '@taiga-ui/addon-mobile';
-import * as ADDON_TABLE from '@taiga-ui/addon-table';
-import * as CDK from '@taiga-ui/cdk';
-import * as CORE from '@taiga-ui/core';
-import * as KIT from '@taiga-ui/kit';
+import {TUI_ICONS_PATH, tuiIconsPathFactory, TUI_SANITIZER} from '@taiga-ui/core';
 import {NgDompurifySanitizer} from '@tinkoff/ng-dompurify';
-import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 
+import {ALL_TAIGA_UI_MODULES} from '../all-taiga-modules';
 import {AppComponent} from './app.component';
 
-const {TUI_ICONS_PATH, tuiIconsPathFactory, TUI_SANITIZER} = CORE;
-
 @NgModule({
-  imports: [
-    BrowserModule,
-    BrowserAnimationsModule,
-    FormsModule,
-    ReactiveFormsModule,
-    PolymorpheusModule,
-    RouterModule.forRoot([]),
-    ...tuiPropagateModules(CORE),
-    ...tuiPropagateModules(KIT),
-    ...tuiPropagateModules(CDK),
-    ...tuiPropagateModules(ADDON_EDITOR),
-    ...tuiPropagateModules(ADDON_MOBILE),
-    ...tuiPropagateModules(ADDON_COMMERCE),
-    ...tuiPropagateModules(ADDON_CHARTS),
-    ...tuiPropagateModules(ADDON_TABLE),
-  ],
+  /**
+   * Don't use this approach,
+   * it's a workaround for stackblitz
+   */
+  imports: ALL_TAIGA_UI_MODULES,
   declarations: [AppComponent],
   bootstrap: [AppComponent],
   providers: [
@@ -59,20 +35,4 @@ const {TUI_ICONS_PATH, tuiIconsPathFactory, TUI_SANITIZER} = CORE;
   ],
 })
 export class AppModule {}
-
-/**
- * Don't use this approach,
- * it's a workaround for stackblitz
- */
-function tuiPropagateModules<T>(entryPoint: T) {
-  const modules = [];
-
-  for (const name in entryPoint) {
-    if (name.endsWith('Module')) {
-      modules.push(entryPoint[name]);
-    }
-  }
-
-  return modules;
-}
 ```

--- a/projects/demo/src/modules/app/stackblitz/project-files/src/app/app.module.ts.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/app/app.module.ts.md
@@ -3,7 +3,7 @@ import {NgModule} from '@angular/core';
 import {TUI_ICONS_PATH, tuiIconsPathFactory, TUI_SANITIZER} from '@taiga-ui/core';
 import {NgDompurifySanitizer} from '@tinkoff/ng-dompurify';
 
-import {ALL_TAIGA_UI_MODULES} from '../all-taiga-modules';
+import {ALL_TAIGA_UI_MODULES} from './@stackblitz/all-taiga-modules';
 import {AppComponent} from './app.component';
 
 @NgModule({

--- a/projects/demo/src/modules/app/stackblitz/stackblitz-resources-loader.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz-resources-loader.ts
@@ -200,4 +200,12 @@ export abstract class AbstractTuiStackblitzResourcesLoader {
 
         return styles;
     }
+
+    static async getReadMeFiles(): Promise<{stackblitzReadMe: string}> {
+        const [stackblitzReadMe] = await Promise.all([
+            tuiRawLoad(import(`./project-files/src/app/@stackblitz/README.md?raw`)),
+        ]);
+
+        return {stackblitzReadMe};
+    }
 }

--- a/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
@@ -7,6 +7,7 @@ import {STACKBLITZ_DEPS} from './stackblitz-deps.constants';
 import {AbstractTuiStackblitzResourcesLoader} from './stackblitz-resources-loader';
 import {
     appPrefix,
+    getAllTaigaUIModulesFile,
     getComponentsClassNames,
     getSupportFiles,
     getSupportModules,
@@ -85,6 +86,7 @@ export class TuiStackblitzService implements TuiCodeEditor {
                 'src/main.ts': mainTs,
                 'src/polyfills.ts': polyfills,
                 'src/styles.less': styles,
+                'src/all-taiga-modules.ts': await getAllTaigaUIModulesFile(),
                 [appPrefix`app.module.ts`]: appModule.toString(),
                 [appPrefix`app.component.ts`]: appCompTs.toString(),
                 [appPrefix`app.component.html`]: `<tui-root>\n\n${content.HTML}\n</tui-root>`,

--- a/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
@@ -45,6 +45,9 @@ export class TuiStackblitzService implements TuiCodeEditor {
         const {tsconfig, angularJson, indexHtml, mainTs, polyfills, styles, appModuleTs} =
             await AbstractTuiStackblitzResourcesLoader.getProjectFiles();
 
+        const {stackblitzReadMe} =
+            await AbstractTuiStackblitzResourcesLoader.getReadMeFiles();
+
         const appModule = new TsFileModuleParser(appModuleTs);
         const appCompTs = new TsFileComponentParser(content.TypeScript);
 
@@ -90,6 +93,7 @@ export class TuiStackblitzService implements TuiCodeEditor {
                 'src/main.ts': mainTs,
                 'src/polyfills.ts': polyfills,
                 'src/styles.less': styles,
+                [stackblitzPrefix`README.md`]: stackblitzReadMe,
                 [stackblitzPrefix`all-taiga-modules.ts`]:
                     await getAllTaigaUIModulesFile(),
                 [appPrefix`app.module.ts`]: appModule.toString(),

--- a/projects/demo/src/modules/app/stackblitz/utils.ts
+++ b/projects/demo/src/modules/app/stackblitz/utils.ts
@@ -89,17 +89,20 @@ export function getAllModules(entryPoint: Record<string, unknown>): string {
  */
 export async function getAllTaigaUIModulesFile(): Promise<string> {
     /**
+     * Violated DRY principle:
      * You can't just iterate the array with package-names - it will cause error:
      * `Warning: Critical dependency: the request of a dependency is an expression`
      * */
-    const cdk = getAllModules(await import(`@taiga-ui/cdk`));
-    const core = getAllModules(await import(`@taiga-ui/core`));
-    const kit = getAllModules(await import(`@taiga-ui/kit`));
-    const charts = getAllModules(await import(`@taiga-ui/addon-charts`));
-    const commerce = getAllModules(await import(`@taiga-ui/addon-commerce`));
-    const editor = getAllModules(await import(`@taiga-ui/addon-editor`));
-    const mobile = getAllModules(await import(`@taiga-ui/addon-mobile`));
-    const table = getAllModules(await import(`@taiga-ui/addon-table`));
+    const [cdk, core, kit, charts, commerce, editor, mobile, table] = await Promise.all([
+        import(`@taiga-ui/cdk`),
+        import(`@taiga-ui/core`),
+        import(`@taiga-ui/kit`),
+        import(`@taiga-ui/addon-charts`),
+        import(`@taiga-ui/addon-commerce`),
+        import(`@taiga-ui/addon-editor`),
+        import(`@taiga-ui/addon-mobile`),
+        import(`@taiga-ui/addon-table`),
+    ]).then(modules => modules.map(getAllModules));
 
     return `
 import {

--- a/projects/demo/src/modules/app/stackblitz/utils.ts
+++ b/projects/demo/src/modules/app/stackblitz/utils.ts
@@ -7,13 +7,18 @@ export const prepareLess = (content: string): string => {
     return content
         .replace(
             `~@taiga-ui/core/styles/taiga-ui-local`,
-            `styles/taiga-ui-stackblitz.less`,
+            `@stackblitz/styles/taiga-ui-stackblitz.less`,
         )
         .replace(/@import.+taiga-ui-local';/g, ``);
 };
 
 export const appPrefix = (stringsPart: TemplateStringsArray, path: string = ``): string =>
     `src/app/${stringsPart.join(``)}${path}`;
+
+export const stackblitzPrefix = (
+    stringsPart: TemplateStringsArray,
+    path: string = ``,
+): string => `src/app/@stackblitz/${stringsPart.join(``)}${path}`;
 
 type FileName = string;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [X] Documentation content changes

## What is the current behavior?
Unfortunately, previous [stackblitz-hack](https://github.com/Tinkoff/taiga-ui/blob/main/projects/demo/src/modules/app/stackblitz/project-files/src/app/app.module.ts.md) does not works:
```ts
function tuiPropagateModules<T>(entryPoint: T) {
  const modules = [];

  for (const name in entryPoint) {
    if (name.endsWith('Module')) {
      modules.push(entryPoint[name]);
    }
  }

  return modules;
}
```

It causes error:
```console
Error in src/app/app.module.ts (19:17)
Value at position 1 in the NgModule.declarations of AppModule is not a reference
Value could not be determined statically.
```

See this issue https://github.com/angular/angular/issues/42550

## What is the new behavior?
New hack :)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
