### PR TITLE
fix(addon-doc): change activeItemIndex to 0

### DIFF
--- a/projects/addon-doc/src/components/page/page.component.ts
+++ b/projects/addon-doc/src/components/page/page.component.ts
@@ -38,7 +38,7 @@ export class TuiDocPageComponent {
     @ContentChildren(TuiDocPageTabConnectorDirective)
     readonly tabConnectors: QueryList<TuiDocPageTabConnectorDirective> = EMPTY_QUERY;
 
-    activeItemIndex = NaN;
+    activeItemIndex = 0;
 
     constructor(
         @Inject(TUI_DOC_DEFAULT_TABS) readonly defaultTabs: readonly string[],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [v ] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [v ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Have some problem with routable dialog demo.
After reloading page content inside 'example' tab doesn't appear

https://github.com/Tinkoff/taiga-ui/pull/3369/files#diff-8d0c448dfc1d841f3bd066d2cdd249dd9f028b4d84ff367ab0cb6cc7b22584c0R20

Closes # <!-- link to a relevant issue. -->

## What is the new behavior?

Reloading page for routable dialog demo works as expected

## Does this PR introduce a breaking change?

- [ ] Yes
- [ v] No
