### PR TITLE
chore: `tuiTextfieldCustomContent` fix e2e

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/input/input.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input/input.cy.ts
@@ -6,7 +6,7 @@ describe(`Input`, () => {
 
         it(`has custom content (text) + cleaner + hint which dont overlapping each others`, () => {
             cy.tuiVisit(
-                `${INPUT_PAGE_URL}/API?tuiHintContent=Some content&tuiTextfieldCustomContent=<b>LongTextContent<b>`,
+                `${INPUT_PAGE_URL}/API?tuiMode=null&tuiTextfieldCustomContent=<span>LongTextContent<%2Fspan>&tuiHintContent=Some%20content`,
                 {skipExpectUrl: true},
             );
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #2656 

## What is the new behavior?

valid url for using long text as custom content

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
