### PR TITLE
chore(demo): `Stackblitz` drop hacks for styles

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/project-files/configs.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/configs.md
@@ -21,7 +21,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.app.json",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/app/@stackblitz/styles/taiga-ui-stackblitz.less", "src/styles.less"]
+            "styles": ["src/styles.less"]
           },
           "configurations": {
             "production": {

--- a/projects/demo/src/modules/app/stackblitz/project-files/src/app/@stackblitz/README.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/app/@stackblitz/README.md
@@ -7,17 +7,6 @@ and must not exist in real-world applications.
 
 ## Problem descriptions
 
-### `styles`-folder
-
-Unfortunately, Stackblitz can't properly process relative imports inside `.less`-files of libraries. It throws error:
-
-```
-Error in turbo_modules/@taiga-ui/core@3.4.0/styles/theme/wrapper/icon.less (1:0)
-Could not import ../../taiga-ui-local.less from /~/src/app/@stackblitz/styles/taiga-ui-stackblitz.less
-```
-
-See https://github.com/stackblitz/core/issues/1828
-
 ### `all-taiga-modules.ts`
 
 We don't have a nice way to import only required modules for every stackblitz-example. That is why we import all of

--- a/projects/demo/src/modules/app/stackblitz/project-files/src/stackblitz.less.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/stackblitz.less.md
@@ -1,9 +1,0 @@
-```less
-@import '@taiga-ui/styles/taiga-ui-global.less';
-@import '@taiga-ui/core/styles/theme/variables.less';
-/**
-THIS IS A WORKAROUND FOR STACKBLITZ:
-DO NOT REPEAT, read https://taiga-ui.dev/getting-started#less
- */
-@import 'theme/wrapper.less';
-```

--- a/projects/demo/src/modules/app/stackblitz/project-files/src/styles.less.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/src/styles.less.md
@@ -1,4 +1,8 @@
 ```less
+@import '@taiga-ui/core/styles/taiga-ui-theme.less';
+// @import '@taiga-ui/core/styles/taiga-ui-fonts.less'; // https://github.com/stackblitz/core/issues/2104
+@import '@taiga-ui/styles/taiga-ui-global.less';
+
 /* Add application styles & imports to this file! */
 my-app {
   display: block;

--- a/projects/demo/src/modules/app/stackblitz/stackblitz-resources-loader.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz-resources-loader.ts
@@ -40,63 +40,6 @@ export abstract class AbstractTuiStackblitzResourcesLoader {
         return {angularJson, tsconfig, mainTs, indexHtml, polyfills, appModuleTs, styles};
     }
 
-    static async getTaigaStyles(): Promise<Record<string, string>> {
-        const [
-            accent,
-            base,
-            icon,
-            mono,
-            none,
-            outline,
-            primary,
-            secondary,
-            secondaryDestructive,
-            table,
-            textfield,
-            whiteBlock,
-            wrapper,
-            stackblitzMarkdown,
-        ] = await Promise.all(
-            [
-                import(`../../../../../core/styles/theme/wrapper/accent.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper/base.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper/icon.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper/mono.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper/none.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper/outline.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper/primary.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper/secondary.less?raw`),
-                import(
-                    `../../../../../core/styles/theme/wrapper/secondary-destructive.less?raw`
-                ),
-                import(`../../../../../core/styles/theme/wrapper/table.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper/textfield.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper/whiteblock.less?raw`),
-                import(`../../../../../core/styles/theme/wrapper.less?raw`),
-                import(`./project-files/src/stackblitz.less.md?raw`),
-            ].map(tuiRawLoad),
-        );
-
-        const [stackblitz] = tuiTryParseMarkdownCodeBlock(stackblitzMarkdown);
-
-        return {
-            [`styles/theme/wrapper/accent.less`]: accent,
-            [`styles/theme/wrapper/base.less`]: base,
-            [`styles/theme/wrapper/icon.less`]: icon,
-            [`styles/theme/wrapper/mono.less`]: mono,
-            [`styles/theme/wrapper/none.less`]: none,
-            [`styles/theme/wrapper/outline.less`]: outline,
-            [`styles/theme/wrapper/primary.less`]: primary,
-            [`styles/theme/wrapper/secondary.less`]: secondary,
-            [`styles/theme/wrapper/secondary-destructive.less`]: secondaryDestructive,
-            [`styles/theme/wrapper/table.less`]: table,
-            [`styles/theme/wrapper/textfield.less`]: textfield,
-            [`styles/theme/wrapper/whiteblock.less`]: whiteBlock,
-            [`styles/theme/wrapper.less`]: wrapper,
-            [`styles/taiga-ui-stackblitz.less`]: stackblitz,
-        };
-    }
-
     static async getReadMeFiles(): Promise<{stackblitzReadMe: string}> {
         const [stackblitzReadMe] = await Promise.all([
             tuiRawLoad(import(`./project-files/src/app/@stackblitz/README.md?raw`)),

--- a/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
@@ -127,17 +127,10 @@ export class TuiStackblitzService implements TuiCodeEditor {
     private async getStackblitzOnlyFiles(
         additionalModules: Array<[fileName: string, parsedFile: TsFileModuleParser]> = [],
     ): Promise<Project['files']> {
-        const taigaStyles = Object.fromEntries(
-            Object.entries(
-                await AbstractTuiStackblitzResourcesLoader.getTaigaStyles(),
-            ).map(([path, content]) => [stackblitzPrefix`${path}`, prepareLess(content)]),
-        );
-
         const {stackblitzReadMe} =
             await AbstractTuiStackblitzResourcesLoader.getReadMeFiles();
 
         return {
-            ...taigaStyles,
             [stackblitzPrefix`README.md`]: stackblitzReadMe,
             [stackblitzPrefix`all-taiga-modules.ts`]: await getAllTaigaUIModulesFile(
                 additionalModules,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Previously, Stackblitz could not properly process relative imports inside `.less`-files of libraries. It throws error:

```
Error in turbo_modules/@taiga-ui/core@3.4.0/styles/theme/wrapper/icon.less (1:0)
Could not import ../../taiga-ui-local.less from /~/src/app/@stackblitz/styles/taiga-ui-stackblitz.less
```

See:
* https://github.com/stackblitz/core/issues/2112
* https://github.com/stackblitz/core/issues/1828

## What is the new behavior?
The issue was fixed and now we can drop some hacks.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
