### PR TITLE
fix(kit): fix reopening nested dropdown

### DIFF
--- a/projects/kit/directives/data-list-dropdown-manager/data-list-dropdown-manager.directive.ts
+++ b/projects/kit/directives/data-list-dropdown-manager/data-list-dropdown-manager.directive.ts
@@ -46,7 +46,7 @@ export class TuiDataListDropdownManagerDirective implements AfterViewInit {
     ) {}
 
     ngAfterViewInit(): void {
-        this.right$.subscribe(index => {
+        this.right$.pipe(takeUntil(this.destroy$)).subscribe(index => {
             this.tryToFocus(index);
         });
 

--- a/projects/kit/directives/data-list-dropdown-manager/data-list-dropdown-manager.directive.ts
+++ b/projects/kit/directives/data-list-dropdown-manager/data-list-dropdown-manager.directive.ts
@@ -3,10 +3,13 @@ import {
     ContentChildren,
     Directive,
     ElementRef,
+    Inject,
     QueryList,
+    Self,
 } from '@angular/core';
 import {
     EMPTY_QUERY,
+    TuiDestroyService,
     tuiGetClosestFocusable,
     tuiItemsQueryListObservable,
     tuiPreventDefault,
@@ -23,11 +26,13 @@ import {
     shareReplay,
     switchMap,
     take,
+    takeUntil,
     tap,
 } from 'rxjs/operators';
 
 @Directive({
     selector: `tui-data-list[tuiDataListDropdownManager]`,
+    providers: [TuiDestroyService],
 })
 export class TuiDataListDropdownManagerDirective implements AfterViewInit {
     @ContentChildren(TuiDropdownDirective, {descendants: true})
@@ -35,6 +40,10 @@ export class TuiDataListDropdownManagerDirective implements AfterViewInit {
 
     @ContentChildren(TuiDropdownDirective, {read: ElementRef, descendants: true})
     private readonly elements: QueryList<ElementRef<HTMLElement>> = EMPTY_QUERY;
+
+    constructor(
+        @Self() @Inject(TuiDestroyService) private readonly destroy$: TuiDestroyService,
+    ) {}
 
     ngAfterViewInit(): void {
         this.right$.subscribe(index => {
@@ -76,6 +85,7 @@ export class TuiDataListDropdownManagerDirective implements AfterViewInit {
                         }),
                     );
                 }),
+                takeUntil(this.destroy$),
             )
             .subscribe();
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
I found that reopening happens when we click on the submenu item faster than [this debounceTime](https://github.com/Tinkoff/taiga-ui/blob/main/projects/kit/directives/data-list-dropdown-manager/data-list-dropdown-manager.directive.ts#L139) in `DataListDropdownManager`. The child data list recreates when parent data-list already closed. 

Closes #3249 

## What is the new behavior?
takeUntil stops the stream when the parent data-list closes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
