### PR TITLE
feat(kit): customize display control for input-files component

### DIFF
--- a/projects/cdk/schematics/ng-update/index.ts
+++ b/projects/cdk/schematics/ng-update/index.ts
@@ -37,6 +37,7 @@ import {getExecutionTime} from '../utils/get-execution-time';
 import {migrateTaigaProprietaryIcons} from './steps/migrate-taiga-proprietary-icons';
 import {Schema} from '../ng-add/schema';
 import {migrateExpandTemplates} from './v3-5/steps/migrate-expand-templates';
+import {migrateInputFiles} from './steps/migrate-input-files';
 
 export function updateToV3(options: Schema): Rule {
     const t0 = performance.now();
@@ -94,6 +95,7 @@ function main(options: Schema): Rule {
 
         migrateSliders(updatedFileSystem);
         migrateProgress(updatedFileSystem);
+        migrateInputFiles(updatedFileSystem);
         removeModules();
         dateTimeMigrations();
         replaceFunctions();

--- a/projects/cdk/schematics/ng-update/steps/migrate-input-files.ts
+++ b/projects/cdk/schematics/ng-update/steps/migrate-input-files.ts
@@ -70,7 +70,7 @@ function replaceLabelLinkInputs(
         templateResource,
         fileSystem,
         componentSelector: 'tui-input-files',
-        from: 'label',
+        from: '[label]',
         to: '[content]',
         newValue: LABEL_LINK_INPUTS_MIGRATION_METHOD_NAME,
     });
@@ -79,18 +79,18 @@ function replaceLabelLinkInputs(
         templateResource,
         fileSystem,
         componentSelector: 'tui-input-files',
-        from: 'link',
+        from: '[link]',
         to: '[content]',
         newValue: LABEL_LINK_INPUTS_MIGRATION_METHOD_NAME,
-        filterFn: element => !hasElementAttribute(element, 'label'),
+        filterFn: element => !hasElementAttribute(element, '[label]'),
     });
 
     removeInputProperty({
         templateResource,
         fileSystem,
         componentSelector: 'tui-input-files',
-        inputProperty: 'link',
-        filterFn: element => hasElementAttribute(element, 'label'),
+        inputProperty: '[link]',
+        filterFn: element => hasElementAttribute(element, '[label]'),
     });
 
     if (wasLabelInputModified || wasLinkInputModified) {

--- a/projects/cdk/schematics/ng-update/steps/migrate-input-files.ts
+++ b/projects/cdk/schematics/ng-update/steps/migrate-input-files.ts
@@ -1,0 +1,99 @@
+import {
+    createProject,
+    DevkitFileSystem,
+    saveActiveProject,
+    setActiveProject,
+} from 'ng-morph';
+import {ALL_TS_FILES} from '../../constants';
+import {
+    infoLog,
+    PROCESSING_SYMBOL,
+    processLog,
+    REPLACE_SYMBOL,
+    SMALL_TAB_SYMBOL,
+    successLog,
+    SUCCESS_SYMBOL,
+} from '../../utils/colored-log';
+import {setupProgressLogger} from '../../utils/progress';
+import {hasElementAttribute} from '../../utils/templates/elements';
+import {getComponentTemplates} from '../../utils/templates/get-component-templates';
+import {
+    removeInputProperty,
+    replaceInputProperty,
+} from '../../utils/templates/ng-component-input-manipulations';
+import {TemplateResource} from '../interfaces/template-resourse';
+
+const LABEL_LINK_INPUTS_MIGRATION_METHOD_NAME = `tuiMigrationLabelLinkInputs`;
+
+export function migrateInputFiles(fileSystem: DevkitFileSystem): void {
+    infoLog(`${SMALL_TAB_SYMBOL}${REPLACE_SYMBOL} migrating input-files...`);
+    processLog(`${SMALL_TAB_SYMBOL}${SMALL_TAB_SYMBOL}${PROCESSING_SYMBOL}InputFiles...`);
+
+    migrateInputFilesComponent(fileSystem);
+
+    successLog(`${SMALL_TAB_SYMBOL}${SUCCESS_SYMBOL} input-files migrated \n`);
+}
+
+function migrateInputFilesComponent(fileSystem: DevkitFileSystem): void {
+    const templateResources = getComponentTemplates(ALL_TS_FILES);
+    const COMPONENTS_WITH_LABEL_LINK_INPUTS = new Set<string>();
+
+    let progressLog = setupProgressLogger({
+        total: templateResources.length,
+        prefix: '[replaceLabelLinkInputs]',
+    });
+
+    for (const templateResource of templateResources) {
+        progressLog(templateResource.componentPath);
+        replaceLabelLinkInputs(
+            templateResource,
+            fileSystem,
+            COMPONENTS_WITH_LABEL_LINK_INPUTS,
+        );
+    }
+
+    /**
+     * We should update virtual file tree
+     * otherwise all following ng-morph commands will overwrite all previous template manipulations
+     * */
+    fileSystem.commitEdits();
+    saveActiveProject();
+    setActiveProject(createProject(fileSystem.tree));
+}
+
+function replaceLabelLinkInputs(
+    templateResource: TemplateResource,
+    fileSystem: DevkitFileSystem,
+    modifiedComponentStorage: Set<string>,
+): void {
+    const wasLabelInputModified = replaceInputProperty({
+        templateResource,
+        fileSystem,
+        componentSelector: 'tui-input-files',
+        from: 'label',
+        to: '[content]',
+        newValue: LABEL_LINK_INPUTS_MIGRATION_METHOD_NAME,
+    });
+
+    const wasLinkInputModified = replaceInputProperty({
+        templateResource,
+        fileSystem,
+        componentSelector: 'tui-input-files',
+        from: 'link',
+        to: '[content]',
+        newValue: LABEL_LINK_INPUTS_MIGRATION_METHOD_NAME,
+        filterFn: element => !hasElementAttribute(element, 'label'),
+    });
+
+    removeInputProperty({
+        templateResource,
+        fileSystem,
+        componentSelector: 'tui-input-files',
+        inputProperty: 'link',
+        filterFn: element => hasElementAttribute(element, 'label'),
+    });
+
+    if (wasLabelInputModified || wasLinkInputModified) {
+        modifiedComponentStorage.add(templateResource.componentPath);
+    }
+}

--- a/projects/cdk/schematics/ng-update/tests/schematic-replace-html.spec.ts
+++ b/projects/cdk/schematics/ng-update/tests/schematic-replace-html.spec.ts
@@ -446,11 +446,6 @@ const TEMPLATE_AFTER = `<!-- TODO: (Taiga UI migration) tuiFormatNumber pipe has
     </ng-container>
 </tui-breadcrumbs>
 
-<tui-input-files
-    [content]="contentLabel"
->
-</tui-input-files>
-
 <tui-hosted-dropdown
     tuiDropdownAlign="left"
     [sided]="true"
@@ -466,6 +461,11 @@ const TEMPLATE_AFTER = `<!-- TODO: (Taiga UI migration) tuiFormatNumber pipe has
         Button
     </button>
 </tui-hosted-dropdown>
+
+<tui-input-files
+    [content]="contentLabel"
+>
+</tui-input-files>
 `;
 
 const COMPONENT_BEFORE = `

--- a/projects/cdk/schematics/ng-update/tests/schematic-replace-html.spec.ts
+++ b/projects/cdk/schematics/ng-update/tests/schematic-replace-html.spec.ts
@@ -239,6 +239,12 @@ const TEMPLATE_BEFORE = `
         Button
     </button>
 </tui-hosted-dropdown>
+
+<tui-input-files
+    [label]="contentLabel"
+    [link]="contentLink"
+>
+</tui-input-files>
 `;
 
 const TEMPLATE_AFTER = `<!-- TODO: (Taiga UI migration) tuiFormatNumber pipe has new API. See https://taiga-ui.dev/pipes/format-number -->
@@ -439,6 +445,11 @@ const TEMPLATE_AFTER = `<!-- TODO: (Taiga UI migration) tuiFormatNumber pipe has
         </a>
     </ng-container>
 </tui-breadcrumbs>
+
+<tui-input-files
+    [content]="contentLabel"
+>
+</tui-input-files>
 
 <tui-hosted-dropdown
     tuiDropdownAlign="left"

--- a/projects/demo/src/modules/components/input-files/input-files.component.ts
+++ b/projects/demo/src/modules/components/input-files/input-files.component.ts
@@ -55,8 +55,8 @@ export class ExampleTuiInputFilesComponent extends AbstractExampleTuiControl {
     };
 
     readonly control = new FormControl();
-    link = `Choose a file`;
-    label = `or drop\u00A0it\u00A0here`;
+    content = ``;
+    contentVariants = [``, `Drop your file here`, `Place for your file`];
     multiple = true;
     showSize = true;
     accept = ``;

--- a/projects/demo/src/modules/components/input-files/input-files.template.html
+++ b/projects/demo/src/modules/components/input-files/input-files.template.html
@@ -71,8 +71,8 @@
         <tui-doc-demo>
             <tui-input-files
                 [formControl]="control"
-                [link]="link"
-                [label]="label"
+                [accept]="accept"
+                [content]="content"
                 [maxFileSize]="maxFileSize"
                 [focusable]="focusable"
                 [pseudoFocus]="pseudoFocused"
@@ -163,7 +163,7 @@
                 documentationPropertyName="label"
                 documentationPropertyMode="input"
                 documentationPropertyType="string"
-                [(documentationPropertyValue)]="label"
+                [documentationPropertyDeprecated]="true"
             >
                 Label text
             </ng-template>
@@ -172,9 +172,19 @@
                 documentationPropertyName="link"
                 documentationPropertyMode="input"
                 documentationPropertyType="string"
-                [(documentationPropertyValue)]="link"
+                [documentationPropertyDeprecated]="true"
             >
                 Link text
+            </ng-template>
+            <ng-template
+                i18n
+                documentationPropertyName="content"
+                documentationPropertyMode="input"
+                documentationPropertyType="PolymorpheusContent"
+                [documentationPropertyValues]="contentVariants"
+                [(documentationPropertyValue)]="content"
+            >
+                Input label content
             </ng-template>
 
             <ng-template

--- a/projects/kit/components/input-files/input-files.component.ts
+++ b/projects/kit/components/input-files/input-files.component.ts
@@ -28,7 +28,12 @@ import {
 } from '@taiga-ui/cdk';
 import {MODE_PROVIDER, TuiSizeL} from '@taiga-ui/core';
 import {TuiFileLike} from '@taiga-ui/kit/interfaces';
-import {TUI_INPUT_FILE_TEXTS} from '@taiga-ui/kit/tokens';
+import {
+    TUI_INPUT_FILE_TEXTS,
+    TUI_INPUT_FILES_CONTENT,
+    TuiInputFilesContent,
+} from '@taiga-ui/kit/tokens';
+import {} from '@taiga-ui/kit/tokens/input-files-content';
 import {tuiGetAcceptArray} from '@taiga-ui/kit/utils/files';
 import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {Observable, of} from 'rxjs';
@@ -55,6 +60,12 @@ export class TuiInputFilesComponent
 
     private dataTransfer: DataTransfer | null = null;
 
+    /** @deprecated use `content` instead */
+    @Input()
+    @tuiDefaultProp()
+    link: PolymorpheusContent = this.defaultContentValues.link;
+
+    /** @deprecated use `content` instead */
     @ContentChild(TuiInputFilesDirective, {read: TuiInputFilesDirective})
     readonly nativeInput?: TuiInputFilesDirective;
 
@@ -66,11 +77,11 @@ export class TuiInputFilesComponent
 
     @Input()
     @tuiDefaultProp()
-    link: PolymorpheusContent = ``;
+    label: PolymorpheusContent = this.defaultContentValues.label;
 
     @Input()
     @tuiDefaultProp()
-    label: PolymorpheusContent = ``;
+    content: PolymorpheusContent = ``;
 
     /**
      * @deprecated: use `<input tuiInputFiles accept="image/*" />`
@@ -120,6 +131,8 @@ export class TuiInputFilesComponent
                 string
             >
         >,
+        @Inject(TUI_INPUT_FILES_CONTENT)
+        private readonly defaultContentValues: TuiInputFilesContent,
         @Inject(TUI_INPUT_FILES_OPTIONS)
         readonly options: TuiInputFilesOptions,
     ) {

--- a/projects/kit/components/input-files/input-files.component.ts
+++ b/projects/kit/components/input-files/input-files.component.ts
@@ -33,7 +33,6 @@ import {
     TUI_INPUT_FILES_CONTENT,
     TuiInputFilesContent,
 } from '@taiga-ui/kit/tokens';
-import {} from '@taiga-ui/kit/tokens/input-files-content';
 import {tuiGetAcceptArray} from '@taiga-ui/kit/utils/files';
 import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {Observable, of} from 'rxjs';

--- a/projects/kit/components/input-files/input-files.template.html
+++ b/projects/kit/components/input-files/input-files.template.html
@@ -14,14 +14,19 @@
         (tuiDroppableDragOverChange)="onDragOver($event)"
         (mousedown.prevent.silent)="(0)"
     >
-        <a tuiLink>
-            <ng-container *polymorpheusOutlet="computedLink$ | async as text">
+        <ng-container *ngIf="content; else defaultContent">
+            <div *polymorpheusOutlet="content as valueContent">{{ valueContent }}</div>
+        </ng-container>
+        <ng-template #defaultContent>
+            <a tuiLink>
+                <ng-container *polymorpheusOutlet="computedLink$ | async as text">
+                    {{ text }}
+                </ng-container>
+            </a>
+            <ng-container *polymorpheusOutlet="computedLabel$ | async as text">
                 {{ text }}
             </ng-container>
-        </a>
-        <ng-container *polymorpheusOutlet="computedLabel$ | async as text">
-            {{ text }}
-        </ng-container>
+        </ng-template>
         <ng-container *ngIf="!readOnly && !computedDisabled">
             <ng-content select="input"></ng-content>
             <input

--- a/projects/kit/tokens/index.ts
+++ b/projects/kit/tokens/index.ts
@@ -2,6 +2,7 @@ export * from './calendar-date-stream';
 export * from './date-inputs-value-transformers';
 export * from './i18n';
 export * from './input-date-options';
+export * from './input-files-content';
 export * from './items-handlers';
 export * from './mobile-calendar';
 export * from './month-formatter';

--- a/projects/kit/tokens/input-files-content.ts
+++ b/projects/kit/tokens/input-files-content.ts
@@ -1,0 +1,26 @@
+import {InjectionToken, ValueProvider} from '@angular/core';
+import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
+
+export interface TuiInputFilesContent {
+    readonly link: PolymorpheusContent;
+    readonly label: PolymorpheusContent;
+}
+
+export const TUI_INPUT_FILES_DEFAULT_CONTENT: TuiInputFilesContent = {
+    label: ``,
+    link: ``,
+};
+
+export const TUI_INPUT_FILES_CONTENT = new InjectionToken<TuiInputFilesContent>(
+    `[TUI_INPUT_FILES_CONTENT]: Default parameters for files input component`,
+    {
+        factory: () => TUI_INPUT_FILES_DEFAULT_CONTENT,
+    },
+);
+
+export const tuiInputFilesContentProvider: (
+    content: Partial<TuiInputFilesContent>,
+) => ValueProvider = (content: Partial<TuiInputFilesContent>) => ({
+    provide: TUI_INPUT_FILES_CONTENT,
+    useValue: {...TUI_INPUT_FILES_DEFAULT_CONTENT, ...content},
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [x] Documentation content changes

## What is the current behavior?

It's tricky to customize the content of the files component since it assumes there are 2 content elements (`label` and `link`). In the case where dragging occurs the only option for content is via the texts property.

Closes #2734 

## What is the new behavior?

If you want to override the content of the files component you are able to do this via the `content: PolymorpheusContent` input property. If you don't provide a `content` property value, the default behavior is the same and there will be displayed the default `link` and `label` elements.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
