### PR TITLE
fix(addon-table): don't update direction order when updating sorter programmatically

### DIFF
--- a/projects/addon-table/components/table/directives/table.directive.ts
+++ b/projects/addon-table/components/table/directives/table.directive.ts
@@ -63,21 +63,30 @@ export class TuiTableDirective<
     @tuiDefaultProp()
     sorter: TuiComparator<T> = () => 0;
 
-    updateSorter(sorter: TuiComparator<T> | null): void {
+    updateSorterAndDirection(sorter: TuiComparator<T> | null): void {
         if (this.sorter === sorter) {
-            this.direction = this.direction === 1 ? -1 : 1;
-            this.directionChange.emit(this.direction);
+            this.updateDirection(this.direction === 1 ? -1 : 1);
         } else {
-            this.sorter = sorter || (() => 0);
-            this.sorterChange.emit(this.sorter);
-            this.direction = 1;
-            this.directionChange.emit(1);
+            this.updateSorter(sorter);
+            this.updateDirection(1);
         }
-
-        this.change$.next();
     }
 
     ngAfterViewInit(): void {
         this.changeDetectorRef.detectChanges();
+    }
+
+    updateSorter(sorter: TuiComparator<T> | null): void {
+        if (sorter !== this.sorter) {
+            this.sorter = sorter || (() => 0);
+            this.sorterChange.emit(this.sorter);
+            this.change$.next();
+        }
+    }
+
+    private updateDirection(direction: -1 | 1): void {
+        this.direction = direction;
+        this.directionChange.emit(this.direction);
+        this.change$.next();
     }
 }

--- a/projects/addon-table/components/table/directives/table.directive.ts
+++ b/projects/addon-table/components/table/directives/table.directive.ts
@@ -77,11 +77,9 @@ export class TuiTableDirective<
     }
 
     updateSorter(sorter: TuiComparator<T> | null): void {
-        if (sorter !== this.sorter) {
-            this.sorter = sorter || (() => 0);
-            this.sorterChange.emit(this.sorter);
-            this.change$.next();
-        }
+        this.sorter = sorter || (() => 0);
+        this.sorterChange.emit(this.sorter);
+        this.change$.next();
     }
 
     private updateDirection(direction: -1 | 1): void {

--- a/projects/addon-table/components/table/directives/test/direction-order.directive.spec.ts
+++ b/projects/addon-table/components/table/directives/test/direction-order.directive.spec.ts
@@ -65,5 +65,11 @@ describe(`TuiDirectionOrder directive`, () => {
 
             expect(testComponent.directionOrderChange).toHaveBeenCalledWith(`desc`);
         });
+
+        it(`should not emit directionChange when updating sorter programmatically`, () => {
+            testComponent.table.updateSorter(() => -1);
+
+            expect(testComponent.directionOrderChange).not.toHaveBeenCalled();
+        });
     });
 });

--- a/projects/addon-table/components/table/th/th.template.html
+++ b/projects/addon-table/components/table/th/th.template.html
@@ -3,7 +3,7 @@
     type="button"
     class="t-sort"
     [class.t-sort_sorted]="isCurrent"
-    (click)="table.updateSorter(sorter)"
+    (click)="table.updateSorterAndDirection(sorter)"
 >
     <ng-container [ngTemplateOutlet]="content"></ng-container>
     {{ table.change$ | async }}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #2969 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
