### PR TITLE
ci: replace only `next` or `v.x` subpath of route (#2691)

### DIFF
--- a/projects/demo/src/404.html
+++ b/projects/demo/src/404.html
@@ -5,17 +5,14 @@
         <meta charset="utf-8" />
         <title>Taiga UI</title>
         <script>
-            if (!localStorage.getItem('env')) {
-                const base = location.pathname + location.search + location.hash;
-                const segments = base.split('/').filter(Boolean);
-                const version = segments[0] ?? ``;
-                const pattern = /^(next|v[0-9])$/;
+            const base = `${location.pathname}${location.search}${location.hash}`;
+            const segments = base.split('/').filter(Boolean);
+            const version = segments[0] ?? ``;
+            const pattern = /^(next|v[0-9])$/;
+            const redirectUrl = pattern.test(version) ? `/${version}` : `/`;
 
-                localStorage.setItem('env', base);
-                location.replace(pattern.test(version) ? `/${version}` : `/`);
-            } else {
-                localStorage.removeItem('env');
-            }
+            localStorage.setItem('env', base);
+            location.replace(redirectUrl);
         </script>
     </head>
     <body></body>

--- a/projects/demo/src/modules/app/abstract.app.ts
+++ b/projects/demo/src/modules/app/abstract.app.ts
@@ -57,7 +57,7 @@ export abstract class AbstractDemoComponent implements OnInit {
 
         if (env) {
             this.storage.removeItem(`env`);
-            await this.router.navigateByUrl(env.replace(/\/[A-z0-9]*\//, ``));
+            await this.router.navigateByUrl(env.replace(/^\/(next|v[0-9])\//, ``));
         }
     }
 }


### PR DESCRIPTION
(cherry picked from commit 7dfc227af1aa74c8e469a2e3559ce3257b91d113)
