### PR TITLE
fix(i18n): fix dutch translations for `multiSelectTexts`

### DIFF
--- a/projects/i18n/languages/dutch/kit.ts
+++ b/projects/i18n/languages/dutch/kit.ts
@@ -54,7 +54,7 @@ export const TUI_DUTCH_LANGUAGE_KIT: TuiLanguageKit = {
         dropMultiple: `Zet hier bestanden neer`,
     },
     multiSelectTexts: {
-        all: `Selecteer alle`,
+        all: `Selecteer alles`,
         none: `Selecteer geen`,
     },
 };

--- a/projects/i18n/languages/dutch/kit.ts
+++ b/projects/i18n/languages/dutch/kit.ts
@@ -54,7 +54,7 @@ export const TUI_DUTCH_LANGUAGE_KIT: TuiLanguageKit = {
         dropMultiple: `Zet hier bestanden neer`,
     },
     multiSelectTexts: {
-        all: `Vælg alle`,
-        none: `Vælg ingen`,
+        all: `Selecteer alle`,
+        none: `Selecteer geen`,
     },
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Current texts are in Norwegian (I guess?) instead of Dutch.

## What is the new behavior?

Now the texts are correctly translated.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
