### PR TITLE
fix(kit): `Slider` has wrong height of the progress in Firefox

### DIFF
--- a/projects/kit/components/slider/slider.style.less
+++ b/projects/kit/components/slider/slider.style.less
@@ -164,6 +164,7 @@
 
     /* stylelint-disable-next-line no-duplicate-selectors */
     &::-moz-range-progress {
+        height: @track-height;
         background: @thumb-color;
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
In 3.x we dropped `normalize.less`.
But Firefox has the following default styles:
<img width="511" alt="firefox-default-styles" src="https://user-images.githubusercontent.com/35179038/214330726-40a1f803-f37e-4c00-b86d-3a7abbb64f52.png">




## What is the new behavior?
`/components/input-slider/API`
before => after
<img width="1183" alt="before-after" src="https://user-images.githubusercontent.com/35179038/214330409-18ad94ea-f1cf-417c-b267-4e0eda956c61.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
