### PR TITLE
fix(eslint-plugin): fix incorrect project name search

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,7 +99,7 @@ module.exports = {
         '@taiga-ui/no-deep-imports': [
             'error',
             {
-                currentProject: `(?<=/projects/)([-\\w]+)`,
+                currentProject: `(?<=projects/)([-\\w]+)`,
                 ignoreImports: [
                     '\\?raw',
                     '@taiga-ui/testing/cypress',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

The script gets the absolute path of the file, so if another folder (except for our Taiga `projects` folder) in that path was named `projects` the script would incorrectly resolve the package name to that folders child name.

## What is the new behavior?

Now we check for the regex match only relative to our working directory.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
