### PR TITLE
fix(addon-charts): `LineDaysChart` hide dots on `mouseleave`

### DIFF
--- a/projects/addon-charts/components/line-days-chart/line-days-chart.component.ts
+++ b/projects/addon-charts/components/line-days-chart/line-days-chart.component.ts
@@ -2,6 +2,7 @@ import {
     ChangeDetectionStrategy,
     Component,
     HostBinding,
+    HostListener,
     Inject,
     Input,
     Optional,
@@ -48,7 +49,7 @@ const DUMMY: TuiPoint = [NaN, NaN];
 })
 export class TuiLineDaysChartComponent {
     @ViewChildren(TuiLineChartComponent)
-    private readonly charts: QueryList<TuiLineChartComponent> = EMPTY_QUERY;
+    readonly charts: QueryList<TuiLineChartComponent> = EMPTY_QUERY;
 
     @ViewChildren(TuiDriver)
     readonly drivers: QueryList<Observable<boolean>> = EMPTY_QUERY;
@@ -113,6 +114,13 @@ export class TuiLineDaysChartComponent {
         @Inject(TuiLineDaysChartHintDirective)
         private readonly hintDirective: TuiLineDaysChartHintDirective | null,
     ) {}
+
+    @HostListener('mouseleave')
+    onMouseLeave(): void {
+        if (!this.hintDirective) {
+            this.onHovered(NaN);
+        }
+    }
 
     get months(): ReadonlyArray<readonly TuiPoint[]> {
         return this.value.length ? this.breakMonths(this.value) : EMPTY_ARRAY;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #3402

`TuiLineDaysChartComponent` uses `TuiLineChartComponent`:
https://github.com/Tinkoff/taiga-ui/blob/0a2daff2f3edfc44089a8dd1ac9b4e2d3db6ff37/projects/addon-charts/components/line-days-chart/line-days-chart.template.html#L1

But bug is NOT reproducible only for `LineChart` (either the chart has `[tuiLineChartHint]` or it does not)!

It happens because of 2 buggy moments :harold-pain:

### Case 1. The chart doesn't have `[tuiLineChartHint]`
`LineChart` processes this case via
https://github.com/Tinkoff/taiga-ui/blob/0a2daff2f3edfc44089a8dd1ac9b4e2d3db6ff37/projects/addon-charts/components/line-chart/line-chart.component.ts#L163-L168

It doesn't work for `LineDaysChart` because `!this.hintDirective` is always `false`.
`LineDaysChart` always provide `this.hintDirective`:
https://github.com/Tinkoff/taiga-ui/blob/0a2daff2f3edfc44089a8dd1ac9b4e2d3db6ff37/projects/addon-charts/components/line-days-chart/line-days-chart.component.ts#L42-L47

To solve this problem we should just duplicate these lines inside `TuiLineDaysChartComponent`(`TuiLineDaysChartComponent` has its own not-fake `this.hintDirective`):
```ts
@HostListener('mouseleave')
onMouseLeave(): void {
    if (!this.hintDirective) {
        this.onHovered(NaN);
    }
}
```

### Case 2. The chart has `[tuiLineChartHint]`
When `LineChart` has hint, it doesn't manage hover-state.
`[tuiLineChartHint]` does it.
https://github.com/Tinkoff/taiga-ui/blob/4b799b5f5fb98eeda678b5aa7af82f9901544667/projects/addon-charts/components/line-days-chart/line-days-chart-hint.directive.ts#L52-L61

But the problem that this directive does not take nested `TuiLineChartComponent`s' drivers.

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
