### PR TITLE
fix(kit): `Stepper` use `TuiScrollService` instead of scrollIntoView

### DIFF
--- a/projects/demo/src/modules/components/stepper/examples/3/index.html
+++ b/projects/demo/src/modules/components/stepper/examples/3/index.html
@@ -1,0 +1,12 @@
+<tui-stepper
+    orientation="vertical"
+    class="stepper"
+    [activeItemIndex]="5"
+>
+    <button
+        *ngFor="let step of steps"
+        tuiStep
+    >
+        {{ step }}
+    </button>
+</tui-stepper>

--- a/projects/demo/src/modules/components/stepper/examples/3/index.less
+++ b/projects/demo/src/modules/components/stepper/examples/3/index.less
@@ -1,0 +1,4 @@
+.stepper {
+    max-height: 10rem;
+    border: 1px solid var(--tui-base-03);
+}

--- a/projects/demo/src/modules/components/stepper/examples/3/index.ts
+++ b/projects/demo/src/modules/components/stepper/examples/3/index.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+
+@Component({
+    selector: 'tui-stepper-example-3',
+    templateUrl: './index.html',
+    styleUrls: ['./index.less'],
+    changeDetection,
+    encapsulation,
+})
+export class TuiStepperExample3 {
+    readonly steps = ['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven'];
+}

--- a/projects/demo/src/modules/components/stepper/stepper.component.ts
+++ b/projects/demo/src/modules/components/stepper/stepper.component.ts
@@ -23,6 +23,11 @@ export class ExampleTuiStepperComponent {
         HTML: import('./examples/2/index.html?raw'),
     };
 
+    readonly example3: TuiDocExample = {
+        TypeScript: import('./examples/3/index.ts?raw'),
+        HTML: import('./examples/3/index.html?raw'),
+    };
+
     activeItemIndex = 0;
 
     readonly orientationVariants: readonly TuiOrientation[] = ['horizontal', 'vertical'];

--- a/projects/demo/src/modules/components/stepper/stepper.module.ts
+++ b/projects/demo/src/modules/components/stepper/stepper.module.ts
@@ -7,6 +7,7 @@ import {TuiStepperModule} from '@taiga-ui/kit';
 
 import {TuiStepperExample1} from './examples/1';
 import {TuiStepperExample2} from './examples/2';
+import {TuiStepperExample3} from './examples/3';
 import {ExampleTuiStepperComponent} from './stepper.component';
 
 @NgModule({
@@ -18,7 +19,12 @@ import {ExampleTuiStepperComponent} from './stepper.component';
         TuiAddonDocModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiStepperComponent)),
     ],
-    declarations: [ExampleTuiStepperComponent, TuiStepperExample1, TuiStepperExample2],
+    declarations: [
+        ExampleTuiStepperComponent,
+        TuiStepperExample1,
+        TuiStepperExample2,
+        TuiStepperExample3,
+    ],
     exports: [ExampleTuiStepperComponent],
 })
 export class ExampleTuiStepperModule {}

--- a/projects/demo/src/modules/components/stepper/stepper.template.html
+++ b/projects/demo/src/modules/components/stepper/stepper.template.html
@@ -21,6 +21,14 @@
         >
             <tui-stepper-example-2></tui-stepper-example-2>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="scroll"
+            heading="Vertical autoscroll"
+            [content]="example3"
+        >
+            <tui-stepper-example-3></tui-stepper-example-3>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>

