### PR TITLE
feat(core): replace `TUI_DROPDOWN_OFFSET` with injection token

### DIFF
--- a/projects/core/directives/dropdown/dropdown-options.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-options.directive.ts
@@ -16,17 +16,13 @@ import {
 } from '@taiga-ui/core/types';
 import {tuiOverrideOptions} from '@taiga-ui/core/utils';
 
-/**
- * Safe space around host and screen edges
- */
-export const TUI_DROPDOWN_OFFSET = 4;
-
 export interface TuiDropdownOptions {
     readonly align: TuiHorizontalDirection;
     readonly direction: TuiVerticalDirection | null;
     readonly limitWidth: TuiDropdownWidth;
     readonly minHeight: number;
     readonly maxHeight: number;
+    readonly offset: number;
 }
 
 /** Default values for dropdown options */
@@ -36,6 +32,7 @@ export const TUI_DROPDOWN_DEFAULT_OPTIONS: TuiDropdownOptions = {
     limitWidth: `auto`,
     maxHeight: 400,
     minHeight: 80,
+    offset: 4,
 };
 
 export const TUI_DROPDOWN_OPTIONS = new InjectionToken<TuiDropdownOptions>(
@@ -57,7 +54,7 @@ export const tuiDropdownOptionsProvider: (
 });
 
 @Directive({
-    selector: `[tuiDropdownAlign], [tuiDropdownDirection], [tuiDropdownLimitWidth], [tuiDropdownMinHeight], [tuiDropdownMaxHeight]`,
+    selector: `[tuiDropdownAlign], [tuiDropdownDirection], [tuiDropdownLimitWidth], [tuiDropdownMinHeight], [tuiDropdownMaxHeight], [tuiDropdownOffset]`,
     providers: [
         {
             provide: TUI_DROPDOWN_OPTIONS,
@@ -85,6 +82,10 @@ export class TuiDropdownOptionsDirective implements TuiDropdownOptions {
     @Input(`tuiDropdownMaxHeight`)
     @tuiDefaultProp()
     maxHeight = this.options.maxHeight;
+
+    @Input(`tuiDropdownOffset`)
+    @tuiDefaultProp()
+    offset = this.options.offset;
 
     constructor(
         @SkipSelf()

--- a/projects/core/directives/dropdown/dropdown-position-sided.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-position-sided.directive.ts
@@ -7,11 +7,7 @@ import {
 } from '@taiga-ui/core/abstract';
 import {TuiPoint} from '@taiga-ui/core/types';
 
-import {
-    TUI_DROPDOWN_OFFSET,
-    TUI_DROPDOWN_OPTIONS,
-    TuiDropdownOptions,
-} from './dropdown-options.directive';
+import {TUI_DROPDOWN_OPTIONS, TuiDropdownOptions} from './dropdown-options.directive';
 import {TuiDropdownPositionDirective} from './dropdown-position.directive';
 
 @Directive({
@@ -46,15 +42,15 @@ export class TuiDropdownPositionSidedDirective implements TuiPositionAccessor {
         const {align, direction, minHeight} = this.options;
         const available = {
             top: hostRect.bottom,
-            left: hostRect.left - TUI_DROPDOWN_OFFSET,
-            right: innerWidth - hostRect.right - TUI_DROPDOWN_OFFSET,
+            left: hostRect.left - this.options.offset,
+            right: innerWidth - hostRect.right - this.options.offset,
             bottom: innerHeight - hostRect.top,
         } as const;
         const position = {
-            top: hostRect.bottom - height + 2 * TUI_DROPDOWN_OFFSET + 1, // 1 for border
-            left: hostRect.left - width - TUI_DROPDOWN_OFFSET,
-            right: hostRect.right + TUI_DROPDOWN_OFFSET,
-            bottom: hostRect.top - 2 * TUI_DROPDOWN_OFFSET - 1, // 1 for border
+            top: hostRect.bottom - height + 1, // 1 for border
+            left: hostRect.left - width - this.options.offset,
+            right: hostRect.right + this.options.offset,
+            bottom: hostRect.top - 1, // 1 for border
         } as const;
         const better = available.top > available.bottom ? `top` : `bottom`;
         const maxLeft = available.left > available.right ? position.left : position.right;

--- a/projects/core/directives/dropdown/dropdown-position.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-position.directive.ts
@@ -7,11 +7,7 @@ import {
 } from '@taiga-ui/core/abstract';
 import {TuiPoint, TuiVerticalDirection} from '@taiga-ui/core/types';
 
-import {
-    TUI_DROPDOWN_OFFSET,
-    TUI_DROPDOWN_OPTIONS,
-    TuiDropdownOptions,
-} from './dropdown-options.directive';
+import {TUI_DROPDOWN_OPTIONS, TuiDropdownOptions} from './dropdown-options.directive';
 
 @Directive({
     selector: `[tuiDropdown]:not([tuiDropdownCustomPosition]):not([tuiDropdownSided])`,
@@ -31,17 +27,17 @@ export class TuiDropdownPositionDirective implements TuiPositionAccessor {
         const {innerHeight, innerWidth} = this.windowRef;
         const {minHeight, align, direction} = this.options;
         const previous = this.previous || direction || `bottom`;
-        const right = Math.max(hostRect.right - width, TUI_DROPDOWN_OFFSET);
+        const right = Math.max(hostRect.right - width, this.options.offset);
         const available = {
-            top: hostRect.top - 2 * TUI_DROPDOWN_OFFSET,
-            bottom: innerHeight - hostRect.bottom - 2 * TUI_DROPDOWN_OFFSET,
+            top: hostRect.top - 2 * this.options.offset,
+            bottom: innerHeight - hostRect.bottom - 2 * this.options.offset,
         } as const;
         const position = {
-            top: hostRect.top - TUI_DROPDOWN_OFFSET - height,
-            bottom: hostRect.bottom + TUI_DROPDOWN_OFFSET,
+            top: hostRect.top - this.options.offset - height,
+            bottom: hostRect.bottom + this.options.offset,
             right,
             left:
-                hostRect.left + width < innerWidth - TUI_DROPDOWN_OFFSET
+                hostRect.left + width < innerWidth - this.options.offset
                     ? hostRect.left
                     : right,
         } as const;

--- a/projects/core/directives/dropdown/dropdown.component.ts
+++ b/projects/core/directives/dropdown/dropdown.component.ts
@@ -28,11 +28,7 @@ import {takeUntil} from 'rxjs/operators';
 // eslint-disable-next-line import/no-cycle
 import {TuiDropdownDirective} from './dropdown.directive';
 import {TuiDropdownHoverDirective} from './dropdown-hover.directive';
-import {
-    TUI_DROPDOWN_OFFSET,
-    TUI_DROPDOWN_OPTIONS,
-    TuiDropdownOptions,
-} from './dropdown-options.directive';
+import {TUI_DROPDOWN_OPTIONS, TuiDropdownOptions} from './dropdown-options.directive';
 
 /**
  *  This component is used to show template in a portal using default style of white rounded box with a shadow
@@ -105,13 +101,13 @@ export class TuiDropdownComponent {
         const isIntersecting =
             left < rect.right &&
             right > rect.left &&
-            top < offsetY + 2 * TUI_DROPDOWN_OFFSET;
+            top < offsetY + 2 * this.options.offset;
         const available = isIntersecting
-            ? rect.top - 2 * TUI_DROPDOWN_OFFSET
-            : offsetY + innerHeight - top - TUI_DROPDOWN_OFFSET;
+            ? rect.top - 2 * this.options.offset
+            : offsetY + innerHeight - top - this.options.offset;
 
         style.position = position;
-        style.top = tuiPx(Math.max(top, offsetY + TUI_DROPDOWN_OFFSET));
+        style.top = tuiPx(Math.max(top, offsetY + this.options.offset));
         style.left = tuiPx(left);
         style.maxHeight = tuiPx(Math.min(maxHeight, available));
         style.width = ``;

--- a/projects/demo/src/modules/app/autogenerated-code-hints/autogenerated-code-hints.component.ts
+++ b/projects/demo/src/modules/app/autogenerated-code-hints/autogenerated-code-hints.component.ts
@@ -17,6 +17,7 @@ const DROPDOWN_CONTROLLER_SELECTORS = [
     `tuiDropdownLimitWidth`,
     `tuiDropdownMinHeight`,
     `tuiDropdownMaxHeight`,
+    `tuiDropdownOffset`,
 ];
 
 @Component({

--- a/projects/demo/src/modules/components/abstract/control.ts
+++ b/projects/demo/src/modules/components/abstract/control.ts
@@ -147,6 +147,8 @@ export abstract class AbstractExampleTuiControl
 
     postfix = this.prefixVariants[0];
 
+    dropdownOffset = TUI_DROPDOWN_DEFAULT_OPTIONS.offset;
+
     get customContent(): PolymorpheusContent {
         return this.customContentSelected === CUSTOM_SVG_NAME
             ? CUSTOM_SVG

--- a/projects/demo/src/modules/components/abstract/dropdown-documentation/dropdown-documentation.template.html
+++ b/projects/demo/src/modules/components/abstract/dropdown-documentation/dropdown-documentation.template.html
@@ -69,4 +69,13 @@
     >
         Maximum height of dropdown
     </ng-template>
+    <ng-template
+        i18n
+        documentationPropertyName="dropdownOffset"
+        documentationPropertyMode="input"
+        documentationPropertyType="number"
+        [(documentationPropertyValue)]="documentedComponent.dropdownOffset"
+    >
+        Dropdown offset
+    </ng-template>
 </tui-doc-documentation>

--- a/projects/demo/src/modules/components/abstract/dropdown.ts
+++ b/projects/demo/src/modules/components/abstract/dropdown.ts
@@ -24,4 +24,5 @@ export abstract class AbstractExampleTuiDropdown {
     dropdownLimitWidth = TUI_DROPDOWN_DEFAULT_OPTIONS.limitWidth;
     dropdownMinHeight = TUI_DROPDOWN_DEFAULT_OPTIONS.minHeight;
     dropdownMaxHeight = TUI_DROPDOWN_DEFAULT_OPTIONS.maxHeight;
+    dropdownOffset = TUI_DROPDOWN_DEFAULT_OPTIONS.offset;
 }

--- a/projects/demo/src/modules/components/combo-box/combo-box.template.html
+++ b/projects/demo/src/modules/components/combo-box/combo-box.template.html
@@ -115,6 +115,7 @@
                     [tuiDropdownLimitWidth]="dropdownLimitWidth"
                     [tuiDropdownMinHeight]="dropdownMinHeight"
                     [tuiDropdownMaxHeight]="dropdownMaxHeight"
+                    [tuiDropdownOffset]="dropdownOffset"
                     [tuiHintContent]="hintContent"
                     [tuiHintDirection]="hintDirection"
                     [tuiHintAppearance]="hintAppearance"

--- a/projects/demo/src/modules/components/hosted-dropdown/hosted-dropdown.template.html
+++ b/projects/demo/src/modules/components/hosted-dropdown/hosted-dropdown.template.html
@@ -68,6 +68,7 @@
                 [tuiDropdownLimitWidth]="dropdownLimitWidth"
                 [tuiDropdownMinHeight]="dropdownMinHeight"
                 [tuiDropdownMaxHeight]="dropdownMaxHeight"
+                [tuiDropdownOffset]="dropdownOffset"
                 [(open)]="open"
             >
                 <tui-input

--- a/projects/demo/src/modules/components/input-phone-international/input-phone-international.template.html
+++ b/projects/demo/src/modules/components/input-phone-international/input-phone-international.template.html
@@ -47,6 +47,7 @@
                     [tuiDropdownDirection]="dropdownDirection"
                     [tuiDropdownMinHeight]="dropdownMinHeight"
                     [tuiDropdownMaxHeight]="dropdownMaxHeight"
+                    [tuiDropdownOffset]="dropdownOffset"
                     [tuiHintContent]="hintContent"
                     [tuiHintDirection]="hintDirection"
                     [tuiHintAppearance]="hintAppearance"

--- a/projects/demo/src/modules/components/input-phone/input-phone.template.html
+++ b/projects/demo/src/modules/components/input-phone/input-phone.template.html
@@ -71,6 +71,7 @@
                     [tuiDropdownLimitWidth]="dropdownLimitWidth"
                     [tuiDropdownMinHeight]="dropdownMinHeight"
                     [tuiDropdownMaxHeight]="dropdownMaxHeight"
+                    [tuiDropdownOffset]="dropdownOffset"
                     [tuiHintContent]="hintContent"
                     [tuiHintDirection]="hintDirection"
                     [tuiHintAppearance]="hintAppearance"

--- a/projects/demo/src/modules/components/input-tag/input-tag.template.html
+++ b/projects/demo/src/modules/components/input-tag/input-tag.template.html
@@ -92,6 +92,7 @@
                     [tuiDropdownLimitWidth]="dropdownLimitWidth"
                     [tuiDropdownMinHeight]="dropdownMinHeight"
                     [tuiDropdownMaxHeight]="dropdownMaxHeight"
+                    [tuiDropdownOffset]="dropdownOffset"
                     [tuiHintContent]="hintContent"
                     [tuiHintDirection]="hintDirection"
                     [tuiHintAppearance]="hintAppearance"

--- a/projects/demo/src/modules/components/input-time/input-time.template.html
+++ b/projects/demo/src/modules/components/input-time/input-time.template.html
@@ -69,6 +69,7 @@
                     [tuiDropdownLimitWidth]="dropdownLimitWidth"
                     [tuiDropdownMinHeight]="dropdownMinHeight"
                     [tuiDropdownMaxHeight]="dropdownMaxHeight"
+                    [tuiDropdownOffset]="dropdownOffset"
                     [items]="items"
                     [itemSize]="itemSize"
                     [tuiTextfieldCleaner]="cleaner"

--- a/projects/demo/src/modules/components/input/input.template.html
+++ b/projects/demo/src/modules/components/input/input.template.html
@@ -248,6 +248,7 @@
                     [tuiDropdownLimitWidth]="dropdownLimitWidth"
                     [tuiDropdownMinHeight]="dropdownMinHeight"
                     [tuiDropdownMaxHeight]="dropdownMaxHeight"
+                    [tuiDropdownOffset]="dropdownOffset"
                     [tuiHintContent]="hintContent"
                     [tuiHintDirection]="hintDirection"
                     [tuiHintAppearance]="hintAppearance"

--- a/projects/demo/src/modules/components/multi-select/multi-select.template.html
+++ b/projects/demo/src/modules/components/multi-select/multi-select.template.html
@@ -116,6 +116,7 @@
                     [tuiDropdownLimitWidth]="dropdownLimitWidth"
                     [tuiDropdownMinHeight]="dropdownMinHeight"
                     [tuiDropdownMaxHeight]="dropdownMaxHeight"
+                    [tuiDropdownOffset]="dropdownOffset"
                     [tuiTextfieldCleaner]="cleaner"
                     [tuiTextfieldLabelOutside]="labelOutside"
                     [tuiTextfieldSize]="size"

--- a/projects/demo/src/modules/components/select/select.template.html
+++ b/projects/demo/src/modules/components/select/select.template.html
@@ -153,6 +153,7 @@
                     [tuiDropdownLimitWidth]="dropdownLimitWidth"
                     [tuiDropdownMinHeight]="dropdownMinHeight"
                     [tuiDropdownMaxHeight]="dropdownMaxHeight"
+                    [tuiDropdownOffset]="dropdownOffset"
                     [tuiTextfieldCleaner]="cleaner"
                     [tuiTextfieldCustomContent]="customContent"
                     [tuiTextfieldLabelOutside]="labelOutside"

--- a/projects/demo/src/modules/directives/dropdown-context/dropdown-context.component.html
+++ b/projects/demo/src/modules/directives/dropdown-context/dropdown-context.component.html
@@ -68,6 +68,7 @@
                 [tuiDropdownAlign]="dropdownAlign"
                 [tuiDropdownDirection]="dropdownDirection"
                 [tuiDropdownLimitWidth]="dropdownLimitWidth"
+                [tuiDropdownOffset]="dropdownOffset"
             >
                 Right click on me to
                 <strong>see a dropdown</strong>

--- a/projects/demo/src/modules/directives/dropdown-hover/dropdown-hover.template.html
+++ b/projects/demo/src/modules/directives/dropdown-hover/dropdown-hover.template.html
@@ -40,6 +40,7 @@
                 [tuiDropdownAlign]="dropdownAlign"
                 [tuiDropdownDirection]="dropdownDirection"
                 [tuiDropdownLimitWidth]="dropdownLimitWidth"
+                [tuiDropdownOffset]="dropdownOffset"
             >
                 Hover pointer over
                 <strong>to see a dropdown</strong>

--- a/projects/demo/src/modules/directives/dropdown-selection/dropdown-selection.template.html
+++ b/projects/demo/src/modules/directives/dropdown-selection/dropdown-selection.template.html
@@ -39,6 +39,7 @@
                 [tuiDropdownAlign]="dropdownAlign"
                 [tuiDropdownDirection]="dropdownDirection"
                 [tuiDropdownLimitWidth]="dropdownLimitWidth"
+                [tuiDropdownOffset]="dropdownOffset"
             >
                 Select a text to
                 <strong>see a dropdown</strong>

--- a/projects/demo/src/modules/directives/dropdown/dropdown.template.html
+++ b/projects/demo/src/modules/directives/dropdown/dropdown.template.html
@@ -70,6 +70,7 @@
                     [tuiDropdownDirection]="dropdownDirection"
                     [tuiDropdownLimitWidth]="dropdownLimitWidth"
                     [tuiDropdownManual]="open"
+                    [tuiDropdownOffset]="dropdownOffset"
                     (tuiObscured)="onObscured($event)"
                     (click)="onClick()"
                 >


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [x] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

In different design systems, the `tui-data-list` may contain paddings other than `4px`, which are set by the `TUI_DROPDOWN_OFFSET` constant. I would like to do this as an injection token so that the dropdown does not cover the content.

<img width="156" alt="image" src="https://user-images.githubusercontent.com/25961234/204524993-36d5de2b-818b-481f-b976-6db40314c9b3.png">

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
