### PR TITLE
feat(kit): avatar now accepts `SafeResourceUrl` as `avatarUrl`

### DIFF
--- a/projects/demo/src/modules/components/avatar/avatar.template.html
+++ b/projects/demo/src/modules/components/avatar/avatar.template.html
@@ -95,7 +95,7 @@
             <ng-template
                 i18n
                 documentationPropertyName="avatarUrl"
-                documentationPropertyType="string | null"
+                documentationPropertyType="string | SafeResourceUrl | null"
                 documentationPropertyMode="input"
                 [documentationPropertyValues]="avatarUrlVariants"
                 [(documentationPropertyValue)]="avatarUrl"

--- a/projects/kit/components/avatar/avatar.component.ts
+++ b/projects/kit/components/avatar/avatar.component.ts
@@ -79,9 +79,7 @@ export class TuiAvatarComponent {
     }
 
     get stringAvatar(): string {
-        return this.iconAvatar && typeof this.avatarUrl === `string`
-            ? this.avatarUrl
-            : ``;
+        return this.iconAvatar ? String(this.avatarUrl) : ``;
     }
 
     onError(): void {

--- a/projects/kit/components/avatar/avatar.component.ts
+++ b/projects/kit/components/avatar/avatar.component.ts
@@ -78,6 +78,12 @@ export class TuiAvatarComponent {
             : words[0].slice(0, 1);
     }
 
+    get stringAvatar(): string {
+        return this.iconAvatar && typeof this.avatarUrl === `string`
+            ? this.avatarUrl
+            : ``;
+    }
+
     onError(): void {
         this.isUrlValid = false;
     }

--- a/projects/kit/components/avatar/avatar.component.ts
+++ b/projects/kit/components/avatar/avatar.component.ts
@@ -5,6 +5,7 @@ import {
     Inject,
     Input,
 } from '@angular/core';
+import {SafeResourceUrl} from '@angular/platform-browser';
 import {tuiDefaultProp, tuiRequiredSetter} from '@taiga-ui/cdk';
 import {tuiSizeBigger} from '@taiga-ui/core';
 import {tuiStringHashToHsl} from '@taiga-ui/kit/utils/format';
@@ -25,7 +26,7 @@ export class TuiAvatarComponent {
 
     @Input(`avatarUrl`)
     @tuiRequiredSetter()
-    set avatarUrlSetter(avatarUrl: string | null) {
+    set avatarUrlSetter(avatarUrl: string | null | SafeResourceUrl) {
         this.avatarUrl = avatarUrl;
         this.isUrlValid = !!avatarUrl && !this.iconAvatar;
     }
@@ -43,7 +44,7 @@ export class TuiAvatarComponent {
     @tuiDefaultProp()
     rounded: boolean = this.options.rounded;
 
-    avatarUrl: string | null = null;
+    avatarUrl: string | null | SafeResourceUrl = null;
 
     isUrlValid = false;
 
@@ -60,7 +61,9 @@ export class TuiAvatarComponent {
     }
 
     get iconAvatar(): boolean {
-        return !!this.avatarUrl?.startsWith(`tuiIcon`);
+        return (
+            typeof this.avatarUrl === `string` && !!this.avatarUrl?.startsWith(`tuiIcon`)
+        );
     }
 
     get computedText(): string {

--- a/projects/kit/components/avatar/avatar.template.html
+++ b/projects/kit/components/avatar/avatar.template.html
@@ -9,6 +9,6 @@
 <tui-svg
     *ngIf="iconAvatar"
     class="t-icon"
-    [src]="avatarUrl || ''"
+    [src]="$any(avatarUrl || '')"
 ></tui-svg>
 <span class="t-text">{{ computedText }}</span>

--- a/projects/kit/components/avatar/avatar.template.html
+++ b/projects/kit/components/avatar/avatar.template.html
@@ -9,6 +9,6 @@
 <tui-svg
     *ngIf="stringAvatar"
     class="t-icon"
-    [src]="stringAvatar || ''"
+    [src]="stringAvatar"
 ></tui-svg>
 <span class="t-text">{{ computedText }}</span>

--- a/projects/kit/components/avatar/avatar.template.html
+++ b/projects/kit/components/avatar/avatar.template.html
@@ -7,8 +7,8 @@
     (error)="onError()"
 />
 <tui-svg
-    *ngIf="iconAvatar"
+    *ngIf="stringAvatar"
     class="t-icon"
-    [src]="$any(avatarUrl || '')"
+    [src]="stringAvatar || ''"
 ></tui-svg>
 <span class="t-text">{{ computedText }}</span>

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -6,6 +6,7 @@ import {
     Inject,
     Input,
 } from '@angular/core';
+import {SafeResourceUrl} from '@angular/platform-browser';
 import {IntersectionObserverService} from '@ng-web-apis/intersection-observer';
 import {TuiDestroyService} from '@taiga-ui/cdk';
 
@@ -17,7 +18,7 @@ import {TuiLazyLoadingService} from './lazy-loading.service';
 })
 export class TuiLazyLoadingDirective {
     @Input(`src`)
-    set srcSetter(src: string) {
+    set srcSetter(src: string | SafeResourceUrl) {
         this.src = this.supported ? src : null;
         this.src$.next(src);
     }
@@ -29,7 +30,7 @@ export class TuiLazyLoadingDirective {
     background = `var(--tui-clear-hover)`;
 
     @HostBinding(`attr.src`)
-    src: string | null = null;
+    src: string | null | SafeResourceUrl = null;
 
     constructor(
         @Inject(TuiLazyLoadingService)

--- a/projects/kit/directives/lazy-loading/lazy-loading.service.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.service.ts
@@ -1,12 +1,13 @@
 import {ChangeDetectorRef, Inject, Injectable} from '@angular/core';
+import {SafeResourceUrl} from '@angular/platform-browser';
 import {IntersectionObserverService} from '@ng-web-apis/intersection-observer';
 import {TuiDestroyService, tuiWatch} from '@taiga-ui/cdk';
 import {Observable, of, Subject} from 'rxjs';
 import {catchError, filter, mapTo, switchMap, take, takeUntil} from 'rxjs/operators';
 
 @Injectable()
-export class TuiLazyLoadingService extends Observable<string> {
-    private readonly src$ = new Subject<string>();
+export class TuiLazyLoadingService extends Observable<string | SafeResourceUrl> {
+    private readonly src$ = new Subject<string | SafeResourceUrl>();
 
     constructor(
         @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
@@ -32,7 +33,7 @@ export class TuiLazyLoadingService extends Observable<string> {
         );
     }
 
-    next(src: string): void {
+    next(src: string | SafeResourceUrl): void {
         this.src$.next(src);
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

If `SafeResourceUrl` is provided via the input the component breaks. 

Closes #3047 

## What is the new behavior?

Works correctly and can use `SafeResourceUrl`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