--- a/projects/kit/components/stepper/stepper.component.ts
+++ b/projects/kit/components/stepper/stepper.component.ts
@@ -1,4 +1,5 @@
 import {
+    AfterViewChecked,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -21,6 +22,8 @@ import {
     tuiMoveFocus,
     tuiPure,
     tuiQueryListChanges,
+    TuiResizeService,
+    TuiScrollService,
 } from '@taiga-ui/cdk';
 import {TuiOrientation} from '@taiga-ui/core';
 import {Observable} from 'rxjs';
@@ -30,23 +33,13 @@ import {delay} from 'rxjs/operators';
 // eslint-disable-next-line import/no-cycle
 import {TuiStepComponent} from './step/step.component';
 
-const ONLY_HORIZONTAL_SCROLL: ScrollIntoViewOptions = {
-    block: 'nearest',
-    inline: 'center',
-};
-
-const ONLY_VERTICAL_SCROLL: ScrollIntoViewOptions = {
-    block: 'center',
-    inline: 'nearest',
-};
-
 @Component({
     selector: 'tui-stepper, nav[tuiStepper]',
     templateUrl: './stepper.template.html',
     styleUrls: ['./stepper.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TuiStepperComponent {
+export class TuiStepperComponent  {
     @ContentChildren(forwardRef(() => TuiStepComponent), {read: ElementRef})
     private readonly steps: QueryList<ElementRef<HTMLElement>> = EMPTY_QUERY;
 
@@ -68,7 +61,12 @@ export class TuiStepperComponent {
 
     constructor(
         @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
-    ) {}
+        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(TuiScrollService) private readonly scrollService: TuiScrollService,
+        @Inject(TuiResizeService) resize$: Observable<void>,
+    ) {
+        resize$.subscribe(() => this.changeDetectorRef.markForCheck());
+    }
 
     @tuiPure
     get changes$(): Observable<unknown> {
@@ -97,6 +95,10 @@ export class TuiStepperComponent {
 
         event.preventDefault();
         this.moveFocus(event.target, step);
+    }
+
+    ngAfterViewChecked(): void {
+        this.scrollIntoView(this.activeItemIndex);
     }
 
     indexOf(step: HTMLElement): number {
@@ -138,11 +140,26 @@ export class TuiStepperComponent {
         tuiMoveFocus(index, stepElements, step);
     }
 
-    private scrollIntoView(targetStepIndex: number): void {
-        this.getNativeElements(this.steps)[targetStepIndex]?.scrollIntoView(
-            this.orientation === 'vertical'
-                ? ONLY_VERTICAL_SCROLL
-                : ONLY_HORIZONTAL_SCROLL,
-        );
+    private scrollIntoView(index: number): void {
+        const step = this.getNativeElements(this.steps)[index];
+
+        if (!step) {
+            return;
+        }
+
+        const {nativeElement} = this.elementRef;
+        const {clientHeight, clientWidth, offsetTop, offsetLeft} = nativeElement;
+        const {
+            offsetHeight,
+            offsetWidth,
+            offsetTop: stepOffsetTop,
+            offsetLeft: stepOffsetLeft,
+        } = step;
+        const top = stepOffsetTop - offsetTop - clientHeight / 2 + offsetHeight / 2;
+        const left = stepOffsetLeft - offsetLeft - clientWidth / 2 + offsetWidth / 2;
+
+        this.scrollService
+            .scroll$(nativeElement, Math.max(0, top), Math.max(0, left), 100)
+            .subscribe();
     }
 }

--- a/projects/kit/components/stepper/stepper.component.ts
+++ b/projects/kit/components/stepper/stepper.component.ts
@@ -49,15 +49,10 @@ export class TuiStepperComponent  {
     orientation: TuiOrientation = 'horizontal';
 
     @Input('activeItemIndex')
-    set activeIndex(index: number) {
-        this.activeItemIndex = index;
-        this.scrollIntoView(index);
-    }
+    activeItemIndex = 0;
 
     @Output()
     readonly activeItemIndexChange = new EventEmitter<number>();
-
-    activeItemIndex = 0;
 
     constructor(
         @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
@@ -98,7 +93,9 @@ export class TuiStepperComponent  {
     }
 
     ngAfterViewChecked(): void {
-        this.scrollIntoView(this.activeItemIndex);
+        if (this.initialized) {
+            this.scrollIntoView(this.activeItemIndex);
+        }
     }
 
     indexOf(step: HTMLElement): number {
@@ -129,17 +126,7 @@ export class TuiStepperComponent  {
         return queryList.map(({nativeElement}) => nativeElement);
     }
 
-    private moveFocus(current: EventTarget, step: number): void {
-        if (!tuiIsElement(current)) {
-            return;
-        }
-
-        const stepElements = this.getNativeElements(this.steps);
-        const index = stepElements.findIndex(item => item === current);
-
-        tuiMoveFocus(index, stepElements, step);
-    }
-
+    @tuiPure
     private scrollIntoView(index: number): void {
         const step = this.getNativeElements(this.steps)[index];
 
@@ -161,5 +148,25 @@ export class TuiStepperComponent  {
         this.scrollService
             .scroll$(nativeElement, Math.max(0, top), Math.max(0, left), 100)
             .subscribe();
+    }
+
+    private get initialized(): boolean {
+        const {nativeElement} = this.elementRef;
+
+        return (
+            !!nativeElement.offsetWidth &&
+            !!this.getNativeElements(this.steps)[this.activeItemIndex]
+        );
+    }
+
+    private moveFocus(current: EventTarget, step: number): void {
+        if (!tuiIsElement(current)) {
+            return;
+        }
+
+        const stepElements = this.getNativeElements(this.steps);
+        const index = stepElements.findIndex(item => item === current);
+
+        tuiMoveFocus(index, stepElements, step);
     }
 }

--- a/projects/kit/components/stepper/stepper.component.ts
+++ b/projects/kit/components/stepper/stepper.component.ts
@@ -120,13 +120,6 @@ export class TuiStepperComponent  {
     }
 
     @tuiPure
-    private getNativeElements(
-        queryList: QueryList<ElementRef<HTMLElement>>,
-    ): HTMLElement[] {
-        return queryList.map(({nativeElement}) => nativeElement);
-    }
-
-    @tuiPure
     private scrollIntoView(index: number): void {
         const step = this.getNativeElements(this.steps)[index];
 
@@ -148,6 +141,13 @@ export class TuiStepperComponent  {
         this.scrollService
             .scroll$(nativeElement, Math.max(0, top), Math.max(0, left), 100)
             .subscribe();
+    }
+
+    @tuiPure
+    private getNativeElements(
+        queryList: QueryList<ElementRef<HTMLElement>>,
+    ): HTMLElement[] {
+        return queryList.map(({nativeElement}) => nativeElement);
     }
 
     private get initialized(): boolean {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #3629

There is a chromium bug with `element.scrollIntoView` https://bugs.chromium.org/p/chromium/issues/detail?id=833617
Autoscroll doesn't work if there is more then one stepper on the page

## What is the new behavior?
With `TuiScrollService` scroll works correctly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
