### PR TITLE
ci: `ng update @taiga-ui/cdk` doesn't update all Taiga's packages

### DIFF
--- a/projects/cdk/package.json
+++ b/projects/cdk/package.json
@@ -40,6 +40,8 @@
             "@taiga-ui/cdk",
             "@taiga-ui/core",
             "@taiga-ui/kit",
+            "@taiga-ui/styles",
+            "@taiga-ui/testing",
             "@taiga-ui/addon-doc",
             "@taiga-ui/addon-charts",
             "@taiga-ui/addon-commerce",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Run `nx migrate @taiga-ui/cdk` or `ng update @taiga-ui/cdk`:
<img width="1204" alt="Screenshot 2023-02-21 at 14 07 35" src="https://user-images.githubusercontent.com/35179038/220328814-9ab02961-1d52-4a50-8f5b-e41c5631c1fc.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
