### PR TITLE
feat(addon-doc): add `TUI_USE_DEFAULT_NIGHT_THEME` token for ignore dark theme styles

### DIFF
--- a/projects/addon-doc/src/components/main/main.component.ts
+++ b/projects/addon-doc/src/components/main/main.component.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import {TuiSwipeService} from '@taiga-ui/cdk';
 import {TuiBrightness, TuiModeDirective} from '@taiga-ui/core';
+import {distinctUntilChanged, map, share, startWith} from 'rxjs/operators';
 
 import {TuiThemeService} from '../../services/theme.service';
 import {TuiThemeNightService} from '../../services/theme-night.service';
@@ -29,15 +30,22 @@ import {TuiThemeNightService} from '../../services/theme-night.service';
     ],
 })
 export class TuiDocMainComponent {
-    readonly change$ = this.nightService;
+    readonly change$ = this.night;
+
+    readonly night$ = this.change$.pipe(
+        startWith(null),
+        map(() => this.night.value),
+        distinctUntilChanged(),
+        share(),
+    );
 
     constructor(
-        @Inject(TuiThemeService) readonly themeService: TuiThemeService,
-        @Inject(TuiThemeNightService) readonly nightService: TuiThemeNightService,
+        @Inject(TuiThemeService) readonly theme: TuiThemeService,
+        @Inject(TuiThemeNightService) readonly night: TuiThemeNightService,
     ) {}
 
     @HostBinding('attr.data-mode')
     get mode(): TuiBrightness | null {
-        return this.nightService.value ? 'onDark' : null;
+        return this.night.value ? 'onDark' : null;
     }
 }

--- a/projects/addon-doc/src/components/main/main.template.html
+++ b/projects/addon-doc/src/components/main/main.template.html
@@ -1,4 +1,4 @@
-<tui-theme-night *ngIf="nightService.value && themeService.isDefaultTheme"></tui-theme-night>
+<tui-theme-night *ngIf="theme.isDefaultTheme && night.useDefaultNightTheme && (night$ | async)"></tui-theme-night>
 <tui-root>
     <div class="tui-doc-page">
         <tui-doc-navigation class="tui-doc-navigation">
@@ -18,8 +18,8 @@
             shape="rounded"
             type="button"
             class="tui-doc-night-mode-switch"
-            [icon]="nightService.value ? 'tuiIconSunLarge' : 'tuiIconMoonLarge'"
-            (click)="nightService.toggle()"
+            [icon]="night.value ? 'tuiIconSunLarge' : 'tuiIconMoonLarge'"
+            (click)="night.toggle()"
         ></button>
     </header>
     <ng-container ngProjectAs="tuiOverContent">

--- a/projects/addon-doc/src/services/theme-night.options.ts
+++ b/projects/addon-doc/src/services/theme-night.options.ts
@@ -1,8 +1,15 @@
 import {InjectionToken} from '@angular/core';
+// eslint-disable-next-line @taiga-ui/no-deep-imports
+import {ALWAYS_TRUE_HANDLER} from '@taiga-ui/cdk/constants';
 
 export const TUI_THEME_NIGHT_STORAGE_DEFAULT_KEY = `tuiNight` as const;
 
 export const TUI_THEME_NIGHT_STORAGE_KEY = new InjectionToken<string>(
     `[TUI_THEME_NIGHT_STORAGE_KEY]`,
     {factory: () => TUI_THEME_NIGHT_STORAGE_DEFAULT_KEY},
+);
+
+export const TUI_USE_DEFAULT_NIGHT_THEME = new InjectionToken<boolean>(
+    `[TUI_USE_DEFAULT_NIGHT_THEME]`,
+    {factory: ALWAYS_TRUE_HANDLER},
 );

--- a/projects/addon-doc/src/services/theme-night.service.ts
+++ b/projects/addon-doc/src/services/theme-night.service.ts
@@ -2,7 +2,10 @@ import {Inject, Injectable} from '@angular/core';
 import {LOCAL_STORAGE, WINDOW} from '@ng-web-apis/common';
 import {BehaviorSubject} from 'rxjs';
 
-import {TUI_THEME_NIGHT_STORAGE_KEY} from './theme-night.options';
+import {
+    TUI_THEME_NIGHT_STORAGE_KEY,
+    TUI_USE_DEFAULT_NIGHT_THEME,
+} from './theme-night.options';
 
 @Injectable({
     providedIn: `root`,
@@ -12,6 +15,7 @@ export class TuiThemeNightService extends BehaviorSubject<boolean> {
         @Inject(WINDOW) readonly windowRef: Window,
         @Inject(LOCAL_STORAGE) readonly storage: Storage,
         @Inject(TUI_THEME_NIGHT_STORAGE_KEY) readonly key: string,
+        @Inject(TUI_USE_DEFAULT_NIGHT_THEME) readonly useDefaultNightTheme: boolean,
     ) {
         super(
             storage.getItem(key) === `true` ||


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [x] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?

if we do not want to include styles
out of the box for the dark theme we can turn it off