### PR TITLE
fix(kit): `InputFlies` new value of i18n-token `TUI_INPUT_FILE_TEXTS` triggers text changes

### DIFF
--- a/projects/demo-integrations/cypress/support/commands.ts
+++ b/projects/demo-integrations/cypress/support/commands.ts
@@ -11,6 +11,7 @@ import {tuiHideLanguageSwitcher} from './hide-language-switcher';
 import {tuiHideNavigation} from './hide-navigation';
 import {tuiHideVersionManager} from './hide-version-manager';
 import {tuiScrollIntoView} from './scroll-into-view';
+import {tuiSetLanguage} from './set-language';
 import {tuiSetNightMode} from './set-night-mode';
 import {tuiTab} from './type-tab';
 import {tuiVisit} from './visit';
@@ -27,6 +28,7 @@ declare global {
             tuiVisit: typeof tuiVisit;
             tuiHideHeader: typeof tuiHideHeader;
             tuiWaitKitDialog: typeof tuiWaitKitDialog;
+            tuiSetLanguage: typeof tuiSetLanguage;
             tuiSetNightMode: typeof tuiSetNightMode;
             tuiHideNavigation: typeof tuiHideNavigation;
             tuiHideVersionManager: typeof tuiHideVersionManager;
@@ -67,6 +69,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(`tuiVisit`, tuiVisit);
 Cypress.Commands.add(`tuiHideHeader`, tuiHideHeader);
 Cypress.Commands.add(`tuiWaitKitDialog`, tuiWaitKitDialog);
+Cypress.Commands.add(`tuiSetLanguage`, tuiSetLanguage);
 Cypress.Commands.add(`tuiSetNightMode`, tuiSetNightMode);
 Cypress.Commands.add(`tuiHideNavigation`, tuiHideNavigation);
 Cypress.Commands.add(`tuiHideVersionManager`, tuiHideVersionManager);

--- a/projects/demo-integrations/cypress/support/set-language.ts
+++ b/projects/demo-integrations/cypress/support/set-language.ts
@@ -1,6 +1,6 @@
 export function tuiSetLanguage(language: string): void {
     cy.get(`tui-language-switcher`, {log: false}).click({log: false});
-    cy.get(`tui-dropdown [tuiOption]`, {log: false})
+    cy.get(`tui-dropdown-box [tuiOption]`, {log: false})
         .contains(language, {matchCase: false, log: false})
         .click({force: true, log: false});
 }

--- a/projects/demo-integrations/cypress/support/set-language.ts
+++ b/projects/demo-integrations/cypress/support/set-language.ts
@@ -1,0 +1,6 @@
+export function tuiSetLanguage(language: string): void {
+    cy.get(`tui-language-switcher`, {log: false}).click({log: false});
+    cy.get(`tui-dropdown [tuiOption]`, {log: false})
+        .contains(language, {matchCase: false, log: false})
+        .click({force: true, log: false});
+}

--- a/projects/demo-integrations/cypress/tests/kit/input-files/input-files.spec.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-files/input-files.spec.ts
@@ -1,0 +1,49 @@
+describe(`InputFiles`, () => {
+    describe(`supports dynamic change of i18n for errors`, () => {
+        it(`Wrong file type`, () => {
+            cy.viewport(800, 500);
+            cy.tuiVisit(`/components/input-files/API?accept=application/pdf`, {
+                skipExpectUrl: true,
+                hideNavigation: false,
+                hideLanguageSwitcher: false,
+            });
+
+            cy.get(`#demoContent input[type="file"]`).selectFile(
+                `cypress/fixtures/stubs/web-api.svg`,
+            );
+
+            cy.get(`#demoContent tui-file`)
+                .should(`contain.text`, `Wrong file type`)
+                .matchImageSnapshot(`01-01-input-files-[english]-wrong-file-type`);
+
+            cy.tuiSetLanguage(`dutch`);
+
+            cy.get(`#demoContent tui-file`)
+                .should(`contain.text`, `Verkeerd bestandsformaat`)
+                .matchImageSnapshot(`01-02-input-files-[dutch]-wrong-file-type`);
+        });
+
+        it(`File is too large`, () => {
+            cy.viewport(850, 500);
+            cy.tuiVisit(`/components/input-files/API?accept=image/*&maxFileSize=2000`, {
+                skipExpectUrl: true,
+                hideNavigation: false,
+                hideLanguageSwitcher: false,
+            });
+
+            cy.get(`#demoContent input[type="file"]`).selectFile(
+                `cypress/fixtures/stubs/web-api.svg`,
+            );
+
+            cy.get(`#demoContent tui-file`)
+                .should(`contain.text`, `File is too large 2 KB`)
+                .matchImageSnapshot(`02-01-input-files-[english]-file-too-large`);
+
+            cy.tuiSetLanguage(`dutch`);
+
+            cy.get(`#demoContent tui-file`)
+                .should(`contain.text`, `Bestandsgrootte overschreden 2 KB`)
+                .matchImageSnapshot(`02-02-input-files-[dutch]-file-too-large`);
+        });
+    });
+});

--- a/projects/i18n/languages/dutch/kit.ts
+++ b/projects/i18n/languages/dutch/kit.ts
@@ -48,7 +48,7 @@ export const TUI_DUTCH_LANGUAGE_KIT: LanguageKit = {
         defaultLabelMultiple: `of zet\u00A0ze\u00A0hier`,
         defaultLinkSingle: `Kies een bestand`,
         defaultLinkMultiple: `Kies bestanden`,
-        maxSizeRejectionReason: `Bestandsgrootte overschreden`,
+        maxSizeRejectionReason: `Bestandsgrootte overschreden `,
         formatRejectionReason: `Verkeerd bestandsformaat`,
         drop: `Zet hier bestand neer`,
         dropMultiple: `Zet hier bestanden neer`,

--- a/projects/i18n/languages/italian/kit.ts
+++ b/projects/i18n/languages/italian/kit.ts
@@ -48,7 +48,7 @@ export const TUI_ITALIAN_LANGUAGE_KIT: LanguageKit = {
         defaultLabelMultiple: `o trascinali\u00A0qui`,
         defaultLinkSingle: `Scegliere il file`,
         defaultLinkMultiple: `Scegliere i file`,
-        maxSizeRejectionReason: `Il file supera le dimensioni`,
+        maxSizeRejectionReason: `Il file supera le dimensioni `,
         formatRejectionReason: `Formato file errato`,
         drop: `Trascina il file qui`,
         dropMultiple: `Trascina i file qui`,

--- a/projects/kit/components/input-files/input-files.component.ts
+++ b/projects/kit/components/input-files/input-files.component.ts
@@ -160,17 +160,19 @@ export class TuiInputFilesComponent
 
     onFilesSelected(
         input: HTMLInputElement,
-        errors: Record<'maxSizeRejection' | 'formatRejection', PolymorpheusContent>,
+        formatRejection: PolymorpheusContent,
+        maxSizeRejection: PolymorpheusContent,
     ): void {
-        this.processSelectedFiles(input.files, errors);
+        this.processSelectedFiles(input.files, {formatRejection, maxSizeRejection});
         input.value = ``;
     }
 
     onDropped(
         event: DataTransfer,
-        errors: Record<'maxSizeRejection' | 'formatRejection', PolymorpheusContent>,
+        formatRejection: PolymorpheusContent,
+        maxSizeRejection: PolymorpheusContent,
     ): void {
-        this.processSelectedFiles(event.files, errors);
+        this.processSelectedFiles(event.files, {formatRejection, maxSizeRejection});
     }
 
     onDragOver(dataTransfer: DataTransfer | null): void {

--- a/projects/kit/components/input-files/input-files.component.ts
+++ b/projects/kit/components/input-files/input-files.component.ts
@@ -27,8 +27,8 @@ import {
 } from '@taiga-ui/cdk';
 import {MODE_PROVIDER, TuiSizeL} from '@taiga-ui/core';
 import {TuiFileLike} from '@taiga-ui/kit/interfaces';
-import {TUI_DIGITAL_INFORMATION_UNITS, TUI_INPUT_FILE_TEXTS} from '@taiga-ui/kit/tokens';
-import {formatSize, getAcceptArray} from '@taiga-ui/kit/utils/files';
+import {TUI_INPUT_FILE_TEXTS} from '@taiga-ui/kit/tokens';
+import {getAcceptArray} from '@taiga-ui/kit/utils/files';
 import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {Observable, of} from 'rxjs';
 import {map} from 'rxjs/operators';
@@ -109,8 +109,6 @@ export class TuiInputFilesComponent
                 string
             >
         >,
-        @Inject(TUI_DIGITAL_INFORMATION_UNITS)
-        readonly units$: Observable<[string, string, string]>,
     ) {
         super(control, changeDetectorRef);
     }
@@ -162,19 +160,17 @@ export class TuiInputFilesComponent
 
     onFilesSelected(
         input: HTMLInputElement,
-        texts: Record<'maxSizeRejectionReason' | 'formatRejectionReason', string>,
-        units: [string, string, string],
+        errors: Record<'maxSizeRejection' | 'formatRejection', PolymorpheusContent>,
     ): void {
-        this.processSelectedFiles(input.files, texts, units);
+        this.processSelectedFiles(input.files, errors);
         input.value = ``;
     }
 
     onDropped(
         event: DataTransfer,
-        texts: Record<'maxSizeRejectionReason' | 'formatRejectionReason', string>,
-        units: [string, string, string],
+        errors: Record<'maxSizeRejection' | 'formatRejection', PolymorpheusContent>,
     ): void {
-        this.processSelectedFiles(event.files, texts, units);
+        this.processSelectedFiles(event.files, errors);
     }
 
     onDragOver(dataTransfer: DataTransfer | null): void {
@@ -243,8 +239,7 @@ export class TuiInputFilesComponent
 
     private processSelectedFiles(
         files: FileList | null,
-        texts: Record<'maxSizeRejectionReason' | 'formatRejectionReason', string>,
-        units: [string, string, string],
+        errors: Record<'maxSizeRejection' | 'formatRejection', PolymorpheusContent>,
     ): void {
         // IE11 after selecting a file through the open dialog generates a second event passing an empty FileList.
         if (!files?.length) {
@@ -266,15 +261,13 @@ export class TuiInputFilesComponent
                     name: file.name,
                     type: file.type,
                     size: file.size,
-                    content:
-                        texts.maxSizeRejectionReason +
-                        formatSize(units, this.maxFileSize),
+                    content: errors.maxSizeRejection,
                 })),
                 ...wrongFormatFiles.map(file => ({
                     name: file.name,
                     type: file.type,
                     size: file.size,
-                    content: texts.formatRejectionReason,
+                    content: errors.formatRejection,
                 })),
             ]);
         }

