### PR TITLE
feat(addon-editor): use `https` by default for links in editor

### DIFF
--- a/projects/addon-editor/components/edit-link/edit-link.component.ts
+++ b/projects/addon-editor/components/edit-link/edit-link.component.ts
@@ -9,15 +9,20 @@ import {
     Output,
 } from '@angular/core';
 import {AbstractTuiEditor} from '@taiga-ui/addon-editor/abstract';
+import {
+    TUI_EDITOR_LINK_HASH_PREFIX,
+    TUI_EDITOR_LINK_HTTP_PREFIX,
+    TUI_EDITOR_LINK_HTTPS_PREFIX,
+    TuiEditorLinkPrefix,
+    TuiEditorLinkProtocol,
+} from '@taiga-ui/addon-editor/constants';
 import {TuiTiptapEditorService} from '@taiga-ui/addon-editor/directives';
-import {TUI_EDITOR_LINK_TEXTS} from '@taiga-ui/addon-editor/tokens';
+import {
+    TUI_EDITOR_LINK_TEXTS,
+    TUI_EDITOR_OPTIONS,
+    TuiEditorOptions,
+} from '@taiga-ui/addon-editor/tokens';
 import {tuiDefaultProp, TuiInjectionTokenType, tuiIsElement} from '@taiga-ui/cdk';
