### PR TITLE
feat: extend custom icon type to `PolymorpheusContent`

### DIFF
--- a/projects/addon-commerce/components/input-card/input-card.component.ts
+++ b/projects/addon-commerce/components/input-card/input-card.component.ts
@@ -77,7 +77,7 @@ export class TuiInputCardComponent
         super(control, changeDetectorRef);
     }
 
-    get defaultCardIcon(): string | null {
+    private get defaultCardIcon(): string | null {
         const {paymentSystem} = this;
 
         return paymentSystem ? icons[paymentSystem] : null;

--- a/projects/addon-commerce/components/input-card/input-card.component.ts
+++ b/projects/addon-commerce/components/input-card/input-card.component.ts
@@ -23,6 +23,7 @@ import {
     TuiFocusableElementAccessor,
 } from '@taiga-ui/cdk';
 import {TuiPrimitiveTextfieldComponent, TuiTextMaskOptions} from '@taiga-ui/core';
+import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 
 const icons: Record<TuiPaymentSystem, string> = {
     mir: `tuiIconMir`,
@@ -51,7 +52,7 @@ export class TuiInputCardComponent
 
     @Input()
     @tuiDefaultProp()
-    cardSrc: string | null = null;
+    cardSrc: PolymorpheusContent = ``;
 
     @Input()
     @tuiDefaultProp()
@@ -76,6 +77,12 @@ export class TuiInputCardComponent
         super(control, changeDetectorRef);
     }
 
+    get defaultCardIcon(): string | null {
+        const {paymentSystem} = this;
+
+        return paymentSystem ? icons[paymentSystem] : null;
+    }
+
     get nativeFocusableElement(): HTMLInputElement | null {
         return this.input ? this.input.nativeFocusableElement : null;
     }
@@ -84,14 +91,8 @@ export class TuiInputCardComponent
         return !!this.input && this.input.focused;
     }
 
-    get icon(): string | null {
-        if (this.cardSrc !== null) {
-            return this.cardSrc;
-        }
-
-        const {paymentSystem} = this;
-
-        return paymentSystem ? icons[paymentSystem] : null;
+    get icon(): PolymorpheusContent {
+        return this.cardSrc || this.defaultCardIcon;
     }
 
     get autocomplete(): TuiAutofillFieldName {

--- a/projects/addon-commerce/components/input-card/test/input-card.component.spec.ts
+++ b/projects/addon-commerce/components/input-card/test/input-card.component.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, TemplateRef, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {configureTestSuite} from '@taiga-ui/testing';
@@ -13,11 +13,18 @@ describe(`InputCard`, () => {
                 [formControl]="control"
                 (binChange)="onBinChange($event)"
             ></tui-input-card>
+
+            <ng-template #customIconTemplateRef>
+                <tui-svg src="tuiIconMastercard"></tui-svg>
+            </ng-template>
         `,
     })
     class TestComponent {
         @ViewChild(TuiInputCardComponent, {static: true})
         component!: TuiInputCardComponent;
+
+        @ViewChild(`customIconTemplateRef`, {read: TemplateRef})
+        customIconTemplateRef!: TemplateRef<any>;
 
         control = new FormControl(``);
 
@@ -137,6 +144,34 @@ describe(`InputCard`, () => {
 
         it(`19`, async () => {
             await testFormat(`4000000000000000000`, `4000 0000 0000 0000 000`);
+        });
+    });
+
+    describe(`customIconSource`, () => {
+        beforeEach(() => testComponent.control.setValue(`4111 1111 1111 1111`));
+
+        it(`input-card component has a default icon`, () => {
+            expect(testComponent.control.valid).toEqual(true);
+            expect(testComponent.component.defaultCardIcon).toEqual(`tuiIconVisa`);
+            expect(testComponent.component.icon).toEqual(`tuiIconVisa`);
+            expect(testComponent.control.value).toEqual(`4111 1111 1111 1111`);
+        });
+
+        it(`input-card component has a tuiIconElectron icon`, () => {
+            testComponent.component.cardSrc = `tuiIconElectron`;
+            expect(testComponent.control.valid).toEqual(true);
+            expect(testComponent.component.defaultCardIcon).toEqual(`tuiIconVisa`);
+            expect(testComponent.component.icon).toEqual(`tuiIconElectron`);
+            expect(testComponent.control.value).toEqual(`4111 1111 1111 1111`);
+        });
+
+        it(`input-card component has an icon source as TemplateRef`, () => {
+            testComponent.component.cardSrc =
+                fixture.componentInstance.customIconTemplateRef;
+            expect(testComponent.control.valid).toEqual(true);
+            expect(testComponent.component.defaultCardIcon).toEqual(`tuiIconVisa`);
+            expect(testComponent.component.icon).toEqual(jasmine.any(TemplateRef));
+            expect(testComponent.control.value).toEqual(`4111 1111 1111 1111`);
         });
     });
 

--- a/projects/addon-commerce/components/input-card/test/input-card.component.spec.ts
+++ b/projects/addon-commerce/components/input-card/test/input-card.component.spec.ts
@@ -152,7 +152,6 @@ describe(`InputCard`, () => {
 
         it(`input-card component has a default icon`, () => {
             expect(testComponent.control.valid).toEqual(true);
-            expect(testComponent.component.defaultCardIcon).toEqual(`tuiIconVisa`);
             expect(testComponent.component.icon).toEqual(`tuiIconVisa`);
             expect(testComponent.control.value).toEqual(`4111 1111 1111 1111`);
         });
@@ -160,7 +159,6 @@ describe(`InputCard`, () => {
         it(`input-card component has a tuiIconElectron icon`, () => {
             testComponent.component.cardSrc = `tuiIconElectron`;
             expect(testComponent.control.valid).toEqual(true);
-            expect(testComponent.component.defaultCardIcon).toEqual(`tuiIconVisa`);
             expect(testComponent.component.icon).toEqual(`tuiIconElectron`);
             expect(testComponent.control.value).toEqual(`4111 1111 1111 1111`);
         });
@@ -169,7 +167,6 @@ describe(`InputCard`, () => {
             testComponent.component.cardSrc =
                 fixture.componentInstance.customIconTemplateRef;
             expect(testComponent.control.valid).toEqual(true);
-            expect(testComponent.component.defaultCardIcon).toEqual(`tuiIconVisa`);
             expect(testComponent.component.icon).toEqual(jasmine.any(TemplateRef));
             expect(testComponent.control.value).toEqual(`4111 1111 1111 1111`);
         });

--- a/projects/demo/src/modules/components/input-card/input-card.template.html
+++ b/projects/demo/src/modules/components/input-card/input-card.template.html
@@ -130,7 +130,7 @@
                             i18n
                             documentationPropertyName="cardSrc"
                             documentationPropertyMode="input"
-                            documentationPropertyType="string | null"
+                            documentationPropertyType="PolymorpheusContent"
                             [documentationPropertyValues]="cardSrcVariants"
                             [(documentationPropertyValue)]="cardSrcSelected"
                         >


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Card icon displayed according to payment system card detection, and supports only string type customisations.

Closes  #2752 

## What is the new behavior?

If you want to override icon handled by payment system with custom card icon, you can do it with `cardSrc` input. Now It works also for templates and custom icons.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
