### PR TITLE
chore(demo): source code button for `2.x`-demo should open `v2.x`-branch

### DIFF
--- a/projects/demo/src/modules/app/app.providers.ts
+++ b/projects/demo/src/modules/app/app.providers.ts
@@ -60,7 +60,7 @@ export const APP_PROVIDERS: Provider[] = [
     {
         provide: TUI_DOC_SOURCE_CODE,
         useValue: (context: TuiDocSourceCodePathOptions) => {
-            const link = `https://github.com/tinkoff/taiga-ui/tree/main/projects`;
+            const link = `https://github.com/tinkoff/taiga-ui/tree/v2.x/projects`;
 
             if (!context.package) {
                 return null;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [X] Documentation content changes

## What is the current behavior?
1. Open https://taiga-ui.dev/v2/components/field-error
2. Click on source code button
<img width="870" alt="source-code-button" src="https://user-images.githubusercontent.com/35179038/220093952-5c5b5779-330d-4e0c-b3de-1ac5067ffb2d.png">

Github returns `404`
<img width="1123" alt="404" src="https://user-images.githubusercontent.com/35179038/220093997-f73339e3-8df9-4637-83a5-6653d972295a.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