--- a/projects/kit/components/input-files/input-files.module.ts
+++ b/projects/kit/components/input-files/input-files.module.ts
@@ -26,6 +26,7 @@ import {
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 
 import {TuiInputFilesComponent} from './input-files.component';
+import {TuiMaxSizeRejectionErrorPipe} from './max-size-rejection-error.pipe';
 
 @NgModule({
     imports: [
@@ -46,7 +47,7 @@ import {TuiInputFilesComponent} from './input-files.component';
         TuiGroupModule,
         TuiFilesModule,
     ],
-    declarations: [TuiInputFilesComponent],
+    declarations: [TuiInputFilesComponent, TuiMaxSizeRejectionErrorPipe],
     exports: [
         TuiInputFilesComponent,
         TuiFilesComponent,

--- a/projects/kit/components/input-files/input-files.template.html
+++ b/projects/kit/components/input-files/input-files.template.html
@@ -32,11 +32,11 @@
                 [accept]="accept"
                 [multiple]="multiple"
                 [tuiFocusable]="focusable"
-                (change)="onFilesSelected(input, {formatRejection, maxSizeRejection})"
+                (change)="onFilesSelected(input, formatRejection, maxSizeRejection)"
                 (tuiHoveredChange)="onHovered($event)"
                 (tuiFocusedChange)="onFocused($event)"
                 (tuiPressedChange)="onPressed($event)"
-                (tuiDroppableDropped)="onDropped($event, {formatRejection, maxSizeRejection})"
+                (tuiDroppableDropped)="onDropped($event, formatRejection, maxSizeRejection)"
                 (tuiDroppableDragOverChange)="onDragOver($event)"
                 (mousedown.prevent.silent)="(0)"
             />

--- a/projects/kit/components/input-files/input-files.template.html
+++ b/projects/kit/components/input-files/input-files.template.html
@@ -7,10 +7,7 @@
     [pressed]="computedPressed"
     [disabled]="computedDisabled"
 >
-    <label
-        *ngIf="units$ | async as units"
-        automation-id="tui-input-file__label"
-    >
+    <label automation-id="tui-input-file__label">
         <a tuiLink>
             <span
                 polymorpheus-outlet
@@ -28,7 +25,6 @@
         </ng-container>
         <ng-container *ngIf="!readOnly && !computedDisabled">
             <input
-                *ngIf="inputFileTexts$ | async as texts"
                 #input
                 type="file"
                 class="t-native"
@@ -36,14 +32,22 @@
                 [accept]="accept"
                 [multiple]="multiple"
                 [tuiFocusable]="focusable"
-                (change)="onFilesSelected(input, texts, units)"
+                (change)="onFilesSelected(input, {formatRejection, maxSizeRejection})"
                 (tuiHoveredChange)="onHovered($event)"
                 (tuiFocusedChange)="onFocused($event)"
                 (tuiPressedChange)="onPressed($event)"
-                (tuiDroppableDropped)="onDropped($event, texts, units)"
+                (tuiDroppableDropped)="onDropped($event, {formatRejection, maxSizeRejection})"
                 (tuiDroppableDragOverChange)="onDragOver($event)"
                 (mousedown.prevent.silent)="(0)"
             />
         </ng-container>
     </label>
 </tui-wrapper>
+
+<ng-template #formatRejection>
+    {{ (inputFileTexts$ | async)?.formatRejectionReason || '' }}
+</ng-template>
+
+<ng-template #maxSizeRejection>
+    {{ maxFileSize | tuiMaxSizeRejectionError | async }}
+</ng-template>

--- a/projects/kit/components/input-files/max-size-rejection-error.pipe.ts
+++ b/projects/kit/components/input-files/max-size-rejection-error.pipe.ts
@@ -1,0 +1,29 @@
+import {Inject, Pipe, PipeTransform} from '@angular/core';
+import {TuiInjectionTokenType} from '@taiga-ui/cdk';
+import {TUI_DIGITAL_INFORMATION_UNITS, TUI_INPUT_FILE_TEXTS} from '@taiga-ui/kit/tokens';
+import {tuiFormatSize} from '@taiga-ui/kit/utils';
+import {combineLatest, Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+@Pipe({name: `tuiMaxSizeRejectionError`})
+export class TuiMaxSizeRejectionErrorPipe implements PipeTransform {
+    constructor(
+        @Inject(TUI_INPUT_FILE_TEXTS)
+        private readonly inputFileTexts$: TuiInjectionTokenType<
+            typeof TUI_INPUT_FILE_TEXTS
+        >,
+        @Inject(TUI_DIGITAL_INFORMATION_UNITS)
+        private readonly units$: TuiInjectionTokenType<
+            typeof TUI_DIGITAL_INFORMATION_UNITS
+        >,
+    ) {}
+
+    transform(maxFileSize: number): Observable<string> {
+        return combineLatest([this.inputFileTexts$, this.units$]).pipe(
+            map(
+                ([{maxSizeRejectionReason}, units]) =>
+                    maxSizeRejectionReason + tuiFormatSize(units, maxFileSize),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes https://github.com/Tinkoff/taiga-ui/issues/2709 (for `v2.x`-branch)

## What is the new behavior?
Cherry-picked https://github.com/Tinkoff/taiga-ui/pull/2711

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
