### PR TITLE
fix(kit): `InputPhoneInternational` change Mauritius phone pattern

### DIFF
--- a/projects/kit/components/input-phone-international/tokens/countries-masks.ts
+++ b/projects/kit/components/input-phone-international/tokens/countries-masks.ts
@@ -138,7 +138,7 @@ export const TUI_COUNTRIES_MASKS: InjectionToken<Record<TuiCountryIsoCode, strin
             [TuiCountryIsoCode.MR]: `+222##-##-####`,
             [TuiCountryIsoCode.MS]: `+1(664) ###-####`,
             [TuiCountryIsoCode.MT]: `+356####-####`,
-            [TuiCountryIsoCode.MU]: `+230###-####`,
+            [TuiCountryIsoCode.MU]: `+230####-####`,
             [TuiCountryIsoCode.MV]: `+960###-####`,
             [TuiCountryIsoCode.MW]: `+265#-####-####`,
             [TuiCountryIsoCode.MX]: `+52(###) ###-####`,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #3897

## What is the new behavior?
As temporary fast workaround, I've opened this PR.

It will change
```
+230 XXX XXXX => +230 XXXX XXXX
```

Now both phone formats can be typed (short and long).
Yes, I understand that short version of the mask is not visually perfect.
But it becomes less critical than previous version.
Other cosmetic improvement will be done in another issue later (it requires more complex refactoring to add support of conditional masking).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
