### PR TITLE
fix(eslint-plugin): `no-deep-imports` add `Windows`-OS support

### DIFF
--- a/projects/eslint-plugin/no-deep-imports.js
+++ b/projects/eslint-plugin/no-deep-imports.js
@@ -57,7 +57,7 @@ module.exports = {
             [`ImportDeclaration[source.value=/${importDeclaration}/]`]({
                 source: sourceNode,
             }) {
-                const currentFilePath = context.getFilename();
+                const currentFilePath = context.getFilename().replace(/\\+/g, '/');
                 const [currentFileProjectName] =
                     (currentProject &&
                         currentFilePath.match(new RegExp(currentProject, 'g'))) ||


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Windows has file paths like this:
```
C:\\Users\\nsbarsukov\\WebstormProjects\\taiga-ui\\projects\\core\\directives\\hint\\hint.component.ts
```
I know, it looks terrible :peka: 


## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
