### PR TITLE
docs: add flag to show edit button only if TS & HTML exist

### DIFF
--- a/projects/addon-doc/src/components/example/example.component.ts
+++ b/projects/addon-doc/src/components/example/example.component.ts
@@ -18,7 +18,7 @@ import {BehaviorSubject, Observable, Subject} from 'rxjs';
 import {map, switchMap} from 'rxjs/operators';
 
 import {TuiCodeEditor} from '../../interfaces/code-editor';
-import {TuiDocExample} from '../../interfaces/page';
+import {TUI_EXAMPLE_PRIMARY_FILE_NAME, TuiDocExample} from '../../interfaces/page';
 import {TUI_DOC_CODE_ACTIONS} from '../../tokens/code-actions';
 import {TUI_DOC_CODE_EDITOR} from '../../tokens/code-editor';
 import {TUI_DOC_EXAMPLE_CONTENT_PROCESSOR} from '../../tokens/example-content-processor';
@@ -87,6 +87,13 @@ export class TuiDocExampleComponent {
         @Inject(ActivatedRoute) private readonly route: ActivatedRoute,
         @Inject(NgLocation) private readonly ngLocation: NgLocation,
     ) {}
+
+    readonly visible = (files: Record<string, string>): boolean =>
+        Boolean(
+            this.codeEditor &&
+                files[TUI_EXAMPLE_PRIMARY_FILE_NAME.TS] &&
+                files[TUI_EXAMPLE_PRIMARY_FILE_NAME.HTML],
+        );
 
     copyExampleLink(): void {
         const hashPosition = this.location.href.indexOf(`#`);

--- a/projects/addon-doc/src/components/example/example.module.ts
+++ b/projects/addon-doc/src/components/example/example.module.ts
@@ -1,6 +1,7 @@
 import {ClipboardModule} from '@angular/cdk/clipboard';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {TuiMapperPipeModule} from '@taiga-ui/cdk';
 import {TuiButtonModule} from '@taiga-ui/core';
 import {TuiTabsModule} from '@taiga-ui/kit';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
@@ -20,6 +21,7 @@ import {TuiDocExampleGetTabsPipe} from './example-get-tabs.pipe';
         TuiDocCopyModule,
         TuiDocCodeModule,
         PolymorpheusModule,
+        TuiMapperPipeModule,
     ],
     declarations: [
         TuiDocExampleComponent,

--- a/projects/addon-doc/src/components/example/example.template.html
+++ b/projects/addon-doc/src/components/example/example.template.html
@@ -48,14 +48,14 @@
             </tui-tabs-with-more>
 
             <button
-                *ngIf="codeEditor"
+                *ngIf="files | tuiMapper: visible"
                 tuiButton
                 appearance="flat"
                 size="s"
                 [showLoader]="!!(loading$ | async)"
                 (click)="edit(files)"
             >
-                Edit on {{ codeEditor.name }}
+                Edit on {{ codeEditor!.name }}
             </button>
         </div>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #2766

## What is the new behavior?

An `Edit on` link is not visible for examples without HTML or TypeScript files.

An `Edit on` link doesn't work in the linked issue since the example doesn't have a TypeScript property, but `TuiStackblitzService.edit` method requires it. The possible solution is just to add this missing property to the example object. But there are other examples where the `Edit on` feature also doesn't work, e.g. [variables](https://taiga-ui.dev/variables). I guess that we can't force to use HTML & TypeScript properties all the time. So I implemented logic to hide an `Edit on ...` link if an example has neither HTML nor TypeScript properties. Otherwise, the button is visible but an example still cannot be opened due to the if condition in `TuiStackblitzService.edit`.

![image](https://user-images.githubusercontent.com/22116465/193409636-63b66368-2476-4873-8e84-729ad0287013.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
