### PR TITLE
fix(core): fix TUI_DIALOG_CLOSE_STREAM event targets to use event.composedPath to get actual target inside shadowDom

### DIFF
--- a/projects/core/components/dialog/dialog.providers.ts
+++ b/projects/core/components/dialog/dialog.providers.ts
@@ -5,6 +5,7 @@ import {
     tuiContainsOrAfter,
     TuiDestroyService,
     TuiDialog,
+    tuiGetActualTarget,
     tuiIsCurrentTarget,
     tuiIsElement,
     tuiTypedFromEvent,
@@ -53,30 +54,41 @@ export const TUI_DIALOG_PROVIDERS: Provider[] = [
                           filter(tuiIsCurrentTarget),
                       ),
                       tuiTypedFromEvent(documentRef, `keydown`).pipe(
-                          filter(
-                              ({key, target}) =>
+                          filter(event => {
+                              const key = event.key;
+                              const target = tuiGetActualTarget(event);
+
+                              return (
                                   key === `Escape` &&
                                   tuiIsElement(target) &&
                                   (!tuiContainsOrAfter(nativeElement, target) ||
-                                      nativeElement.contains(target)),
-                          ),
+                                      nativeElement.contains(target))
+                              );
+                          }),
                       ),
                       tuiTypedFromEvent(documentRef, `mousedown`).pipe(
-                          filter(
-                              ({target, clientX}) =>
+                          filter(event => {
+                              const target = tuiGetActualTarget(event);
+                              const clientX = event.clientX;
+
+                              return (
                                   tuiIsElement(target) &&
                                   tuiGetViewportWidth(windowRef) - clientX >
                                       SCROLLBAR_PLACEHOLDER &&
-                                  !tuiContainsOrAfter(nativeElement, target),
-                          ),
+                                  !tuiContainsOrAfter(nativeElement, target)
+                              );
+                          }),
                           switchMap(() =>
                               tuiTypedFromEvent(documentRef, `mouseup`).pipe(
                                   take(1),
-                                  filter(
-                                      ({target}) =>
+                                  filter(event => {
+                                      const target = tuiGetActualTarget(event);
+
+                                      return (
                                           tuiIsElement(target) &&
-                                          !tuiContainsOrAfter(nativeElement, target),
-                                  ),
+                                          !tuiContainsOrAfter(nativeElement, target)
+                                      );
+                                  }),
                               ),
                           ),
                       ),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes https://github.com/Tinkoff/taiga-ui/issues/2223

## What is the new behavior?

Now `event.composedPath()[0]` used to detect target, because this will always show actual element inside shadowDom. In case of shadowDom, `event.target` is ShadowRoot

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
