### PR TITLE
feat(core): extend secondary appearance variables set

### DIFF
--- a/projects/core/styles/theme/variables.less
+++ b/projects/core/styles/theme/variables.less
@@ -153,4 +153,19 @@
     --tui-chart-2: var(--tui-support-21);
     --tui-chart-3: var(--tui-support-11);
     --tui-chart-4: var(--tui-base-05);
+    // extend secondary appearance properties:
+    --tui-secondary-text: var(--tui-link);
+    --tui-secondary-text-hover: var(--tui-link-hover);
+    // for night:
+    --tui-secondary-night: var(--tui-clear-inverse);
+    --tui-secondary-hover-night: var(--tui-clear-inverse-hover);
+    --tui-secondary-active-night: var(--tui-clear-inverse-active);
+    --tui-secondary-text-night: var(--tui-text-01-night);
+    --tui-secondary-text-hover-night: var(--tui-text-01-night);
+    // for light:
+    --tui-secondary-light: var(--tui-clear);
+    --tui-secondary-hover-light: var(--tui-clear-hover);
+    --tui-secondary-active-light: var(--tui-clear-active);
+    --tui-secondary-text-light: var(--tui-text-01);
+    --tui-secondary-text-hover-light: var(--tui-text-01);
 }

--- a/projects/core/styles/theme/wrapper/secondary.less
+++ b/projects/core/styles/theme/wrapper/secondary.less
@@ -4,19 +4,19 @@
 [tuiWrapper][data-appearance='secondary'],
 [tuiWrapper][data-appearance='flat'] {
     background: var(--tui-secondary);
-    color: var(--tui-link);
+    color: var(--tui-secondary-text);
 
     &[data-mode='onDark'] {
-        background: var(--tui-clear-inverse);
-        color: var(--tui-text-01-night);
+        background: var(--tui-secondary-night);
+        color: var(--tui-secondary-text-night);
 
         .wrapper-hover({
-            background: var(--tui-clear-inverse-hover);
-            color: var(--tui-text-01-night);
+            background: var(--tui-secondary-hover-night);
+            color: var(--tui-secondary-text-hover-night);
         });
 
         .wrapper-active({
-            background: var(--tui-clear-inverse-active);
+            background: var(--tui-secondary-active-night);
         });
 
         .wrapper-focus({
@@ -25,22 +25,22 @@
     }
 
     &[data-mode='onLight'] {
-        background: var(--tui-clear);
-        color: var(--tui-text-01);
+        background: var(--tui-secondary-light);
+        color: var(--tui-secondary-text-light);
 
         .wrapper-hover({
-            background: var(--tui-clear-hover);
-            color: var(--tui-text-01);
+            background: var(--tui-secondary-hover-light);
+            color: var(--tui-secondary-text-hover-light);
         });
 
         .wrapper-active({
-            background: var(--tui-clear-active);
+            background: var(--tui-secondary-active-light);
         });
     }
 
     .wrapper-hover({
         background: var(--tui-secondary-hover);
-        color: var(--tui-link-hover);
+        color: var(--tui-secondary-text-hover);
     });
 
     .wrapper-active({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

The wrapper for the second appearance uses the --tui-link variable to specify a text color. It breaks customization for certain cases, for example: I want to change text color for secondary button, but I dont want to change --tui-link variable:
```
 <button tuiButton type="button" appearance="secondary">
        secondary
      </button>
```
as the result:
![image](https://user-images.githubusercontent.com/13556403/216760891-87e6df55-9f07-4d9e-83b8-5384baffb76f.png)

## What is the new behavior?

I propose to extend variable set for secondary appearance with current defaults and use them in the secondary.less:
```
    // extend secondary appearance properties:
    --tui-secondary-text: var(--tui-link);
    --tui-secondary-text-hover: var(--tui-link-hover);
    // for night:
    --tui-secondary-night: var(--tui-clear-inverse);
    --tui-secondary-hover-night: var(--tui-clear-inverse-hover);
    --tui-secondary-active-night: var(--tui-clear-inverse-active);
    --tui-secondary-text-night: var(--tui-text-01-night);
    --tui-secondary-text-hover-night: var(--tui-text-01-night);
    // for light:
    --tui-secondary-light: var(--tui-clear);
    --tui-secondary-hover-light: var(--tui-clear-hover);
    --tui-secondary-active-light: var(--tui-clear-active);
    --tui-secondary-text-light: var(--tui-text-01);
    --tui-secondary-text-hover-light: var(--tui-text-01);
```
It will allow to change secondary text and more without global share variables changes such as --tui-link and etc.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
