### PR TITLE
fix(styles): pseudo elements `:after` aren't removed in Safari 16

### DIFF
--- a/projects/core/styles/basic/main.less
+++ b/projects/core/styles/basic/main.less
@@ -71,3 +71,16 @@ html,
 ::-ms-reveal {
     display: none;
 }
+
+// @note: only safari 16+
+@supports (-webkit-hyphens: none) and (text-align-last: right) {
+    /**
+      * @descriptions:
+      * Safari 16 has bug when for some reason,
+      * the ::after blocks aren't removed
+      * after the destruction of the parent class
+     */
+    :after {
+        content: none;
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

