### PR TITLE
chore: broken `npm start`-command

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -23,7 +23,6 @@
         "default": {
             "runner": "@nrwl/nx-cloud",
             "options": {
-                "runtimeCacheInputs": ["node -v", "tar cvf - ./scripts/ | sha256sum"],
                 "cacheableOperations": ["build", "test", "lint"],
                 "parallel": 1
             }


### PR DESCRIPTION
See this issue: https://github.com/Tinkoff/taiga-ui/issues/2617

Solution is copied from this PR: https://github.com/Tinkoff/taiga-ui/pull/2620