### PR TITLE
chore(demo): `Stackblitz` error `Property 'X' is used before its initialization`

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/project-files/configs.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/configs.md
@@ -66,10 +66,10 @@
     "declaration": false,
     "downlevelIteration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2020",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "esnext",
+    "target": "es2015",
     "typeRoots": ["node_modules/@types"],
     "lib": ["esnext", "dom"]
   },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [X] Documentation content changes

## What is the current behavior?
Open Stackblitz of any example from this list:
* https://taiga-ui.dev/components/line-days-chart#base
* https://taiga-ui.dev/components/dialog#data
* https://taiga-ui.dev/components/progress-bar#basic
* https://taiga-ui.dev/components/progress-bar#multicolor
* https://taiga-ui.dev/components/progress-bar#label
* https://taiga-ui.dev/components/progress-circle#basic
* https://taiga-ui.dev/components/progress-circle#label

All these examples throw:
```console
Property 'X' is used before its initialization.
```

It happens because we use DI-entity to create another property in constructor.
But we use this technique in many places of our libraries, and it works!
It depends on ts-configs `useDefineForClassFields` and `target`.
Read this [issue](https://github.com/microsoft/TypeScript/issues/45182).

## What is the new behavior?
Stackblitz configs are the same ones as 
https://github.com/Tinkoff/taiga-ui/blob/93b0ed66982d949e8b5cca204052f49e4a98db5d/tsconfig.json#L30-L32

Mentioned examples work.
## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