-
-const HASH_PREFIX = '#' as const;
-const HTTP_PREFIX = 'http://' as const;
-const HTTPS_PREFIX = 'https://' as const;
-
-type TuiLinkPrefix = typeof HASH_PREFIX | typeof HTTP_PREFIX | typeof HTTPS_PREFIX;
 
 @Component({
     selector: 'tui-edit-link',
@@ -38,7 +43,7 @@ export class TuiEditLinkComponent {
 
     edit = !this.url;
 
-    prefix: TuiLinkPrefix = this.makeDefaultPrefix();
+    prefix: TuiEditorLinkPrefix = this.makeDefaultPrefix();
 
     anchorIds = this.getAllAnchorsIds();
 
@@ -48,13 +53,19 @@ export class TuiEditLinkComponent {
         @Inject(TUI_EDITOR_LINK_TEXTS)
         readonly texts$: TuiInjectionTokenType<typeof TUI_EDITOR_LINK_TEXTS>,
         @Inject(TuiTiptapEditorService) private readonly editor: AbstractTuiEditor,
+        @Inject(TUI_EDITOR_OPTIONS)
+        private readonly options: TuiEditorOptions,
     ) {}
+
+    get defaultProtocol(): TuiEditorLinkProtocol {
+        return this.options.linkOptions?.protocol ?? TUI_EDITOR_LINK_HTTPS_PREFIX;
+    }
 
     @Input()
     @tuiDefaultProp()
     set anchorMode(mode: boolean) {
         this.isOnlyAnchorMode = mode;
-        this.prefix = mode ? HASH_PREFIX : this.makeDefaultPrefix();
+        this.prefix = mode ? TUI_EDITOR_LINK_HASH_PREFIX : this.makeDefaultPrefix();
     }
 
     get anchorMode(): boolean {
@@ -62,7 +73,7 @@ export class TuiEditLinkComponent {
     }
 
     get prefixIsHashMode(): boolean {
-        return this.prefix === HASH_PREFIX;
+        return this.prefix === TUI_EDITOR_LINK_HASH_PREFIX;
     }
 
     get hasUrl(): boolean {
@@ -102,7 +113,7 @@ export class TuiEditLinkComponent {
     }
 
     changePrefix(isPrefix: boolean): void {
-        this.prefix = isPrefix ? HASH_PREFIX : HTTP_PREFIX;
+        this.prefix = isPrefix ? TUI_EDITOR_LINK_HASH_PREFIX : this.defaultProtocol;
     }
 
     onSave(): void {
@@ -115,7 +126,9 @@ export class TuiEditLinkComponent {
 
     onBackspace(): void {
         if (!this.url) {
-            this.prefix = this.isOnlyAnchorMode ? HASH_PREFIX : HTTP_PREFIX;
+            this.prefix = this.isOnlyAnchorMode
+                ? TUI_EDITOR_LINK_HASH_PREFIX
+                : this.defaultProtocol;
         }
     }
 
@@ -135,17 +148,17 @@ export class TuiEditLinkComponent {
         this.url = '';
     }
 
-    private makeDefaultPrefix(): TuiLinkPrefix {
+    private makeDefaultPrefix(): TuiEditorLinkPrefix {
         const a = this.getAnchorElement();
 
         if (a) {
             return (!a.getAttribute('href') && a.getAttribute('id')) ||
-                a.getAttribute('href')?.startsWith(HASH_PREFIX)
-                ? HASH_PREFIX
-                : HTTP_PREFIX;
+                a.getAttribute('href')?.startsWith(TUI_EDITOR_LINK_HASH_PREFIX)
+                ? TUI_EDITOR_LINK_HASH_PREFIX
+                : this.defaultProtocol;
         }
 
-        return HTTP_PREFIX;
+        return this.defaultProtocol;
     }
 
     private detectAnchorMode(): boolean {
@@ -171,22 +184,26 @@ export class TuiEditLinkComponent {
     }
 
     private removePrefix(url: string): string {
-        if (url.startsWith(HTTP_PREFIX)) {
-            this.prefix = this.isOnlyAnchorMode ? HASH_PREFIX : HTTP_PREFIX;
+        if (url.startsWith(TUI_EDITOR_LINK_HTTP_PREFIX)) {
+            this.prefix = this.isOnlyAnchorMode
+                ? TUI_EDITOR_LINK_HASH_PREFIX
+                : TUI_EDITOR_LINK_HTTP_PREFIX;
 
-            return url.replace(HTTP_PREFIX, '');
+            return url.replace(TUI_EDITOR_LINK_HTTP_PREFIX, '');
         }
 
-        if (url.startsWith(HTTPS_PREFIX)) {
-            this.prefix = this.isOnlyAnchorMode ? HASH_PREFIX : HTTPS_PREFIX;
+        if (url.startsWith(TUI_EDITOR_LINK_HTTPS_PREFIX)) {
+            this.prefix = this.isOnlyAnchorMode
+                ? TUI_EDITOR_LINK_HASH_PREFIX
+                : TUI_EDITOR_LINK_HTTPS_PREFIX;
 
-            return url.replace(HTTPS_PREFIX, '');
+            return url.replace(TUI_EDITOR_LINK_HTTPS_PREFIX, '');
         }
 
-        if (url.startsWith(HASH_PREFIX)) {
-            this.prefix = HASH_PREFIX;
+        if (url.startsWith(TUI_EDITOR_LINK_HASH_PREFIX)) {
+            this.prefix = TUI_EDITOR_LINK_HASH_PREFIX;
 
-            return url.replace(HASH_PREFIX, '');
+            return url.replace(TUI_EDITOR_LINK_HASH_PREFIX, '');
         }
 
         return url;

--- a/projects/addon-editor/constants/default-link-options-handler.ts
+++ b/projects/addon-editor/constants/default-link-options-handler.ts
@@ -1,0 +1,19 @@
+export const TUI_EDITOR_LINK_HASH_PREFIX = `#` as const;
+export const TUI_EDITOR_LINK_HTTP_PREFIX = `http://` as const;
+export const TUI_EDITOR_LINK_HTTPS_PREFIX = `https://` as const;
+
+export type TuiEditorLinkProtocol =
+    | typeof TUI_EDITOR_LINK_HTTP_PREFIX
+    | typeof TUI_EDITOR_LINK_HTTPS_PREFIX;
+
+export type TuiEditorLinkPrefix =
+    | TuiEditorLinkProtocol
+    | typeof TUI_EDITOR_LINK_HASH_PREFIX;
+
+export interface TuiEditorLinkOptions {
+    readonly protocol: TuiEditorLinkProtocol;
+}
+
+export const TUI_DEFAULT_LINK_OPTIONS = {
+    protocol: TUI_EDITOR_LINK_HTTPS_PREFIX,
+};

--- a/projects/addon-editor/constants/index.ts
+++ b/projects/addon-editor/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './default-editor-colors';
 export * from './default-editor-tools';
 export * from './default-font-options-handler';
+export * from './default-link-options-handler';

--- a/projects/addon-editor/tokens/editor-options.ts
+++ b/projects/addon-editor/tokens/editor-options.ts
@@ -2,18 +2,22 @@ import {InjectionToken, ValueProvider} from '@angular/core';
 import {
     defaultEditorColors,
     EDITOR_BLANK_COLOR,
+    TUI_DEFAULT_LINK_OPTIONS,
     tuiDefaultFontOptionsHandler,
+    TuiEditorLinkOptions,
 } from '@taiga-ui/addon-editor/constants';
 
 export interface TuiEditorOptions {
     readonly blankColor: string;
     readonly colors: ReadonlyMap<string, string>;
     readonly fontOptions: typeof tuiDefaultFontOptionsHandler;
+    readonly linkOptions?: TuiEditorLinkOptions;
 }
 
 export const TUI_EDITOR_DEFAULT_OPTIONS: TuiEditorOptions = {
     colors: defaultEditorColors,
     blankColor: EDITOR_BLANK_COLOR,
+    linkOptions: TUI_DEFAULT_LINK_OPTIONS,
     fontOptions: tuiDefaultFontOptionsHandler,
 };
 

--- a/projects/demo-integrations/cypress/tests/addon-editor/editor-api.cy.ts
+++ b/projects/demo-integrations/cypress/tests/addon-editor/editor-api.cy.ts
@@ -253,7 +253,7 @@ describe(`Editor API`, () => {
 
             tuiClearHint();
 
-            tuiOpenAnchorDropdown({containHref: `http://wysiwyg.com`});
+            tuiOpenAnchorDropdown({containHref: `https://wysiwyg.com`});
             tuiGetEditorScrollbarArea().scrollTo(0, 100);
             tuiGetScreenshotArea().matchImageSnapshot(`8-1-added-new-link`);
 

--- a/projects/demo-integrations/cypress/tests/addon-editor/editor-links.cy.ts
+++ b/projects/demo-integrations/cypress/tests/addon-editor/editor-links.cy.ts
@@ -42,7 +42,7 @@ describe(`Editing links in Editor`, () => {
         tuiFocusToStartInEditor();
 
         tuiGetScreenshotArea().matchImageSnapshot(`2-1-added-new-link`);
-        tuiOpenAnchorDropdown({containHref: `http://wysiwyg.com`});
+        tuiOpenAnchorDropdown({containHref: `https://wysiwyg.com`});
         tuiGetScreenshotArea().matchImageSnapshot(`2-2-focused-new-link`);
 
         tuiFocusToStartInEditor();
@@ -56,12 +56,12 @@ describe(`Editing links in Editor`, () => {
         tuiFocusToStartInEditor();
 
         tuiGetScreenshotArea().matchImageSnapshot(`2-3-added-new-link-2`);
-        tuiOpenAnchorDropdown({containHref: `http://example.com`});
+        tuiOpenAnchorDropdown({containHref: `https://example.com`});
         tuiGetContentEditable().find(`sup`).type(`{leftArrow}`);
 
         tuiGetScreenshotArea().matchImageSnapshot(`2-4-focused-new-link-2`);
 
-        tuiOpenAnchorDropdown({containHref: `http://wysiwyg.com`});
+        tuiOpenAnchorDropdown({containHref: `https://wysiwyg.com`});
         tuiGetScreenshotArea().matchImageSnapshot(
             `2-5-correct-refresh-content-in-dropdown`,
         );
@@ -78,7 +78,7 @@ describe(`Editing links in Editor`, () => {
 
         tuiGetScreenshotArea().matchImageSnapshot(`3-1-before-remove-link`);
 
-        tuiOpenAnchorDropdown({containHref: `http://wysiwyg.com`});
+        tuiOpenAnchorDropdown({containHref: `https://wysiwyg.com`});
         tuiTrashValueByEditLink();
 
         tuiClearHint();


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4044

<img width="512" alt="image" src="https://user-images.githubusercontent.com/12021443/229133781-b26d2819-060f-4a9d-84d9-d8b711a7fa38.png">


## What is the new behavior?

<img width="530" alt="image" src="https://user-images.githubusercontent.com/12021443/229133864-8968d564-2440-4344-9ee1-00ed414162b4.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
