### PR TITLE
fix(kit): put tui-island_transparent after tui-island_hoverable

### DIFF
--- a/projects/styles/markup/tui-island.less
+++ b/projects/styles/markup/tui-island.less
@@ -33,13 +33,13 @@
         }
     }
 
-    &_transparent {
-        background-color: transparent;
-    }
-
     &_hoverable {
         .hoverable-with-shadow();
         background: var(--tui-elevation-02);
+    }
+
+    &_transparent {
+        background-color: transparent;
     }
 
     &_size_s {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #2909

## What is the new behavior?

`tui-island_transparent` has precedence over `tui-island_hoverable`.

![image](https://user-images.githubusercontent.com/22116465/196032152-297f6b3e-8c14-4047-95db-ca2c619ff2af.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
