### PR TITLE
fix(core): visible incorrect initial position from `TuiDropdownComponent` & `TuiHintComponent` without animation & ngZoneEventCoalescing

### DIFF
--- a/projects/core/directives/dropdown/dropdown.component.ts
+++ b/projects/core/directives/dropdown/dropdown.component.ts
@@ -68,6 +68,8 @@ export class TuiDropdownComponent {
         position$.pipe(takeUntil(destroy$)).subscribe(([top, left]) => {
             this.update(top, left);
         });
+
+        this.updateWidth();
     }
 
     onHoveredChange(hovered: boolean): void {
@@ -87,7 +89,7 @@ export class TuiDropdownComponent {
     private update(top: number, left: number): void {
         const {style} = this.elementRef.nativeElement;
         const {right} = this.elementRef.nativeElement.getBoundingClientRect();
-        const {limitWidth, maxHeight, offset} = this.options;
+        const {maxHeight, offset} = this.options;
         const {innerHeight} = this.windowRef;
         const {clientRect} = this.host;
         const {position} = this.directive;
@@ -110,6 +112,14 @@ export class TuiDropdownComponent {
         style.maxHeight = tuiPx(Math.min(maxHeight, available));
         style.width = '';
         style.minWidth = '';
+
+        this.updateWidth();
+    }
+
+    private updateWidth(): void {
+        const {style} = this.elementRef.nativeElement;
+        const rect = this.accessor.getClientRect();
+        const {limitWidth} = this.options;
 
         switch (limitWidth) {
             case 'min':

--- a/projects/core/directives/dropdown/dropdown.style.less
+++ b/projects/core/directives/dropdown/dropdown.style.less
@@ -16,6 +16,10 @@
     &.ng-animating {
         pointer-events: none;
     }
+
+    &:not([style*='top']) {
+        visibility: hidden;
+    }
 }
 
 .t-wrapper {

--- a/projects/core/directives/hint/hint.style.less
+++ b/projects/core/directives/hint/hint.style.less
@@ -37,6 +37,10 @@
             drop-shadow(0 0.75rem 0.75rem rgba(0, 0, 0, 0.04)) drop-shadow(0 0.25rem 0.375rem rgba(0, 0, 0, 0.05));
     }
 
+    &:not([style*='top']) {
+        visibility: hidden;
+    }
+
     &._untouchable {
         pointer-events: none;
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #3514 

## What is the new behavior?

`TuiHintComponent` & `TuiDropdownComponent` are initially hidden until they have position.

 `TuiDropdownComponent` set an initial width in the component constructor to calculate the initial position.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
