### PR TITLE
feat(cdk): `Replace` add new pipe

### DIFF
--- a/projects/addon-doc/src/components/page/page.component.ts
+++ b/projects/addon-doc/src/components/page/page.component.ts
@@ -40,6 +40,9 @@ export class TuiDocPageComponent {
 
     activeItemIndex = 0;
 
+    readonly from = / /g;
+    readonly to = '_';
+
     constructor(
         @Inject(TUI_DOC_DEFAULT_TABS) readonly defaultTabs: readonly string[],
         @Inject(PAGE_SEE_ALSO) readonly seeAlso: readonly string[],
@@ -47,9 +50,5 @@ export class TuiDocPageComponent {
 
     get showSeeAlso(): boolean {
         return !!this.seeAlso.length && this.activeItemIndex === 0;
-    }
-
-    getRouterLink(tab: string = ''): string {
-        return `./${tab.replace(/ /g, '_')}`;
     }
 }

--- a/projects/addon-doc/src/components/page/page.module.ts
+++ b/projects/addon-doc/src/components/page/page.module.ts
@@ -1,6 +1,7 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
+import {TuiReplacePipeModule} from '@taiga-ui/cdk';
 import {TuiTabsModule, TuiTagModule} from '@taiga-ui/kit';
 
 import {TuiDocSeeAlsoModule} from '../../internal/see-also/see-also.module';
@@ -16,6 +17,7 @@ import {TuiDocPageTabConnectorDirective} from './page-tab.directive';
         TuiTabsModule,
         TuiTagModule,
         TuiDocSourceCodeModule,
+        TuiReplacePipeModule,
     ],
     declarations: [TuiDocPageComponent, TuiDocPageTabConnectorDirective],
     exports: [TuiDocPageComponent, TuiDocPageTabConnectorDirective],

--- a/projects/addon-doc/src/components/page/page.template.html
+++ b/projects/addon-doc/src/components/page/page.template.html
@@ -21,27 +21,17 @@
         [(activeItemIndex)]="activeItemIndex"
     >
         <ng-container *ngFor="let tab of tabConnectors; first as first; index as index">
-            <ng-container *ngIf="first; else dynamicTab">
+            <ng-container *ngIf="tab.pageTab || defaultTabs[index] as tabName">
                 <a
                     *tuiItem
                     tuiTab
-                    routerLink="./"
                     routerLinkActive
-                    [routerLinkActiveOptions]="{exact: true}"
+                    [routerLinkActiveOptions]="{exact: first}"
+                    [routerLink]="first ? './' : (tabName | tuiReplace : from : to)"
                 >
-                    {{ tab.pageTab || defaultTabs[index] }}
+                    {{ tabName }}
                 </a>
             </ng-container>
-            <ng-template #dynamicTab>
-                <a
-                    *tuiItem
-                    tuiTab
-                    routerLinkActive
-                    [routerLink]="getRouterLink(tab.pageTab || defaultTabs[index])"
-                >
-                    {{ tab.pageTab || defaultTabs[index] }}
-                </a>
-            </ng-template>
         </ng-container>
     </tui-tabs-with-more>
     <tui-doc-source-code

--- a/projects/cdk/pipes/index.ts
+++ b/projects/cdk/pipes/index.ts
@@ -2,3 +2,4 @@ export * from '@taiga-ui/cdk/pipes/filter';
 export * from '@taiga-ui/cdk/pipes/is-present';
 export * from '@taiga-ui/cdk/pipes/keys';
 export * from '@taiga-ui/cdk/pipes/mapper';
+export * from '@taiga-ui/cdk/pipes/replace';

--- a/projects/cdk/pipes/replace/index.ts
+++ b/projects/cdk/pipes/replace/index.ts
@@ -1,0 +1,2 @@
+export * from './replace.module';
+export * from './replace.pipe';

--- a/projects/cdk/pipes/replace/ng-package.json
+++ b/projects/cdk/pipes/replace/ng-package.json
@@ -1,0 +1,5 @@
+{
+    "lib": {
+        "entryFile": "index.ts"
+    }
+}

--- a/projects/cdk/pipes/replace/replace.module.ts
+++ b/projects/cdk/pipes/replace/replace.module.ts
@@ -1,0 +1,9 @@
+import {NgModule} from '@angular/core';
+
+import {TuiReplacePipe} from './replace.pipe';
+
+@NgModule({
+    exports: [TuiReplacePipe],
+    declarations: [TuiReplacePipe],
+})
+export class TuiReplacePipeModule {}

--- a/projects/cdk/pipes/replace/replace.pipe.ts
+++ b/projects/cdk/pipes/replace/replace.pipe.ts
@@ -1,0 +1,18 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({name: `tuiReplace`})
+export class TuiReplacePipe implements PipeTransform {
+    transform(
+        value: string | null | undefined,
+        search: RegExp | string,
+        replaceValue: string | ((substring: string, ...args: any[]) => string),
+    ): string {
+        return (
+            value?.replace(
+                search,
+                // TS bug: https://github.com/microsoft/TypeScript/issues/22378
+                replaceValue as unknown as string,
+            ) ?? ``
+        );
+    }
+}

--- a/projects/cdk/pipes/replace/test/replace.pipe.spec.ts
+++ b/projects/cdk/pipes/replace/test/replace.pipe.spec.ts
@@ -1,0 +1,34 @@
+import {TuiReplacePipe} from '@taiga-ui/cdk';
+
+describe(`TuiReplacePipe`, () => {
+    let pipe: TuiReplacePipe;
+
+    beforeEach(() => {
+        pipe = new TuiReplacePipe();
+    });
+
+    it(`should return the replaced string`, () => {
+        const result = pipe.transform(`Hello`, `Hello`, `World`);
+
+        expect(result).toEqual(`World`);
+    });
+
+    it(`regex`, () => {
+        const result = pipe.transform(`111222333`, /1/g, `b`);
+
+        expect(result).toEqual(`bbb222333`);
+    });
+
+    it(`function`, () => {
+        const result = pipe.transform(`abcdeabcde`, /a/g, () => `f`);
+
+        expect(result).toEqual(`fbcdefbcde`);
+    });
+
+    it(`unchanged`, () => {
+        expect(pipe.transform(`abc`, ``, ``)).toEqual(`abc`);
+        expect(pipe.transform(``, ``, ``)).toEqual(``);
+        expect(pipe.transform(null, ``, ``)).toEqual(``);
+        expect(pipe.transform(undefined, ``, ``)).toEqual(``);
+    });
+});


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Using `getRouterLink` or `@tuiPure getRouterLink` results in frequent calls to `replace` on strings


https://user-images.githubusercontent.com/12021443/230497337-fe5490e2-947d-4ead-acdb-db6d6e4d11c1.mov


## What is the new behavior?


https://user-images.githubusercontent.com/12021443/230497453-1cc16b69-e2e3-4c41-a746-11ffde91d82f.mov


