### PR TITLE
fix(addon-editor): overflow `tui-editor-socket` only inside `tui-editor`

### DIFF
--- a/projects/addon-editor/components/editor-socket/editor-socket.component.less
+++ b/projects/addon-editor/components/editor-socket/editor-socket.component.less
@@ -3,9 +3,12 @@
 .tui-editor-socket {
     display: block;
     margin: 0;
-    overflow: hidden;
     color: var(--tui-text-01);
     font: var(--tui-font-text-m);
+
+    &[tuiTiptapEditor] {
+        overflow: hidden;
+    }
 
     &._preview-image img {
         cursor: pointer;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## Current

After that PR: https://github.com/Tinkoff/taiga-ui/pull/3994

<img width="1321" alt="image" src="https://user-images.githubusercontent.com/12021443/227885661-e6b79b27-9b7b-4cef-9913-f8de9981fc5a.png">


## What is the new behavior?

<img width="802" alt="image" src="https://user-images.githubusercontent.com/12021443/227885083-98e810d6-43b4-4ad9-8c86-e80c5231f78e.png">

