### PR TITLE
chore(demo): `Stackblitz` uses fixed dep-versions from `cdk` & `kit` packages

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/stackblitz-deps.constants.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz-deps.constants.ts
@@ -1,4 +1,11 @@
 import {TUI_VERSION} from '@taiga-ui/cdk';
+// eslint-disable-next-line @taiga-ui/no-deep-imports
+import CDK_PACKAGE from '@taiga-ui/cdk/package.json';
+// eslint-disable-next-line @taiga-ui/no-deep-imports
+import KIT_PACKAGE from '@taiga-ui/kit/package.json';
+
+const CDK_DEPS = CDK_PACKAGE.dependencies;
+const KIT_DEPS = KIT_PACKAGE.dependencies;
 
 const ANGULAR_VERSION = `14.x.x`;
 const TAIGA_VERSION = `${TUI_VERSION.split(`.`)[0]}.x.x`;
@@ -28,12 +35,13 @@ export const STACKBLITZ_DEPS: Record<string, string> = {
     '@taiga-ui/addon-table': TAIGA_VERSION,
     '@taiga-ui/addon-tablebars': TAIGA_VERSION,
     '@tinkoff/ng-dompurify': `*`,
-    '@tinkoff/ng-polymorpheus': `*`,
-    '@ng-web-apis/common': `*`,
-    '@tinkoff/ng-event-plugins': `*`,
-    '@ng-web-apis/intersection-observer': `*`,
-    '@ng-web-apis/mutation-observer': `*`,
-    'text-mask-core': `*`,
+    '@tinkoff/ng-polymorpheus': CDK_DEPS[`@tinkoff/ng-polymorpheus`],
+    '@ng-web-apis/common': CDK_DEPS[`@ng-web-apis/common`],
+    '@tinkoff/ng-event-plugins': CDK_DEPS[`@tinkoff/ng-event-plugins`],
+    '@ng-web-apis/intersection-observer': KIT_DEPS[`@ng-web-apis/intersection-observer`],
+    '@ng-web-apis/resize-observer': CDK_DEPS[`@ng-web-apis/resize-observer`],
+    '@ng-web-apis/mutation-observer': CDK_DEPS[`@ng-web-apis/mutation-observer`],
+    'text-mask-core': KIT_DEPS[`text-mask-core`],
     dompurify: `*`,
     '@types/dompurify': `*`,
     'prosemirror-state': `*`,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [X] Documentation content changes

## What is the current behavior?
Open https://taiga-ui.dev/next/stackblitz

Stackblitz throws error
```
ERROR NullInjectorError: R3InjectorError(AppModule
[InjectionToken [TUI_IS_MOBILE]:
Mobile browser detection ->
InjectionToken An abstraction over window.navigator.userAgent object ->
InjectionToken An abstraction over window.navigator.userAgent object ->
InjectionToken An abstraction over window.navigator.userAgent object]: 
  NullInjectorError: No provider for InjectionToken An abstraction over window.navigator.userAgent object!
    at NullInjector.get (provider_collection.ts:36:1)
    at R3Injector.get (r3_injector.ts:276:19)
    at R3Injector.get (r3_injector.ts:276:19)
    at R3Injector.get (r3_injector.ts:276:19)
    at injectInjectorOnly (injector_compatibility.ts:94:25)
    at ɵɵinject (injector_compatibility.ts:102:15)
    at Object.inject (injector_compatibility.ts:275:13)
    at Object.factory (is-mobile.ts:14:29)
    at R3Injector.hydrate (r3_injector.ts:388:4)
    at R3Injector.get (r3_injector.ts:264:7)
```

## What is the new behavior?
No error

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
