### PR TITLE
feat(core): disable smooth scrolling when users have prefers-reduced-motion enabled

### DIFF
--- a/projects/addon-doc/src/components/navigation/navigation.style.less
+++ b/projects/addon-doc/src/components/navigation/navigation.style.less
@@ -22,8 +22,8 @@
 }
 
 .t-scrollbar {
+    .scroll-behavior();
     width: 100%;
-    scroll-behavior: smooth;
 }
 
 .t-items-container {

--- a/projects/core/styles/mixins/mixins.less
+++ b/projects/core/styles/mixins/mixins.less
@@ -367,3 +367,15 @@
     overflow: hidden;
     padding: 0;
 }
+
+/**
+ * @description:
+ * disable smooth scrolling when users have prefers-reduced-motion enabled
+ */
+.scroll-behavior(@mode: smooth) {
+    scroll-behavior: @mode;
+
+    @media screen and (prefers-reduced-motion: reduce) {
+        scroll-behavior: auto;
+    }
+}

--- a/projects/kit/components/stepper/stepper.style.less
+++ b/projects/kit/components/stepper/stepper.style.less
@@ -2,10 +2,10 @@
 
 :host {
     .scrollbar-hidden();
+    .scroll-behavior();
     display: flex;
     overflow: auto;
     counter-reset: steps;
-    scroll-behavior: smooth;
 
     &[data-orientation='vertical'] {
         flex-direction: column;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?

Accessibility concerns [#](https://gomakethings.com/how-to-animate-scrolling-to-anchor-links-with-one-line-of-css/#accessibility-concerns)
Animations can cause issues for users who suffer from motion sickness and other conditions.

Fortunately, Windows, macOs, iOS, and Android all provide a way for users to specify that they prefer reduced motion. And all modern browsers (but not IE) provide a way to check for that setting in both CSS and JavaScript.

When using scroll-behavior, you should add a @media check for preders-reduced-motion: reduce, and revert to the default auto.

This prevents animated scrolling when users have specified that they’d prefer reduced motion.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
