### PR TITLE
ci: `tsconfig.json` update `compilerOptions.lib`

### DIFF
--- a/projects/addon-doc/src/components/example/example.component.ts
+++ b/projects/addon-doc/src/components/example/example.component.ts
@@ -117,7 +117,10 @@ export class TuiDocExampleComponent {
         this.loading$.next(true);
         this.codeEditor
             ?.edit(this.componentName, this.id || '', files)
-            .finally(() => this.loading$.next(false));
+            // TODO: replace lines below with `finally` when we bump Firefox to 58+
+            // TODO: Add `es2018.promise` to `tsconfig.json` => `compilerOptions.lib`.
+            .then(() => this.loading$.next(false))
+            .catch(() => this.loading$.next(false));
     }
 
     private setFragmentWithoutRedirect(id: string | null): void {

--- a/projects/cdk/utils/miscellaneous/index.ts
+++ b/projects/cdk/utils/miscellaneous/index.ts
@@ -12,4 +12,5 @@ export * from './is-present';
 export * from './is-string';
 export * from './mark-control-as-touched-and-validate';
 export * from './nullable-same';
+export * from './object-from-entries';
 export * from './uniq-by';

--- a/projects/cdk/utils/miscellaneous/object-from-entries.ts
+++ b/projects/cdk/utils/miscellaneous/object-from-entries.ts
@@ -1,0 +1,16 @@
+/**
+ * @deprecated use `Object.fromEntries` instead
+ * (check browser support first https://caniuse.com/mdn-javascript_builtins_object_fromentries)
+ * ___
+ * TODO: after we bump Firefox to 63+ replace this function with `Object.fromEntries`.
+ * TODO: Add `es2019.object` to `tsconfig.json` => `compilerOptions.lib`.
+ *
+ */
+export function tuiObjectFromEntries<K extends number | string, V>(
+    keyValuePairs: Array<[K, V]>,
+): Record<K, V> {
+    return keyValuePairs.reduce(
+        (obj, [key, val]) => ({...obj, [key]: val}),
+        {} as Record<K, V>,
+    );
+}

--- a/projects/demo/src/modules/app/home/home.component.ts
+++ b/projects/demo/src/modules/app/home/home.component.ts
@@ -32,7 +32,7 @@ export class HomeComponent {
     ).then(({default: content}) => ({
         default: content
             // eslint-disable-next-line @typescript-eslint/quotes
-            .replaceAll("@import '", "@import '@taiga-ui/styles/")
+            .replace(/@import '/g, `@import '@taiga-ui/styles/`)
             .replace('@taiga-ui/styles/@taiga-ui/core', '@taiga-ui/core'),
     }));
 }

--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -24,6 +24,7 @@ import {
     TuiMapper,
     TuiMonth,
     tuiNullableSame,
+    tuiObjectFromEntries,
     tuiPure,
     tuiWatch,
 } from '@taiga-ui/cdk';
@@ -216,7 +217,7 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
                 return disabledItemHandler(item);
             }
 
-            const negativeMinLength = Object.fromEntries(
+            const negativeMinLength = tuiObjectFromEntries(
                 Object.entries(minLength).map(([key, value]) => [key, -value]),
             );
             const disabledBefore = value.from.append(negativeMinLength).append({day: 1});

--- a/projects/kit/constants/max-day-range-length-mapper.ts
+++ b/projects/kit/constants/max-day-range-length-mapper.ts
@@ -1,4 +1,10 @@
-import {TuiDay, TuiDayLike, TuiDayRange, TuiMapper} from '@taiga-ui/cdk';
+import {
+    TuiDay,
+    TuiDayLike,
+    TuiDayRange,
+    TuiMapper,
+    tuiObjectFromEntries,
+} from '@taiga-ui/cdk';
 
 export const MAX_DAY_RANGE_LENGTH_MAPPER: TuiMapper<TuiDay, TuiDay> = (
     min,
@@ -10,7 +16,7 @@ export const MAX_DAY_RANGE_LENGTH_MAPPER: TuiMapper<TuiDay, TuiDay> = (
         return min;
     }
 
-    const negativeMaxLength = Object.fromEntries(
+    const negativeMaxLength = tuiObjectFromEntries(
         Object.entries(maxLength).map(([key, value]) => [key, -value]),
     );
 

--- a/projects/testing/project.json
+++ b/projects/testing/project.json
@@ -9,7 +9,7 @@
             "builder": "@angular-devkit/build-angular:ng-packagr",
             "outputs": ["dist/testing"],
             "options": {
-                "tsConfig": "tsconfig.build.json",
+                "tsConfig": "projects/testing/tsconfig.build.json",
                 "project": "projects/testing/ng-package.json"
             },
             "dependsOn": [

--- a/projects/testing/tsconfig.build.json
+++ b/projects/testing/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "types": ["node", "jest"]
+    }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,7 @@
         "sourceMap": true,
         "inlineSourceMap": true,
         "inlineSources": true,
+        "types": [],
         "paths": {
             "@taiga-ui/cdk/*": ["./dist/cdk/*"],
             "@taiga-ui/cdk": ["./dist/cdk/index"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
         "outDir": "./dist",
         "target": "es2015",
         "module": "es2020",
-        "lib": ["esnext", "dom"],
+        "lib": ["es2017", "es2018.asynciterable", "dom"],
         "typeRoots": ["node_modules/@types"],
         "skipLibCheck": true,
         "downlevelIteration": true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Developer can mistakenly use ES-features which are not supported by all required browsers.
And there will be no error!

See https://taiga-ui.dev/browser-support

## What is the new behavior?
#### es2016
Read section "Feature summary":
https://caniuse.com/?search=es2016
<img width="1079" alt="es2016" src="https://user-images.githubusercontent.com/35179038/216009648-2cfd1e96-e258-44d4-a925-ed64e0987fd2.png">


#### es2017
Read section "Feature summary":
https://caniuse.com/?search=es2017
<img width="1079" alt="es2017" src="https://user-images.githubusercontent.com/35179038/216009676-3211254c-e326-4633-a717-5dba2a25dfbf.png">


User can't use not-supported features.
Typescript throws error for them:
<img width="1702" alt="error-demo" src="https://user-images.githubusercontent.com/35179038/216009518-7e2d34f7-ab17-412b-a647-25810a0b48eb.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
