### PR TITLE
chore(demo): `TUI_DIALOG_CLOSES_ON_BACK` enable for Cypress tests only

### DIFF
--- a/projects/demo-integrations/cypress/tests/desktop/core/dialogs/dialog-browser-back.cy.ts
+++ b/projects/demo-integrations/cypress/tests/desktop/core/dialogs/dialog-browser-back.cy.ts
@@ -82,7 +82,8 @@ describe(`Dialogs + browser back navigation`, () => {
         });
     });
 
-    describe(`feature is disabled`, () => {
+    // TODO: change it back after solving https://github.com/Tinkoff/taiga-ui/issues/3270
+    describe.skip(`feature is disabled`, () => {
         beforeEach(() => {
             cy.tuiVisit(DIALOG_PAGE_URL, {inIframe: true});
         });

--- a/projects/demo/src/modules/app/app.providers.ts
+++ b/projects/demo/src/modules/app/app.providers.ts
@@ -6,7 +6,6 @@ import {
 } from '@angular/common';
 import {inject, Provider} from '@angular/core';
 import {Title} from '@angular/platform-browser';
-import {WINDOW} from '@ng-web-apis/common';
 import {
     TUI_DOC_CODE_EDITOR,
     TUI_DOC_DEFAULT_TABS,
@@ -23,7 +22,6 @@ import {
     TUI_DIALOG_CLOSES_ON_BACK,
     TUI_IS_CYPRESS,
     TUI_TAKE_ONLY_TRUSTED_EVENTS,
-    tuiIsInsideIframe,
 } from '@taiga-ui/cdk';
 import {TUI_ANIMATIONS_DURATION, TUI_SANITIZER} from '@taiga-ui/core';
 import {TuiLanguageName, tuiLanguageSwitcher} from '@taiga-ui/i18n';
@@ -131,7 +129,9 @@ export const APP_PROVIDERS: Provider[] = [
     },
     {
         provide: TUI_DIALOG_CLOSES_ON_BACK,
-        useFactory: () => of(!tuiIsInsideIframe(inject(WINDOW))), // for cypress tests
+        // TODO: change it back after solving https://github.com/Tinkoff/taiga-ui/issues/3270
+        // useFactory: () => of(!tuiIsInsideIframe(inject(WINDOW))), // for cypress tests
+        useFactory: () => of(inject(TUI_IS_CYPRESS)),
     },
     tuiLanguageSwitcher(
         async (language: TuiLanguageName): Promise<unknown> =>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [X] Documentation content changes

## What is the current behavior?
1. Open https://taiga-ui.dev/next/components/dialog#string
2. Press button to open dialog
3. Close dialog

The page is redirected to `https://taiga-ui.dev/next/#string`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
