### PR TITLE
chore(demo): fix broken stackblitz examples with virtual scroll

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/utils.ts
+++ b/projects/demo/src/modules/app/stackblitz/utils.ts
@@ -152,6 +152,7 @@ import {
     ${tablebars}
 } from '@taiga-ui/addon-tablebars';
 
+import {ScrollingModule} from '@angular/cdk/scrolling';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
@@ -164,6 +165,7 @@ export const ALL_TAIGA_UI_MODULES = [
     BrowserAnimationsModule,
     FormsModule,
     ReactiveFormsModule,
+    ScrollingModule,
     PolymorpheusModule,
     RouterModule.forRoot([]),
     /* CDK */

--- a/projects/demo/src/modules/components/combo-box/combo-box.template.html
+++ b/projects/demo/src/modules/components/combo-box/combo-box.template.html
@@ -59,7 +59,23 @@
             id="virtual"
             heading="Virtual scroll"
             [content]="example5"
+            [description]="cdkVirtualScrollDescription"
         >
+            <ng-template #cdkVirtualScrollDescription>
+                You can use
+                <code>ComboBox</code>
+                with
+                <code>ScrollingModule</code>
+                from
+                <a
+                    tuiLink
+                    href="https://material.angular.io/cdk/scrolling/overview"
+                    target="_blank"
+                >
+                    @angular/cdk/scrolling
+                </a>
+                .
+            </ng-template>
             <tui-notification class="tui-space_bottom-3">
                 Note that virtual scroll can imperatively remove focused option from DOM. This causes ExpressionChange
                 errors and to solve those take a look at a tiny

--- a/projects/demo/src/modules/components/multi-select/multi-select.template.html
+++ b/projects/demo/src/modules/components/multi-select/multi-select.template.html
@@ -68,7 +68,23 @@
             id="virtual"
             heading="Virtual scroll"
             [content]="example7"
+            [description]="cdkVirtualScrollDescription"
         >
+            <ng-template #cdkVirtualScrollDescription>
+                You can use
+                <code>MultiSelect</code>
+                with
+                <code>ScrollingModule</code>
+                from
+                <a
+                    tuiLink
+                    href="https://material.angular.io/cdk/scrolling/overview"
+                    target="_blank"
+                >
+                    @angular/cdk/scrolling
+                </a>
+                .
+            </ng-template>
             <tui-multi-select-example-7></tui-multi-select-example-7>
         </tui-doc-example>
 

--- a/projects/demo/src/modules/components/select/select.template.html
+++ b/projects/demo/src/modules/components/select/select.template.html
@@ -82,7 +82,23 @@
             id="virtual"
             heading="Virtual scroll"
             [content]="example8"
+            [description]="cdkVirtualScrollDescription"
         >
+            <ng-template #cdkVirtualScrollDescription>
+                You can use
+                <code>Select</code>
+                with
+                <code>ScrollingModule</code>
+                from
+                <a
+                    tuiLink
+                    href="https://material.angular.io/cdk/scrolling/overview"
+                    target="_blank"
+                >
+                    @angular/cdk/scrolling
+                </a>
+                .
+            </ng-template>
             <tui-select-example-8></tui-select-example-8>
         </tui-doc-example>
 

--- a/projects/demo/src/modules/tables/table/table.template.html
+++ b/projects/demo/src/modules/tables/table/table.template.html
@@ -51,7 +51,23 @@
             i18n-heading
             heading="Virtual scroll"
             [content]="example5"
+            [description]="cdkVirtualScrollDescription"
         >
+            <ng-template #cdkVirtualScrollDescription>
+                You can use
+                <code>Table</code>
+                with
+                <code>ScrollingModule</code>
+                from
+                <a
+                    tuiLink
+                    href="https://material.angular.io/cdk/scrolling/overview"
+                    target="_blank"
+                >
+                    @angular/cdk/scrolling
+                </a>
+                .
+            </ng-template>
             <tui-table-example-5></tui-table-example-5>
         </tui-doc-example>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [X] Documentation content changes

## What is the current behavior?
Open Stackblitz example of https://taiga-ui.dev/components/multi-select#virtual:
```
Can't bind to 'itemSize' since it isn't a known property of 'cdk-virtual-scroll-viewport'.
1. If 'cdk-virtual-scroll-viewport' is an Angular component and it has 'itemSize' input, then verify that it is part of this module.
2. If 'cdk-virtual-scroll-viewport' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.
3. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.
```

## What is the new behavior?
No stackblitz error.

Also, improved documentation:

* https://taiga-ui.dev/components/multi-select#virtual
<img width="450" alt="multi-select" src="https://user-images.githubusercontent.com/35179038/208684208-10d03f5f-e729-418d-ae9a-1da69ba449dd.png">

* https://taiga-ui.dev/components/select#virtual
<img width="450" alt="select" src="https://user-images.githubusercontent.com/35179038/208684323-53cb72bf-e922-4d45-b22a-764a689f3a09.png">

* https://taiga-ui.dev/components/combo-box#virtual

<img width="450" alt="combo-box" src="https://user-images.githubusercontent.com/35179038/208684414-8909dd44-0c3c-4915-b516-9870a4acdf18.png">

* https://taiga-ui.dev/components/table#virtual
<img width="450" alt="table" src="https://user-images.githubusercontent.com/35179038/208684508-eb150f04-2b35-4e50-93c7-c67334a1fbca.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
