### PR TITLE
feat(addon-table): add directive to sort by order

### DIFF
--- a/projects/addon-table/components/table/directives/direction-order.directive.ts
+++ b/projects/addon-table/components/table/directives/direction-order.directive.ts
@@ -1,0 +1,23 @@
+import {Directive, Inject, Input, Output} from '@angular/core';
+import {map} from 'rxjs/operators';
+
+import {TuiTableDirective} from './table.directive';
+
+@Directive({
+    selector: `table[tuiTable][tuiDirectionOrder]`,
+})
+export class TuiDirectionOrderDirective<T> {
+    @Input()
+    set directionOrder(order: 'asc' | 'desc') {
+        this.table.direction = order === `asc` ? 1 : -1;
+    }
+
+    @Output()
+    readonly directionOrderChange = this.table.directionChange.pipe(
+        map(dir => (dir === 1 ? `asc` : `desc`)),
+    );
+
+    constructor(
+        @Inject(TuiTableDirective) private readonly table: TuiTableDirective<T>,
+    ) {}
+}

--- a/projects/addon-table/components/table/directives/test/direction-order.directive.spec.ts
+++ b/projects/addon-table/components/table/directives/test/direction-order.directive.spec.ts
@@ -1,0 +1,69 @@
+import {Component, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {TuiTableDirective, TuiTableModule} from '@taiga-ui/addon-table';
+import {configureTestSuite} from '@taiga-ui/testing';
+
+describe(`TuiDirectionOrder directive`, () => {
+    @Component({
+        template: `
+            <table
+                tuiTable
+                tuiDirectionOrder
+                class="table"
+                [directionOrder]="directionOrder"
+                (directionOrderChange)="directionOrderChange($event)"
+            ></table>
+        `,
+    })
+    class TestComponent {
+        @ViewChild(TuiTableDirective)
+        readonly table!: TuiTableDirective<any>;
+
+        directionOrder = `asc`;
+        directionOrderChange = jasmine.createSpy();
+    }
+
+    let fixture: ComponentFixture<TestComponent>;
+    let testComponent: TestComponent;
+
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            imports: [TuiTableModule],
+            declarations: [TestComponent],
+        });
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        testComponent = fixture.componentInstance;
+
+        fixture.detectChanges();
+    });
+
+    it(`sets the sort direction of table to ascending`, () => {
+        fixture.detectChanges();
+
+        expect(testComponent.table.direction).toEqual(1);
+    });
+
+    it(`sets the sort direction of table to descending`, () => {
+        testComponent.directionOrder = `desc`;
+        fixture.detectChanges();
+
+        expect(testComponent.table.direction).toEqual(-1);
+    });
+
+    describe(`when table emits direction change`, () => {
+        it(`emits ascending directionOrder`, () => {
+            testComponent.table.directionChange.emit(1);
+
+            expect(testComponent.directionOrderChange).toHaveBeenCalledOnceWith(`asc`);
+        });
+
+        it(`emits descending directionOrder`, () => {
+            testComponent.table.directionChange.emit(-1);
+
+            expect(testComponent.directionOrderChange).toHaveBeenCalledOnceWith(`desc`);
+        });
+    });
+});

--- a/projects/addon-table/components/table/index.ts
+++ b/projects/addon-table/components/table/index.ts
@@ -1,4 +1,5 @@
 export * from './directives/cell.directive';
+export * from './directives/direction-order.directive';
 export * from './directives/head.directive';
 export * from './directives/resized.directive';
 export * from './directives/row.directive';

--- a/projects/addon-table/components/table/table.module.ts
+++ b/projects/addon-table/components/table/table.module.ts
@@ -53,6 +53,7 @@ import {TuiTrComponent} from './tr/tr.component';
         TuiSortableDirective,
         TuiTheadDirective,
         TuiTableSortPipe,
+        TuiDirectionOrderDirective,
     ],
 })
 export class TuiTableModule {}

--- a/projects/addon-table/components/table/table.module.ts
+++ b/projects/addon-table/components/table/table.module.ts
@@ -5,6 +5,7 @@ import {TuiSvgModule} from '@taiga-ui/core';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 
 import {TuiCellDirective} from './directives/cell.directive';
+import {TuiDirectionOrderDirective} from './directives/direction-order.directive';
 import {TuiHeadDirective} from './directives/head.directive';
 import {TuiResizedDirective} from './directives/resized.directive';
 import {TuiRowDirective} from './directives/row.directive';
@@ -36,6 +37,7 @@ import {TuiTrComponent} from './tr/tr.component';
         TuiTheadDirective,
         TuiResizedDirective,
         TuiTableSortPipe,
+        TuiDirectionOrderDirective,
     ],
     exports: [
         TuiTableDirective,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
To specify sort direction one needs to pass direction as 1 or -1 which is a bit confusing.

Closes # https://github.com/Tinkoff/taiga-ui/issues/2266

## What is the new behavior?
Allows user to specify direction in terms of order e.g "asc" or "desc" instead of 1 or -1.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
