### PR TITLE
fix(eslint-plugin): broken `no-deep-imports` on `Windows`-OS

### DIFF
--- a/projects/eslint-plugin/no-deep-imports.js
+++ b/projects/eslint-plugin/no-deep-imports.js
@@ -67,10 +67,9 @@ module.exports = {
         };
 
         const isInsideTheSameEntryPoint = source => {
-            const filePath = path.relative(
-                context.getCwd().replace(/\\+/g, '/'),
-                context.getFilename().replace(/\\+/g, '/'),
-            );
+            const filePath = path
+                .relative(context.getCwd(), context.getFilename())
+                .replace(/\\+/g, '/');
 
             const [currentFileProjectName] =
                 (currentProject && filePath.match(new RegExp(currentProject, 'g'))) || [];


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Same problem as here:
https://github.com/Tinkoff/taiga-ui/pull/2741


## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
