### PR TITLE
chore: naming convention to smaller bundle size

### DIFF
--- a/projects/addon-charts/components/arc-chart/arc-chart.component.ts
+++ b/projects/addon-charts/components/arc-chart/arc-chart.component.ts
@@ -93,12 +93,12 @@ export class TuiArcChartComponent {
 
     constructor(
         @Inject(DomSanitizer) private readonly sanitizer: DomSanitizer,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
         // So initial animation works
         setTimeout(() => {
             this.initialized = true;
-            changeDetectorRef.markForCheck();
+            cdr.markForCheck();
         });
     }
 

--- a/projects/addon-commerce/components/input-card-grouped/input-card-grouped.component.ts
+++ b/projects/addon-commerce/components/input-card-grouped/input-card-grouped.component.ts
@@ -185,15 +185,15 @@ export class TuiInputCardGroupedComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_MODE) readonly mode$: Observable<TuiBrightness | null>,
         @Inject(TUI_INPUT_CARD_GROUPED_TEXTS)
         readonly cardGroupedTexts$: Observable<TuiCardGroupedTexts>,
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         readonly controller: TuiTextfieldController,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {
@@ -201,7 +201,7 @@ export class TuiInputCardGroupedComponent
     }
 
     get focused(): boolean {
-        return this.open || tuiIsNativeFocusedIn(this.elementRef.nativeElement);
+        return this.open || tuiIsNativeFocusedIn(this.el.nativeElement);
     }
 
     get appearance(): string {
@@ -322,7 +322,7 @@ export class TuiInputCardGroupedComponent
     @HostListener('keydown.arrowUp.prevent', ['$event.target', '-1'])
     onArrow(element: HTMLElement, step: number): void {
         this.open = this.hasDropdown;
-        this.changeDetectorRef.detectChanges();
+        this.cdr.detectChanges();
         this.datalist?.onKeyDownArrow(element, step);
     }
 

--- a/projects/addon-commerce/components/input-card-grouped/input-card-grouped.providers.ts
+++ b/projects/addon-commerce/components/input-card-grouped/input-card-grouped.providers.ts
@@ -23,13 +23,13 @@ export const TUI_INPUT_CARD_GROUPED_TEXTS = new InjectionToken<
     Observable<TuiCardGroupedTexts>
 >(`[TUI_INPUT_CARD_GROUPED_TEXTS]`, {
     factory: () => {
-        const windowRef = inject(WINDOW);
+        const win = inject(WINDOW);
         const cardNumberTexts = inject(TUI_CARD_NUMBER_TEXTS);
         const expiryTexts = inject(TUI_CARD_EXPIRY_TEXTS);
         const cvcTexts = inject(TUI_CARD_CVC_TEXTS);
         const {desktopSmall} = inject(TUI_MEDIA);
 
-        const media = windowRef.matchMedia(
+        const media = win.matchMedia(
             `screen and (min-width: ${(desktopSmall - 1) / 16}em)`,
         );
 

--- a/projects/addon-commerce/components/input-card-grouped/test/input-card-grouped.component.spec.ts
+++ b/projects/addon-commerce/components/input-card-grouped/test/input-card-grouped.component.spec.ts
@@ -16,7 +16,6 @@ import {
     TUI_AUTOFOCUS_HANDLER,
     TUI_FOCUSABLE_ITEM_ACCESSOR,
     TuiAutoFocusDirective,
-    TuiFocusableElementAccessor,
     TuiSynchronousAutofocusHandler,
 } from '@taiga-ui/cdk';
 import {TuiSvgModule} from '@taiga-ui/core';
@@ -60,14 +59,7 @@ describe(`InputCardGrouped`, () => {
                 providers: [
                     {
                         provide: TUI_AUTOFOCUS_HANDLER,
-                        useFactory: (
-                            tuiFocusableComponent: TuiFocusableElementAccessor | null,
-                            elementRef: ElementRef<HTMLElement>,
-                        ) =>
-                            new TuiSynchronousAutofocusHandler(
-                                tuiFocusableComponent,
-                                elementRef,
-                            ),
+                        useClass: TuiSynchronousAutofocusHandler,
                         deps: [
                             [new Optional(), new Self(), TUI_FOCUSABLE_ITEM_ACCESSOR],
                             ElementRef,

--- a/projects/addon-commerce/components/input-card/input-card.component.ts
+++ b/projects/addon-commerce/components/input-card/input-card.component.ts
@@ -72,9 +72,9 @@ export class TuiInputCardComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     private get defaultCardIcon(): string | null {

--- a/projects/addon-commerce/components/input-cvc/input-cvc.component.ts
+++ b/projects/addon-commerce/components/input-cvc/input-cvc.component.ts
@@ -71,11 +71,11 @@ export class TuiInputCVCComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_TEXTFIELD_LABEL_OUTSIDE)
         private readonly textfieldLabelOutside: TuiTextfieldLabelOutsideDirective,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {

--- a/projects/addon-commerce/components/input-expire/input-expire.component.ts
+++ b/projects/addon-commerce/components/input-expire/input-expire.component.ts
@@ -62,9 +62,9 @@ export class TuiInputExpireComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {

--- a/projects/addon-doc/src/components/demo/demo.component.ts
+++ b/projects/addon-doc/src/components/demo/demo.component.ts
@@ -73,7 +73,7 @@ export class TuiDocDemoComponent implements OnInit {
 
     constructor(
         @Inject(TUI_IS_MOBILE) readonly isMobile: boolean,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(Location) private readonly locationRef: Location,
         @Inject(UrlSerializer) private readonly urlSerializer: UrlSerializer,
         @Inject(TUI_DOC_DEMO_TEXTS) readonly texts: [string, string, string],
@@ -118,7 +118,7 @@ export class TuiDocDemoComponent implements OnInit {
         }
 
         const safe = width || this.resizeable.nativeElement.clientWidth;
-        const total = this.elementRef.nativeElement.clientWidth;
+        const total = this.el.nativeElement.clientWidth;
         const clamped = Math.round(tuiClamp(safe, MIN_WIDTH, total)) - this.delta;
         const validated = safe < total ? clamped : NaN;
 

--- a/projects/addon-doc/src/components/documentation/documentation.component.ts
+++ b/projects/addon-doc/src/components/documentation/documentation.component.ts
@@ -58,7 +58,7 @@ export class TuiDocDocumentationComponent implements AfterContentInit {
     activeItemIndex = 0;
 
     constructor(
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
         @Inject(TUI_DOC_DOCUMENTATION_TEXTS)
         readonly texts: [string, string, string, string, string],
         @Inject(TUI_DOC_EXCLUDED_PROPERTIES)
@@ -76,7 +76,7 @@ export class TuiDocDocumentationComponent implements AfterContentInit {
         tuiQueryListChanges(this.propertiesConnectors)
             .pipe(
                 switchMap(items => merge(...items.map(({changed$}) => changed$))),
-                tuiWatch(this.changeDetectorRef),
+                tuiWatch(this.cdr),
                 takeUntil(this.destroy$),
             )
             .subscribe();

--- a/projects/addon-doc/src/components/example/example.component.ts
+++ b/projects/addon-doc/src/components/example/example.component.ts
@@ -63,7 +63,7 @@ export class TuiDocExampleComponent {
     constructor(
         @Inject(Clipboard) private readonly clipboard: Clipboard,
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
         @Inject(LOCATION) private readonly location: Location,
         @Inject(TUI_COPY_TEXTS) private readonly copyTexts$: Observable<[string, string]>,
         @Inject(TUI_DOC_EXAMPLE_TEXTS) readonly texts: [string, string, string],
@@ -97,7 +97,7 @@ export class TuiDocExampleComponent {
 
         this.setFragmentWithoutRedirect(this.id);
         this.clipboard.copy(url);
-        this.alertService
+        this.alerts
             .open(this.texts[1], {
                 label: this.texts[2],
                 status: TuiNotification.Success,

--- a/projects/addon-doc/src/components/navigation/navigation.component.ts
+++ b/projects/addon-doc/src/components/navigation/navigation.component.ts
@@ -59,10 +59,10 @@ export class TuiDocNavigationComponent {
     );
 
     constructor(
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(Title) titleService: Title,
         @Inject(NAVIGATION_TITLE) title$: Observable<string>,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
+        @Inject(DOCUMENT) private readonly doc: Document,
         @Inject(TuiModeDirective)
         private readonly mode: TuiModeDirective,
         @Optional()
@@ -82,7 +82,7 @@ export class TuiDocNavigationComponent {
         // Angular can't navigate no anchor links
         // https://stackoverflow.com/questions/36101756/angular2-routing-with-hashtag-to-page-anchor
         title$.subscribe(title => {
-            changeDetectorRef.markForCheck();
+            cdr.markForCheck();
             titleService.setTitle(title);
             this.openActivePageGroup();
             this.handleAnchorLink(this.activatedRoute.snapshot.fragment || '');
@@ -197,7 +197,7 @@ export class TuiDocNavigationComponent {
     }
 
     private navigateToAnchorLink(fragment: string): void {
-        const nodes = fragment ? this.documentRef.querySelectorAll(`#${fragment}`) : [];
+        const nodes = fragment ? this.doc.querySelectorAll(`#${fragment}`) : [];
         const element = nodes.length && nodes[nodes.length - 1];
 
         if (!element) {

--- a/projects/addon-doc/src/internal/input-opacity/input-opacity.directive.ts
+++ b/projects/addon-doc/src/internal/input-opacity/input-opacity.directive.ts
@@ -7,7 +7,7 @@ import {TUI_FOCUSABLE_ITEM_ACCESSOR, TuiFocusableElementAccessor} from '@taiga-u
 export class TuiInputOpacityDirective {
     @Input()
     set tuiInputOpacity(opacity: number) {
-        const {nativeFocusableElement} = this.tuiFocusableComponent;
+        const {nativeFocusableElement} = this.focusable;
 
         if (nativeFocusableElement) {
             this.renderer.setStyle(nativeFocusableElement, 'opacity', opacity / 100);
@@ -17,6 +17,6 @@ export class TuiInputOpacityDirective {
     constructor(
         @Inject(Renderer2) private readonly renderer: Renderer2,
         @Inject(TUI_FOCUSABLE_ITEM_ACCESSOR)
-        private readonly tuiFocusableComponent: TuiFocusableElementAccessor,
+        private readonly focusable: TuiFocusableElementAccessor,
     ) {}
 }

--- a/projects/addon-doc/src/services/theme-night.service.ts
+++ b/projects/addon-doc/src/services/theme-night.service.ts
@@ -12,7 +12,7 @@ import {
 })
 export class TuiThemeNightService extends BehaviorSubject<boolean> {
     constructor(
-        @Inject(WINDOW) readonly windowRef: Window,
+        @Inject(WINDOW) readonly win: Window,
         @Inject(LOCAL_STORAGE) readonly storage: Storage,
         @Inject(TUI_THEME_NIGHT_STORAGE_KEY) readonly key: string,
         @Inject(TUI_USE_DEFAULT_NIGHT_THEME) readonly useDefaultNightTheme: boolean,
@@ -20,7 +20,7 @@ export class TuiThemeNightService extends BehaviorSubject<boolean> {
         super(
             storage.getItem(key) === `true` ||
                 (storage.getItem(key) === null &&
-                    windowRef.matchMedia(`(prefers-color-scheme: dark)`).matches),
+                    win.matchMedia(`(prefers-color-scheme: dark)`).matches),
         );
     }
 

--- a/projects/addon-editor/components/edit-link/edit-link.component.ts
+++ b/projects/addon-editor/components/edit-link/edit-link.component.ts
@@ -49,7 +49,7 @@ export class TuiEditLinkComponent {
 
     constructor(
         @Inject(DOCUMENT)
-        private readonly documentRef: Document,
+        private readonly doc: Document,
         @Inject(TUI_EDITOR_LINK_TEXTS)
         readonly texts$: TuiInjectionTokenType<typeof TUI_EDITOR_LINK_TEXTS>,
         @Inject(TuiTiptapEditorService) private readonly editor: AbstractTuiEditor,
@@ -168,7 +168,7 @@ export class TuiEditLinkComponent {
     }
 
     private getFocusedParentElement(): HTMLElement | null {
-        return this.documentRef.getSelection()?.focusNode?.parentElement || null;
+        return this.doc.getSelection()?.focusNode?.parentElement || null;
     }
 
     private getAnchorElement(): HTMLAnchorElement | null {

--- a/projects/addon-editor/components/editor-resizable/editor-resizable.abstract.ts
+++ b/projects/addon-editor/components/editor-resizable/editor-resizable.abstract.ts
@@ -16,13 +16,10 @@ export abstract class AbstractTuiEditorResizable<
     protected _height = 0;
     protected _width = 0;
 
-    constructor(documentRef: Document, destroy$: TuiDestroyService) {
+    constructor(doc: Document, destroy$: TuiDestroyService) {
         super();
 
-        merge(
-            tuiTypedFromEvent(documentRef, `touchend`),
-            tuiTypedFromEvent(documentRef, `mouseup`),
-        )
+        merge(tuiTypedFromEvent(doc, `touchend`), tuiTypedFromEvent(doc, `mouseup`))
             .pipe(takeUntil(destroy$))
             .subscribe(() =>
                 this.updateAttributes({width: this.width, height: this.height}),

--- a/projects/addon-editor/components/editor-socket/editor-socket.component.ts
+++ b/projects/addon-editor/components/editor-socket/editor-socket.component.ts
@@ -30,7 +30,7 @@ export class TuiEditorSocketComponent {
     @Input()
     set content(content: string) {
         this.renderer.setProperty(
-            this.elementRef.nativeElement,
+            this.el.nativeElement,
             'innerHTML',
             this.tuiSanitizer
                 ? this.tuiSanitizer.sanitize(
@@ -42,7 +42,7 @@ export class TuiEditorSocketComponent {
     }
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(Renderer2) private readonly renderer: Renderer2,
         @Inject(Sanitizer) private readonly sanitizer: Sanitizer,
         @Optional()

--- a/projects/addon-editor/components/editor/editor.component.ts
+++ b/projects/addon-editor/components/editor/editor.component.ts
@@ -51,7 +51,7 @@ export class TuiEditorComponent
     implements OnDestroy, TuiFocusableElementAccessor
 {
     @ViewChild(TuiTiptapEditorDirective, {read: ElementRef})
-    private readonly element?: ElementRef<HTMLElement>;
+    private readonly el?: ElementRef<HTMLElement>;
 
     @Input()
     @tuiDefaultProp()
@@ -74,19 +74,19 @@ export class TuiEditorComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TIPTAP_EDITOR) readonly editorLoaded$: Observable<Editor | null>,
         @Inject(TuiTiptapEditorService) readonly editorService: AbstractTuiEditor,
         @Inject(TUI_EDITOR_CONTENT_PROCESSOR)
         private readonly contentProcessor: TuiStringHandler<string>,
         @Inject(DOCUMENT)
-        private readonly documentRef: Document,
+        private readonly doc: Document,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLElement | null {
-        return this.computedDisabled ? null : this.element?.nativeElement || null;
+        return this.computedDisabled ? null : this.el?.nativeElement || null;
     }
 
     get dropdownSelectionHandler(): TuiBooleanHandler<Range> {
@@ -173,7 +173,7 @@ export class TuiEditorComponent
     private currentFocusedNodeIsAnchor(range: Range): boolean {
         return !!range.startContainer.parentElement
             ?.closest('a')
-            ?.contains(this.documentRef.getSelection()?.focusNode || null);
+            ?.contains(this.doc.getSelection()?.focusNode || null);
     }
 
     private get hasValue(): boolean {

--- a/projects/addon-editor/components/editor/portal/editor-portal.directive.ts
+++ b/projects/addon-editor/components/editor/portal/editor-portal.directive.ts
@@ -14,13 +14,11 @@ import {TuiEditorPortalService} from './editor-portal.service';
 export class TuiEditorPortalDirective extends TuiRectAccessor {
     readonly type = 'viewport';
 
-    constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
-    ) {
+    constructor(@Inject(ElementRef) private readonly el: ElementRef<HTMLElement>) {
         super();
     }
 
     getClientRect(): ClientRect {
-        return this.elementRef.nativeElement.getBoundingClientRect();
+        return this.el.nativeElement.getBoundingClientRect();
     }
 }

--- a/projects/addon-editor/components/input-color/input-color.component.ts
+++ b/projects/addon-editor/components/input-color/input-color.component.ts
@@ -57,10 +57,10 @@ export class TuiInputColorComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(DomSanitizer) private readonly domSanitizer: DomSanitizer,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {

--- a/projects/addon-editor/components/toolbar-tools/table-size-selector/table-size-selector.component.ts
+++ b/projects/addon-editor/components/toolbar-tools/table-size-selector/table-size-selector.component.ts
@@ -35,7 +35,7 @@ export class TuiTableSizeSelectorComponent {
         cols: 1,
     };
 
-    constructor(@Inject(WINDOW) private readonly windowRef: Window) {}
+    constructor(@Inject(WINDOW) private readonly win: Window) {}
 
     get columnsNumber(): number {
         return Math.min(Math.max(3, this.tableSize.cols + 1), MAX_COLS_NUMBER);
@@ -50,7 +50,7 @@ export class TuiTableSizeSelectorComponent {
     }
 
     updateCurrentSize(rows: number, cols: number, event: MouseEvent): void {
-        if (tuiGetViewportWidth(this.windowRef) - event.clientX > MIN_DISTANCE_PX) {
+        if (tuiGetViewportWidth(this.win) - event.clientX > MIN_DISTANCE_PX) {
             this.tableSize = {rows, cols};
         }
     }

--- a/projects/addon-editor/components/toolbar/toolbar-navigation-manager.directive.ts
+++ b/projects/addon-editor/components/toolbar/toolbar-navigation-manager.directive.ts
@@ -11,13 +11,11 @@ import {
     selector: '[tuiToolbarNavigationManager]',
 })
 export class TuiToolbarNavigationManagerDirective {
-    constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
-    ) {}
+    constructor(@Inject(ElementRef) private readonly el: ElementRef<HTMLElement>) {}
 
     private get toolsContainers(): readonly HTMLElement[] {
         return Array.from(
-            this.elementRef.nativeElement.querySelectorAll<HTMLElement>('[tuiItem]'),
+            this.el.nativeElement.querySelectorAll<HTMLElement>('[tuiItem]'),
         );
     }
 
@@ -75,7 +73,7 @@ export class TuiToolbarNavigationManagerDirective {
             lookedInside ||
             tuiGetClosestFocusable({
                 initial: wrapper,
-                root: this.elementRef.nativeElement,
+                root: this.el.nativeElement,
                 previous: true,
                 keyboard: false,
             })
@@ -87,7 +85,7 @@ export class TuiToolbarNavigationManagerDirective {
             ? wrapper
             : tuiGetClosestFocusable({
                   initial: wrapper,
-                  root: this.elementRef.nativeElement,
+                  root: this.el.nativeElement,
                   keyboard: false,
               });
     }

--- a/projects/addon-editor/components/toolbar/toolbar.component.ts
+++ b/projects/addon-editor/components/toolbar/toolbar.component.ts
@@ -88,7 +88,7 @@ export class TuiToolbarComponent {
     constructor(
         @Optional()
         @Inject(ElementRef)
-        private readonly elementRef: ElementRef<HTMLElement>,
+        private readonly el: ElementRef<HTMLElement>,
         @Inject(TuiTiptapEditorService) readonly editor: AbstractTuiEditor,
         @Inject(TUI_IMAGE_LOADER)
         private readonly imageLoader: TuiHandler<File, Observable<string>>,
@@ -107,7 +107,7 @@ export class TuiToolbarComponent {
 
     get focused(): boolean {
         return (
-            tuiIsNativeFocusedIn(this.elementRef.nativeElement) ||
+            tuiIsNativeFocusedIn(this.el.nativeElement) ||
             !!this.dropdowns.find(({nativeElement}) =>
                 tuiIsNativeFocusedIn(nativeElement),
             )

--- a/projects/addon-editor/directives/tiptap-editor/tiptap-editor.directive.ts
+++ b/projects/addon-editor/directives/tiptap-editor/tiptap-editor.directive.ts
@@ -41,7 +41,7 @@ export class TuiTiptapEditorDirective {
     readonly stateChange = this.editor.stateChange$;
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(Renderer2) private readonly renderer: Renderer2,
         @Inject(TuiTiptapEditorService) readonly editor: AbstractTuiEditor,
         @Inject(INITIALIZATION_TIPTAP_CONTAINER) readonly editorContainer: HTMLElement,
@@ -49,10 +49,7 @@ export class TuiTiptapEditorDirective {
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
     ) {
         this.editorLoaded$.pipe(takeUntil(destroy$)).subscribe(() => {
-            this.renderer.appendChild(
-                this.elementRef.nativeElement,
-                this.editorContainer,
-            );
+            this.renderer.appendChild(this.el.nativeElement, this.editorContainer);
         });
     }
 }

--- a/projects/addon-editor/extensions/iframe-editor/iframe-editor.component.ts
+++ b/projects/addon-editor/extensions/iframe-editor/iframe-editor.component.ts
@@ -24,13 +24,13 @@ export class TuiIframeEditorComponent extends AbstractTuiEditorResizable<TuiEdit
 
     constructor(
         @Inject(TUI_IFRAME_EDITOR_OPTIONS) readonly options: TuiEditableIframeOptions,
-        @Inject(DOCUMENT) documentRef: Document,
+        @Inject(DOCUMENT) doc: Document,
         @Inject(DomSanitizer) private readonly sanitizer: DomSanitizer,
         @Self()
         @Inject(TuiDestroyService)
         destroy$: TuiDestroyService,
     ) {
-        super(documentRef, destroy$);
+        super(doc, destroy$);
     }
 
     updateSize([width, height]: readonly [width: number, height: number]): void {

--- a/projects/addon-editor/extensions/image-editor/image-editor.component.ts
+++ b/projects/addon-editor/extensions/image-editor/image-editor.component.ts
@@ -51,13 +51,13 @@ export class TuiImageEditorComponent extends AbstractTuiEditorResizable<TuiEdita
         @Inject(TUI_EDITOR_MIN_IMAGE_WIDTH) readonly minWidth: number | null,
         @Inject(TUI_EDITOR_MAX_IMAGE_WIDTH) readonly maxWidth: number | null,
         @Inject(TUI_IMAGE_EDITOR_OPTIONS) readonly options: TuiImageEditorOptions,
-        @Inject(DOCUMENT) documentRef: Document,
+        @Inject(DOCUMENT) doc: Document,
         @Inject(DomSanitizer) private readonly sanitizer: DomSanitizer,
         @Self()
         @Inject(TuiDestroyService)
         destroy$: TuiDestroyService,
     ) {
-        super(documentRef, destroy$);
+        super(doc, destroy$);
     }
 
     updateSize([width]: readonly [width: number, height: number]): void {

--- a/projects/addon-editor/extensions/tiptap-node-view/component-render.ts
+++ b/projects/addon-editor/extensions/tiptap-node-view/component-render.ts
@@ -33,12 +33,12 @@ export class TuiComponentRenderer<C, P> {
         return this.componentRef.instance;
     }
 
-    get elementRef(): ElementRef {
+    get el(): ElementRef {
         return this.componentRef.injector.get(ElementRef);
     }
 
     get dom(): HTMLElement {
-        return this.elementRef.nativeElement;
+        return this.el.nativeElement;
     }
 
     updateProps<T extends P>(props: Partial<T>): void {

--- a/projects/addon-editor/extensions/tiptap-node-view/node-view-render.ts
+++ b/projects/addon-editor/extensions/tiptap-node-view/node-view-render.ts
@@ -53,7 +53,7 @@ class TuiNodeView extends NodeView<
 
     override mount(): void {
         const injector = this.options.injector;
-        const documentRef = injector.get(DOCUMENT);
+        const doc = injector.get(DOCUMENT);
 
         const props: NodeViewProps = {
             editor: this.editor,
@@ -71,14 +71,14 @@ class TuiNodeView extends NodeView<
 
         // Register drag handler
         if (this.extension.config.draggable) {
-            this.renderer.elementRef.nativeElement.ondragstart = (e: DragEvent) => {
+            this.renderer.el.nativeElement.ondragstart = (e: DragEvent) => {
                 this.onDragStart(e);
             };
         }
 
         this.contentDOMElement = this.node.isLeaf
             ? null
-            : documentRef.createElement(this.node.isInline ? `span` : `div`);
+            : doc.createElement(this.node.isInline ? `span` : `div`);
 
         if (this.contentDOMElement) {
             // For some reason the whiteSpace prop is not inherited properly in Chrome and Safari

--- a/projects/addon-editor/services/picker.service.ts
+++ b/projects/addon-editor/services/picker.service.ts
@@ -11,16 +11,16 @@ export class TuiPickerService extends Observable<TuiPoint> {
     constructor(
         @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
         @Inject(ElementRef) {nativeElement}: ElementRef<HTMLElement>,
-        @Inject(DOCUMENT) documentRef: Document,
+        @Inject(DOCUMENT) doc: Document,
     ) {
         const point$ = tuiTypedFromEvent(nativeElement, `mousedown`).pipe(
             tuiPreventDefault(),
             switchMap(event => {
-                const mouseMove$ = tuiTypedFromEvent(documentRef, `mousemove`).pipe(
+                const mouseMove$ = tuiTypedFromEvent(doc, `mousemove`).pipe(
                     map(({clientX, clientY}) =>
                         tuiGetElementPoint(clientX, clientY, nativeElement),
                     ),
-                    takeUntil(tuiTypedFromEvent(documentRef, `mouseup`)),
+                    takeUntil(tuiTypedFromEvent(doc, `mouseup`)),
                 );
 
                 return event.target === nativeElement

--- a/projects/addon-editor/utils/insert-html.ts
+++ b/projects/addon-editor/utils/insert-html.ts
@@ -6,23 +6,23 @@ import {TuiDocumentSelectionException} from '@taiga-ui/cdk';
  *
  * @throws Will throw an error if selection could not be retrieved
  *
- * @param documentRef document to execute on
+ * @param doc document to execute on
  * @param html html to be inserted
  */
-export function tuiInsertHtml(documentRef: Document, html: string): void {
-    if (documentRef.queryCommandSupported(`insertHTML`)) {
-        documentRef.execCommand(`insertHTML`, false, html);
+export function tuiInsertHtml(doc: Document, html: string): void {
+    if (doc.queryCommandSupported(`insertHTML`)) {
+        doc.execCommand(`insertHTML`, false, html);
 
         return;
     }
 
-    const selection = documentRef.getSelection();
+    const selection = doc.getSelection();
 
     if (!selection) {
         throw new TuiDocumentSelectionException();
     }
 
-    documentRef.execCommand(`ms-beginUndoUnit`);
+    doc.execCommand(`ms-beginUndoUnit`);
 
     const range = selection.getRangeAt(0);
     const documentFragment = range.createContextualFragment(html);
@@ -30,5 +30,5 @@ export function tuiInsertHtml(documentRef: Document, html: string): void {
     range.deleteContents();
     range.insertNode(documentFragment);
 
-    documentRef.execCommand(`ms-endUndoUnit`);
+    doc.execCommand(`ms-endUndoUnit`);
 }

--- a/projects/addon-editor/utils/insert-text.ts
+++ b/projects/addon-editor/utils/insert-text.ts
@@ -6,28 +6,28 @@ import {TuiDocumentSelectionException} from '@taiga-ui/cdk';
  *
  * @throws Will throw an error if selection could not be retrieved
  *
- * @param documentRef document to execute on
+ * @param doc document to execute on
  * @param text text to be inserted
  */
-export function tuiInsertText(documentRef: Document, text: string): void {
-    if (documentRef.queryCommandSupported(`insertText`)) {
-        documentRef.execCommand(`insertText`, false, text);
+export function tuiInsertText(doc: Document, text: string): void {
+    if (doc.queryCommandSupported(`insertText`)) {
+        doc.execCommand(`insertText`, false, text);
 
         return;
     }
 
-    const selection = documentRef.getSelection();
+    const selection = doc.getSelection();
 
     if (!selection) {
         throw new TuiDocumentSelectionException();
     }
 
-    documentRef.execCommand(`ms-beginUndoUnit`);
+    doc.execCommand(`ms-beginUndoUnit`);
 
     const range = selection.getRangeAt(0);
 
     range.deleteContents();
-    range.insertNode(documentRef.createTextNode(text));
+    range.insertNode(doc.createTextNode(text));
 
-    documentRef.execCommand(`ms-endUndoUnit`);
+    doc.execCommand(`ms-endUndoUnit`);
 }

--- a/projects/addon-mobile/components/mobile-calendar/mobile-calendar.component.ts
+++ b/projects/addon-mobile/components/mobile-calendar/mobile-calendar.component.ts
@@ -119,7 +119,7 @@ export class TuiMobileCalendarComponent implements AfterViewInit {
     constructor(
         @Inject(TUI_IS_IOS) readonly isIOS: boolean,
         @Inject(TUI_IS_CYPRESS) readonly isCypress: boolean,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
+        @Inject(DOCUMENT) private readonly doc: Document,
         @Self()
         @Inject(TuiDestroyService)
         private readonly destroy$: TuiDestroyService,
@@ -139,7 +139,7 @@ export class TuiMobileCalendarComponent implements AfterViewInit {
     }
 
     get yearWidth(): number {
-        return this.documentRef.documentElement.clientWidth / YEARS_IN_ROW;
+        return this.doc.documentElement.clientWidth / YEARS_IN_ROW;
     }
 
     ngAfterViewInit(): void {

--- a/projects/addon-mobile/components/mobile-calendar/mobile-calendar.providers.ts
+++ b/projects/addon-mobile/components/mobile-calendar/mobile-calendar.providers.ts
@@ -38,12 +38,9 @@ export const TUI_MOBILE_CALENDAR_PROVIDERS: Provider[] = [
         useFactory: (
             value$: Observable<TuiDayRange | null> | null,
             destroy$: Observable<void>,
-            changeDetectorRef: ChangeDetectorRef,
+            cdr: ChangeDetectorRef,
         ): Observable<TuiDayRange | null> => {
-            return (value$ || EMPTY).pipe(
-                tuiWatch(changeDetectorRef),
-                takeUntil(destroy$),
-            );
+            return (value$ || EMPTY).pipe(tuiWatch(cdr), takeUntil(destroy$));
         },
     },
 ];

--- a/projects/addon-mobile/components/sheet/components/sheet-heading/sheet-heading.component.ts
+++ b/projects/addon-mobile/components/sheet/components/sheet-heading/sheet-heading.component.ts
@@ -23,18 +23,18 @@ export class TuiSheetHeadingComponent implements AfterViewInit {
 
     constructor(
         @Inject(TuiIdService) private readonly idService: TuiIdService,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_CLOSE_WORD) readonly closeWord$: Observable<string>,
     ) {}
 
     ngAfterViewInit(): void {
-        this.elementRef.nativeElement.dispatchEvent(
+        this.el.nativeElement.dispatchEvent(
             new CustomEvent(TUI_SHEET_ID, {bubbles: true, detail: this.id}),
         );
     }
 
     onClick(): void {
-        this.elementRef.nativeElement.dispatchEvent(
+        this.el.nativeElement.dispatchEvent(
             new CustomEvent(TUI_SHEET_CLOSE, {bubbles: true}),
         );
     }

--- a/projects/addon-mobile/components/sheet/components/sheet/sheet.component.ts
+++ b/projects/addon-mobile/components/sheet/components/sheet/sheet.component.ts
@@ -60,7 +60,7 @@ export class TuiSheetComponent<T> implements TuiSheetRequiredProps<T>, AfterView
 
     constructor(
         @Inject(TUI_SHEET_SCROLL) private readonly scroll$: Observable<number>,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(NgZone) private readonly ngZone: NgZone,
         @Inject(TUI_IS_IOS) readonly isIos: boolean,
         @Inject(TUI_MORE_WORD) readonly moreWord$: Observable<string>,
@@ -92,13 +92,13 @@ export class TuiSheetComponent<T> implements TuiSheetRequiredProps<T>, AfterView
     }
 
     ngAfterViewInit(): void {
-        const stops = [...this.stops, this.sheetTop, this.contentTop];
-
-        this.elementRef.nativeElement.scrollTop = stops[this.item.initial];
+        this.el.nativeElement.scrollTop = [...this.stops, this.sheetTop, this.contentTop][
+            this.item.initial
+        ];
     }
 
     scrollTo(top: number = this.sheetTop): void {
-        const {nativeElement} = this.elementRef;
+        const {nativeElement} = this.el;
 
         if (this.isIos) {
             fakeSmoothScroll(nativeElement, top - nativeElement.scrollTop - 16);

--- a/projects/addon-mobile/components/sheet/components/sheet/sheet.providers.ts
+++ b/projects/addon-mobile/components/sheet/components/sheet/sheet.providers.ts
@@ -38,11 +38,11 @@ export const TUI_SHEET_PROVIDERS: Provider[] = [
         useFactory: (
             {nativeElement}: ElementRef<HTMLElement>,
             ngZone: NgZone,
-            documentRef: Document,
+            doc: Document,
             isIos: boolean,
         ): Observable<number> => {
             return isIos
-                ? iosScrollFactory(nativeElement, documentRef, ngZone)
+                ? iosScrollFactory(nativeElement, doc, ngZone)
                 : merge(
                       tuiTypedFromEvent(nativeElement, `scroll`),
                       tuiTypedFromEvent(nativeElement, `load`, {capture: true}),

--- a/projects/addon-mobile/components/sheet/directives/sheet-close/sheet-close.directive.ts
+++ b/projects/addon-mobile/components/sheet/directives/sheet-close/sheet-close.directive.ts
@@ -15,12 +15,11 @@ export class TuiSheetCloseDirective {
     @Output()
     // eslint-disable-next-line @angular-eslint/no-output-native
     readonly close: Observable<unknown> = merge(
-        tuiTypedFromEvent(this.elementRef.nativeElement, TUI_SHEET_CLOSE),
+        tuiTypedFromEvent(this.el.nativeElement, TUI_SHEET_CLOSE),
         this.dragged$.pipe(
             startWith(false),
             tuiIfMap(
-                () =>
-                    this.scroll$.pipe(startWith(this.elementRef.nativeElement.scrollTop)),
+                () => this.scroll$.pipe(startWith(this.el.nativeElement.scrollTop)),
                 tuiIsFalsy,
             ),
             filter(y => this.sheet.item?.closeable && this.shouldClose(y)),
@@ -33,15 +32,15 @@ export class TuiSheetCloseDirective {
         @Inject(NgZone) private readonly ngZone: NgZone,
         @Inject(TUI_SHEET_DRAGGED) private readonly dragged$: Observable<boolean>,
         @Inject(TUI_SHEET_SCROLL) private readonly scroll$: Observable<number>,
-        @Inject(WINDOW) private readonly windowRef: Window,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(WINDOW) private readonly win: Window,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TuiSheetComponent) private readonly sheet: TuiSheetComponent<unknown>,
     ) {}
 
     private shouldClose(scrollTop: number): boolean {
         const height = Math.min(
-            this.windowRef.innerHeight,
-            this.elementRef.nativeElement.scrollHeight - this.windowRef.innerHeight,
+            this.win.innerHeight,
+            this.el.nativeElement.scrollHeight - this.win.innerHeight,
         );
         const min = Math.min(height, this.sheet.stops[0] || Infinity);
 

--- a/projects/addon-mobile/components/sheet/directives/sheet-stop/sheet-stop.directive.ts
+++ b/projects/addon-mobile/components/sheet/directives/sheet-stop/sheet-stop.directive.ts
@@ -19,7 +19,7 @@ import {TUI_SHEET_DRAGGED, TUI_SHEET_SCROLL} from '../../sheet-tokens';
 })
 export class TuiSheetStopDirective {
     constructor(
-        @Inject(ElementRef) elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) el: ElementRef<HTMLElement>,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<unknown>,
         @Inject(TUI_SHEET_DRAGGED) dragged$: Observable<boolean>,
         @Inject(TUI_SHEET_SCROLL) scroll$: Observable<number>,
@@ -27,7 +27,7 @@ export class TuiSheetStopDirective {
     ) {
         scroll$
             .pipe(
-                map(y => Math.floor(y) > elementRef.nativeElement.offsetTop),
+                map(y => Math.floor(y) > el.nativeElement.offsetTop),
                 distinctUntilChanged(),
                 withLatestFrom(dragged$),
                 map(([above, dragged]) => !above && !dragged),
@@ -38,7 +38,7 @@ export class TuiSheetStopDirective {
             .subscribe(() => {
                 nativeElement.style.overflow = 'hidden';
                 nativeElement.classList.remove('_stuck'); // iOS
-                nativeElement.scrollTop = elementRef.nativeElement.offsetTop;
+                nativeElement.scrollTop = el.nativeElement.offsetTop;
 
                 setTimeout(() => {
                     nativeElement.style.overflow = '';

--- a/projects/addon-mobile/components/sheet/directives/sheet-top/sheet-top.directive.ts
+++ b/projects/addon-mobile/components/sheet/directives/sheet-top/sheet-top.directive.ts
@@ -38,12 +38,12 @@ export class TuiSheetTopDirective {
         @Inject(TUI_SHEET_SCROLL) private readonly scroll$: Observable<number>,
         @Inject(TUI_SHEET)
         private readonly component: TuiSheetRequiredProps,
-        @Inject(WINDOW) private readonly windowRef: Window,
+        @Inject(WINDOW) private readonly win: Window,
     ) {}
 
     private getY(scrollTop: number): number {
         const value = scrollTop - this.stop;
-        const total = this.windowRef.innerHeight - this.component.item.offset - this.stop;
+        const total = this.win.innerHeight - this.component.item.offset - this.stop;
 
         return this.stop && tuiClamp(100 - (value / total) * 100, 0, 100);
     }

--- a/projects/addon-mobile/components/sheet/directives/sheet-wrapper/sheet-wrapper.directive.ts
+++ b/projects/addon-mobile/components/sheet/directives/sheet-wrapper/sheet-wrapper.directive.ts
@@ -43,13 +43,13 @@ export class TuiSheetWrapperDirective {
 
     constructor(
         @Inject(NgZone) private readonly ngZone: NgZone,
-        @Inject(WINDOW) private readonly windowRef: Window,
+        @Inject(WINDOW) private readonly win: Window,
     ) {}
 
     @tuiPure
     get overlay$(): Observable<boolean> {
         return this.scroll$.pipe(
-            map(y => y + 16 > this.windowRef.innerHeight - this.tuiSheetWrapper),
+            map(y => y + 16 > this.win.innerHeight - this.tuiSheetWrapper),
             distinctUntilChanged(),
             tuiZonefull(this.ngZone),
         );
@@ -71,11 +71,7 @@ export class TuiSheetWrapperDirective {
     private getHeight(value: number): number | null {
         return this.sheet?.context.overlay
             ? null
-            : tuiClamp(
-                  this.withImage(value) + OFFSET,
-                  OFFSET,
-                  this.windowRef.innerHeight,
-              );
+            : tuiClamp(this.withImage(value) + OFFSET, OFFSET, this.win.innerHeight);
     }
 
     private withImage(value: number): number {

--- a/projects/addon-mobile/components/sheet/ios.hacks.ts
+++ b/projects/addon-mobile/components/sheet/ios.hacks.ts
@@ -6,13 +6,13 @@ import {delay, map, share, switchMap, take, takeUntil} from 'rxjs/operators';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function iosScrollFactory(
     element: HTMLElement,
-    documentRef: Document,
+    doc: Document,
     ngZone: NgZone,
 ): Observable<number> {
     const load$ = tuiTypedFromEvent(element, `load`, {capture: true});
     const touchstart$ = tuiTypedFromEvent(element, `touchstart`, {passive: true});
-    const touchmove$ = tuiTypedFromEvent(documentRef, `touchmove`, {passive: true});
-    const touchend$ = tuiTypedFromEvent(documentRef, `touchend`);
+    const touchmove$ = tuiTypedFromEvent(doc, `touchmove`, {passive: true});
+    const touchend$ = tuiTypedFromEvent(doc, `touchend`);
     const scroll$ = tuiTypedFromEvent(element, `scroll`).pipe(
         map(() => element.scrollTop),
     );

--- a/projects/addon-mobile/components/sheet/sheet.directive.ts
+++ b/projects/addon-mobile/components/sheet/sheet.directive.ts
@@ -40,10 +40,10 @@ export class TuiSheetDirective extends PolymorpheusTemplate<TuiSheet<never>> {
     );
 
     constructor(
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TemplateRef) templateRef: TemplateRef<TuiSheet<never>>,
         @Inject(TuiSheetService) private readonly service: TuiSheetService,
     ) {
-        super(templateRef, changeDetectorRef);
+        super(templateRef, cdr);
     }
 }

--- a/projects/addon-mobile/components/tab-bar/tab-bar-item.directive.ts
+++ b/projects/addon-mobile/components/tab-bar/tab-bar-item.directive.ts
@@ -16,10 +16,10 @@ export class TuiTabBarItemDirective {
         @Inject(TuiRouterLinkActiveService) active$: Observable<boolean>,
         @Inject(TuiTabBarComponent) tabs: TuiTabBarComponent,
         @Inject(ElementRef) {nativeElement}: ElementRef<HTMLElement>,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
         active$
-            .pipe(filter(Boolean), tuiWatch(changeDetectorRef), takeUntil(destroy$))
+            .pipe(filter(Boolean), tuiWatch(cdr), takeUntil(destroy$))
             .subscribe(() => {
                 tabs.setActive(nativeElement);
             });

--- a/projects/addon-mobile/directives/elastic-sticky/elastic-sticky.service.ts
+++ b/projects/addon-mobile/directives/elastic-sticky/elastic-sticky.service.ts
@@ -26,7 +26,7 @@ export class TuiElasticStickyService extends Observable<number> {
         scrollRef: ElementRef<HTMLElement> | null,
         @Inject(ElementRef) {nativeElement}: ElementRef<HTMLElement>,
         @Inject(NgZone) ngZone: NgZone,
-        @Inject(WINDOW) windowRef: Window,
+        @Inject(WINDOW) win: Window,
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
     ) {
         super(subscriber =>
@@ -38,19 +38,17 @@ export class TuiElasticStickyService extends Observable<number> {
                         const host = scrollRef?.nativeElement || closest;
                         const {offsetHeight} = nativeElement;
                         const offsetTop = this.getInitialOffset(
-                            host || windowRef,
+                            host || win,
                             nativeElement,
                         );
 
-                        return tuiTypedFromEvent(host || windowRef, `scroll`).pipe(
+                        return tuiTypedFromEvent(host || win, `scroll`).pipe(
                             map(() =>
                                 Math.max(
                                     1 -
                                         Math.max(
                                             Math.round(
-                                                host
-                                                    ? host.scrollTop
-                                                    : windowRef.pageYOffset,
+                                                host ? host.scrollTop : win.pageYOffset,
                                             ) - offsetTop,
                                             0,
                                         ) /

--- a/projects/addon-mobile/directives/sidebar/sidebar.directive.ts
+++ b/projects/addon-mobile/directives/sidebar/sidebar.directive.ts
@@ -50,9 +50,9 @@ export class TuiSidebarDirective<T = Record<string, unknown>>
         @Inject(Injector) private readonly injector: Injector,
         @Inject(TuiDropdownPortalService)
         private readonly portalService: TuiDropdownPortalService,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
-        super(content, changeDetectorRef);
+        super(content, cdr);
     }
 
     ngOnDestroy(): void {

--- a/projects/addon-mobile/directives/touchable/touchable.directive.ts
+++ b/projects/addon-mobile/directives/touchable/touchable.directive.ts
@@ -35,7 +35,7 @@ export class TuiTouchableDirective {
     tuiTouchable: TuiTouchMode | '' = '';
 
     constructor(
-        @Optional() @Inject(TUI_ELEMENT_REF) elementRef: ElementRef<HTMLElement> | null,
+        @Optional() @Inject(TUI_ELEMENT_REF) el: ElementRef<HTMLElement> | null,
         @Inject(TUI_IS_IOS) isIos: boolean,
         @Inject(ElementRef) {nativeElement}: ElementRef<HTMLElement>,
         @Inject(Renderer2) renderer: Renderer2,
@@ -45,7 +45,7 @@ export class TuiTouchableDirective {
             return;
         }
 
-        const element = elementRef ? elementRef.nativeElement : nativeElement;
+        const element = el?.nativeElement || nativeElement;
 
         tuiTypedFromEvent(element, 'touchstart', {passive: true})
             .pipe(

--- a/projects/addon-preview/components/preview/preview.component.ts
+++ b/projects/addon-preview/components/preview/preview.component.ts
@@ -4,14 +4,12 @@ import {
     ElementRef,
     Inject,
     Input,
-    Self,
 } from '@angular/core';
 import {TUI_PREVIEW_TEXTS} from '@taiga-ui/addon-preview/tokens';
 import {
     ALWAYS_FALSE_HANDLER,
     tuiClamp,
     tuiDefaultProp,
-    TuiDestroyService,
     tuiDragAndDropFrom,
     TuiDragStage,
     tuiPx,
@@ -34,7 +32,6 @@ const ROTATION_ANGLE = 90;
     styleUrls: ['./preview.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     animations: [tuiSlideInTop],
-    providers: [TuiDestroyService],
 })
 export class TuiPreviewComponent {
     @Input()
@@ -57,18 +54,18 @@ export class TuiPreviewComponent {
     );
 
     readonly transitioned$ = merge(
-        tuiDragAndDropFrom(this.elementRef.nativeElement).pipe(
+        tuiDragAndDropFrom(this.el.nativeElement).pipe(
             map(({stage}) => stage !== TuiDragStage.Continues),
         ),
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'touchmove', {
+        tuiTypedFromEvent(this.el.nativeElement, 'touchmove', {
             passive: true,
         }).pipe(map(ALWAYS_FALSE_HANDLER)),
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'wheel', {passive: true}).pipe(
+        tuiTypedFromEvent(this.el.nativeElement, 'wheel', {passive: true}).pipe(
             map(ALWAYS_FALSE_HANDLER),
         ),
     );
 
-    readonly cursor$ = tuiDragAndDropFrom(this.elementRef.nativeElement).pipe(
+    readonly cursor$ = tuiDragAndDropFrom(this.el.nativeElement).pipe(
         map(({stage}) => (stage === TuiDragStage.Continues ? 'grabbing' : 'initial')),
         startWith('initial'),
     );
@@ -85,8 +82,7 @@ export class TuiPreviewComponent {
     );
 
     constructor(
-        @Inject(ElementRef) readonly elementRef: ElementRef<HTMLElement>,
-        @Self() @Inject(TuiDestroyService) readonly destroy$: Observable<void>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_PREVIEW_TEXTS)
         readonly texts$: Observable<TuiLanguagePreview['previewTexts']>,
     ) {}
@@ -147,7 +143,7 @@ export class TuiPreviewComponent {
         const bigSize =
             contentHeight > boxHeight * INITIAL_SCALE_COEF ||
             contentWidth > boxWidth * INITIAL_SCALE_COEF;
-        const {clientHeight, clientWidth} = this.elementRef.nativeElement;
+        const {clientHeight, clientWidth} = this.el.nativeElement;
 
         return bigSize
             ? tuiRound(
@@ -166,8 +162,8 @@ export class TuiPreviewComponent {
         this.minZoom = this.calculateMinZoom(
             height,
             width,
-            this.elementRef.nativeElement.clientHeight,
-            this.elementRef.nativeElement.clientWidth,
+            this.el.nativeElement.clientHeight,
+            this.el.nativeElement.clientWidth,
         );
         this.zoom$.next(this.minZoom);
         this.coordinates$.next(EMPTY_COORDINATES);
@@ -208,8 +204,8 @@ export class TuiPreviewComponent {
         scale: number,
     ): [number, number] {
         return [
-            (clientX - x - this.elementRef.nativeElement.offsetWidth / 2) / scale,
-            (clientY - y - this.elementRef.nativeElement.offsetHeight / 2) / scale,
+            (clientX - x - this.el.nativeElement.offsetWidth / 2) / scale,
+            (clientY - y - this.el.nativeElement.offsetHeight / 2) / scale,
         ];
     }
 }

--- a/projects/addon-table/components/table/directives/resized.directive.ts
+++ b/projects/addon-table/components/table/directives/resized.directive.ts
@@ -9,26 +9,23 @@ import {distinctUntilChanged, map, switchMap, takeUntil} from 'rxjs/operators';
 })
 export class TuiResizedDirective {
     @Output()
-    readonly tuiResized = tuiTypedFromEvent(
-        this.elementRef.nativeElement,
-        'mousedown',
-    ).pipe(
+    readonly tuiResized = tuiTypedFromEvent(this.el.nativeElement, 'mousedown').pipe(
         tuiPreventDefault(),
         switchMap(() => {
             const {width, right} = this.parentRef.nativeElement.getBoundingClientRect();
 
-            return tuiTypedFromEvent(this.documentRef, 'mousemove').pipe(
+            return tuiTypedFromEvent(this.doc, 'mousemove').pipe(
                 distinctUntilChanged(),
                 map(({clientX}) => width + clientX - right),
-                takeUntil(tuiTypedFromEvent(this.documentRef, 'mouseup')),
+                takeUntil(tuiTypedFromEvent(this.doc, 'mouseup')),
             );
         }),
     );
 
     constructor(
-        @Inject(DOCUMENT) private readonly documentRef: Document,
+        @Inject(DOCUMENT) private readonly doc: Document,
         @Inject(ElementRef)
-        private readonly elementRef: ElementRef<HTMLElement>,
+        private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_ELEMENT_REF)
         private readonly parentRef: ElementRef<HTMLTableHeaderCellElement>,
     ) {}

--- a/projects/addon-table/components/table/directives/table.directive.ts
+++ b/projects/addon-table/components/table/directives/table.directive.ts
@@ -56,7 +56,7 @@ export class TuiTableDirective<T extends Partial<Record<keyof T, any>>>
         readonly entries$: Observable<IntersectionObserverEntry[]>,
         @Inject(TUI_MODE) readonly mode$: Observable<TuiBrightness | null>,
         @Inject(TUI_STUCK) readonly stuck$: Observable<boolean>,
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
     ) {
         super();
     }
@@ -75,7 +75,7 @@ export class TuiTableDirective<T extends Partial<Record<keyof T, any>>>
     }
 
     ngAfterViewInit(): void {
-        this.changeDetectorRef.detectChanges();
+        this.cdr.detectChanges();
     }
 
     updateSorter(sorter: TuiComparator<T> | null): void {

--- a/projects/addon-tablebars/components/table-bars-host/table-bars-host.component.ts
+++ b/projects/addon-tablebars/components/table-bars-host/table-bars-host.component.ts
@@ -35,11 +35,11 @@ export class TuiTableBarsHostComponent {
         @Inject(TUI_CLOSE_WORD) readonly closeWord$: Observable<string>,
         @Inject(TUI_ANIMATION_OPTIONS) private readonly options: AnimationOptions,
         @Inject(TUI_MEDIA) private readonly media: TuiMedia,
-        @Inject(WINDOW) private readonly windowRef: Window,
+        @Inject(WINDOW) private readonly win: Window,
     ) {}
 
     get isMobile(): boolean {
-        return tuiIsMobile(this.windowRef, this.media);
+        return tuiIsMobile(this.win, this.media);
     }
 
     get closeIcon(): string {

--- a/projects/cdk/abstract/control.ts
+++ b/projects/cdk/abstract/control.ts
@@ -51,7 +51,7 @@ export abstract class AbstractTuiControl<T>
     constructor(
         @Optional()
         private readonly ngControl: NgControl | null,
-        protected readonly changeDetectorRef: ChangeDetectorRef,
+        protected readonly cdr: ChangeDetectorRef,
         @Optional()
         @Inject(AbstractTuiValueTransformer)
         protected readonly valueTransformer?: TuiControlValueTransformer<T> | null,
@@ -159,7 +159,7 @@ export abstract class AbstractTuiControl<T>
     }
 
     checkControlUpdate(): void {
-        this.changeDetectorRef.markForCheck();
+        this.cdr.markForCheck();
     }
 
     registerOnChange(onChange: (value: T | unknown) => void): void {

--- a/projects/cdk/abstract/dialog.directive.ts
+++ b/projects/cdk/abstract/dialog.directive.ts
@@ -29,10 +29,10 @@ export abstract class AbstractTuiDialogDirective<T> extends PolymorpheusTemplate
     constructor(
         @Inject(TemplateRef)
         templateRef: TemplateRef<TuiDialog<T, void>>,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(AbstractTuiDialogService)
         private readonly service: AbstractTuiDialogService<T>,
     ) {
-        super(templateRef, changeDetectorRef);
+        super(templateRef, cdr);
     }
 }

--- a/projects/cdk/abstract/portal-host.ts
+++ b/projects/cdk/abstract/portal-host.ts
@@ -23,19 +23,18 @@ import {AbstractTuiPortalService} from './portal-service';
 @Directive()
 export abstract class AbstractTuiPortalHostComponent {
     @ViewChild(`viewContainer`, {read: ViewContainerRef})
-    viewContainerRef!: ViewContainerRef;
+    private readonly vcr!: ViewContainerRef;
 
     constructor(
         @Inject(INJECTOR) private readonly injector: Injector,
-        @Inject(ElementRef)
-        readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(AbstractTuiPortalService) portalService: AbstractTuiPortalService,
     ) {
         portalService.attach(this);
     }
 
     get clientRect(): ClientRect {
-        return this.elementRef.nativeElement.getBoundingClientRect();
+        return this.el.nativeElement.getBoundingClientRect();
     }
 
     addComponentChild<C>(component: PolymorpheusComponent<C, any>): ComponentRef<C> {
@@ -44,7 +43,7 @@ export abstract class AbstractTuiPortalHostComponent {
         const factory = resolver.resolveComponentFactory(component.component);
         const providers = [{provide: AbstractTuiPortalHostComponent, useValue: this}];
         const injector = Injector.create({parent, providers});
-        const ref = this.viewContainerRef.createComponent(factory, undefined, injector);
+        const ref = this.vcr.createComponent(factory, undefined, injector);
 
         ref.changeDetectorRef.detectChanges();
 
@@ -52,6 +51,6 @@ export abstract class AbstractTuiPortalHostComponent {
     }
 
     addTemplateChild<C>(templateRef: TemplateRef<C>, context?: C): EmbeddedViewRef<C> {
-        return this.viewContainerRef.createEmbeddedView(templateRef, context);
+        return this.vcr.createEmbeddedView(templateRef, context);
     }
 }

--- a/projects/cdk/abstract/theme-switcher.ts
+++ b/projects/cdk/abstract/theme-switcher.ts
@@ -11,14 +11,14 @@ import {Directive, Inject, OnDestroy} from '@angular/core';
 export abstract class AbstractTuiThemeSwitcher implements OnDestroy {
     static style: HTMLStyleElement | null = null;
 
-    constructor(@Inject(DOCUMENT) private readonly documentRef: Document) {
+    constructor(@Inject(DOCUMENT) private readonly doc: Document) {
         if (this.style !== null) {
             this.addTheme();
 
             return;
         }
 
-        const styles = this.documentRef.head.querySelectorAll(`style`);
+        const styles = this.doc.head.querySelectorAll(`style`);
 
         (this.constructor as typeof AbstractTuiThemeSwitcher).style =
             styles[styles.length - 1];
@@ -34,13 +34,13 @@ export abstract class AbstractTuiThemeSwitcher implements OnDestroy {
 
     private addTheme(): void {
         if (this.style) {
-            this.documentRef.head.appendChild(this.style);
+            this.doc.head.appendChild(this.style);
         }
     }
 
     private removeTheme(): void {
-        if (this.style && this.documentRef.head.contains(this.style)) {
-            this.documentRef.head.removeChild(this.style);
+        if (this.style && this.doc.head.contains(this.style)) {
+            this.doc.head.removeChild(this.style);
         }
     }
 }

--- a/projects/cdk/components/alert-host/alert-host.style.less
+++ b/projects/cdk/components/alert-host/alert-host.style.less
@@ -1,4 +1,4 @@
-tui-alert-host > .t-notifications-wrapper {
+tui-alert-host > .t-wrapper {
     position: fixed;
     top: 0;
     left: 0;

--- a/projects/cdk/components/alert-host/alert-host.template.html
+++ b/projects/cdk/components/alert-host/alert-host.template.html
@@ -1,6 +1,6 @@
 <div
     *ngFor="let alert$ of alerts"
-    class="t-notifications-wrapper"
+    class="t-wrapper"
     @tuiParentAnimation
 >
     <ng-container

--- a/projects/cdk/directives/active-zone/active-zone.directive.ts
+++ b/projects/cdk/directives/active-zone/active-zone.directive.ts
@@ -45,7 +45,7 @@ export class TuiActiveZoneDirective implements OnDestroy {
         @Inject(TUI_ACTIVE_ELEMENT)
         private readonly active$: Observable<Element | null>,
         @Inject(NgZone) private readonly ngZone: NgZone,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<Element>,
+        @Inject(ElementRef) private readonly el: ElementRef<Element>,
         @Optional()
         @SkipSelf()
         @Inject(TuiActiveZoneDirective)
@@ -68,7 +68,7 @@ export class TuiActiveZoneDirective implements OnDestroy {
 
     contains(node: Node): boolean {
         return (
-            this.elementRef.nativeElement.contains(node) ||
+            this.el.nativeElement.contains(node) ||
             this.subActiveZones.some(
                 (item, index, array) =>
                     array.indexOf(item) === index && item.contains(node),

--- a/projects/cdk/directives/auto-focus/autofocus.options.ts
+++ b/projects/cdk/directives/auto-focus/autofocus.options.ts
@@ -29,27 +29,17 @@ export const TUI_AUTOFOCUS_PROVIDERS = [
     {
         provide: TUI_AUTOFOCUS_HANDLER,
         useFactory: (
-            tuiFocusableComponent: TuiFocusableElementAccessor | null,
-            elementRef: ElementRef<HTMLElement>,
+            focusable: TuiFocusableElementAccessor | null,
+            el: ElementRef<HTMLElement>,
             animationFrame$: Observable<number>,
             renderer: Renderer2,
             ngZone: NgZone,
-            windowRef: Window,
+            win: Window,
             isIos: boolean,
         ) =>
             isIos
-                ? new TuiIosAutofocusHandler(
-                      tuiFocusableComponent,
-                      elementRef,
-                      renderer,
-                      ngZone,
-                      windowRef,
-                  )
-                : new TuiDefaultAutofocusHandler(
-                      tuiFocusableComponent,
-                      elementRef,
-                      animationFrame$,
-                  ),
+                ? new TuiIosAutofocusHandler(focusable, el, renderer, ngZone, win)
+                : new TuiDefaultAutofocusHandler(focusable, el, animationFrame$),
         deps: [
             [new Optional(), new Self(), TUI_FOCUSABLE_ITEM_ACCESSOR],
             ElementRef,

--- a/projects/cdk/directives/auto-focus/handlers/abstract.handler.ts
+++ b/projects/cdk/directives/auto-focus/handlers/abstract.handler.ts
@@ -9,15 +9,12 @@ import type {TuiAutofocusHandler} from '../autofocus.options';
 @Directive()
 export abstract class AbstractTuiAutofocusHandler implements TuiAutofocusHandler {
     constructor(
-        protected readonly tuiFocusableComponent: TuiFocusableElementAccessor | null,
-        protected readonly elementRef: ElementRef<HTMLElement>,
+        protected readonly focusable: TuiFocusableElementAccessor | null,
+        protected readonly el: ElementRef<HTMLElement>,
     ) {}
 
     protected get element(): TuiNativeFocusableElement {
-        return (
-            this.tuiFocusableComponent?.nativeFocusableElement ||
-            this.elementRef.nativeElement
-        );
+        return this.focusable?.nativeFocusableElement || this.el.nativeElement;
     }
 
     protected get isTextFieldElement(): boolean {

--- a/projects/cdk/directives/auto-focus/handlers/default.handler.ts
+++ b/projects/cdk/directives/auto-focus/handlers/default.handler.ts
@@ -19,11 +19,11 @@ export class TuiDefaultAutofocusHandler extends AbstractTuiAutofocusHandler {
         @Optional()
         @Self()
         @Inject(TUI_FOCUSABLE_ITEM_ACCESSOR)
-        tuiFocusableComponent: TuiFocusableElementAccessor | null,
-        @Inject(ElementRef) elementRef: ElementRef<HTMLElement>,
+        focusable: TuiFocusableElementAccessor | null,
+        @Inject(ElementRef) el: ElementRef<HTMLElement>,
         @Inject(ANIMATION_FRAME) private readonly animationFrame$: Observable<number>,
     ) {
-        super(tuiFocusableComponent, elementRef);
+        super(focusable, el);
     }
 
     setFocus(): void {

--- a/projects/cdk/directives/auto-focus/handlers/ios.handler.ts
+++ b/projects/cdk/directives/auto-focus/handlers/ios.handler.ts
@@ -22,13 +22,13 @@ export class TuiIosAutofocusHandler extends AbstractTuiAutofocusHandler {
         @Optional()
         @Self()
         @Inject(TUI_FOCUSABLE_ITEM_ACCESSOR)
-        tuiFocusableComponent: TuiFocusableElementAccessor | null,
-        @Inject(ElementRef) elementRef: ElementRef<HTMLElement>,
+        focusable: TuiFocusableElementAccessor | null,
+        @Inject(ElementRef) el: ElementRef<HTMLElement>,
         @Inject(Renderer2) private readonly renderer: Renderer2,
         @Inject(NgZone) private readonly ngZone: NgZone,
-        @Inject(WINDOW) private readonly windowRef: Window,
+        @Inject(WINDOW) private readonly win: Window,
     ) {
-        super(tuiFocusableComponent, elementRef);
+        super(focusable, el);
         this.patchCssStyles();
     }
 
@@ -50,13 +50,13 @@ export class TuiIosAutofocusHandler extends AbstractTuiAutofocusHandler {
         const focusHandler = (): void => {
             clearTimeout(fakeFocusTimeoutId);
 
-            fakeFocusTimeoutId = this.windowRef.setTimeout(() => {
+            fakeFocusTimeoutId = this.win.setTimeout(() => {
                 clearTimeout(elementFocusTimeoutId);
 
                 fakeInput.removeEventListener(`blur`, blurHandler);
                 fakeInput.removeEventListener(`focus`, focusHandler);
 
-                elementFocusTimeoutId = this.windowRef.setTimeout(() => {
+                elementFocusTimeoutId = this.win.setTimeout(() => {
                     this.element.focus({preventScroll: false});
                     fakeInput.remove();
                 }, duration);
@@ -67,7 +67,7 @@ export class TuiIosAutofocusHandler extends AbstractTuiAutofocusHandler {
         fakeInput.addEventListener(`focus`, focusHandler);
 
         if (this.insideDialog()) {
-            this.windowRef.document.body.appendChild(fakeInput);
+            this.win.document.body.appendChild(fakeInput);
         } else {
             this.element.parentElement?.appendChild(fakeInput);
         }
@@ -108,7 +108,7 @@ export class TuiIosAutofocusHandler extends AbstractTuiAutofocusHandler {
     private getDurationTimeBeforeFocus(): number {
         return (
             parseFloat(
-                this.windowRef
+                this.win
                     .getComputedStyle(this.element)
                     .getPropertyValue(`--tui-duration`),
             ) || 0
@@ -135,9 +135,9 @@ export class TuiIosAutofocusHandler extends AbstractTuiAutofocusHandler {
      * so that when focusing the dialogs don't shake
      */
     private patchCssStyles(): void {
-        const documentRef = this.windowRef.document;
+        const doc = this.win.document;
 
-        for (const element of [documentRef.documentElement, documentRef.body]) {
+        for (const element of [doc.documentElement, doc.body]) {
             element.style.setProperty(`overflow`, `auto`);
             element.style.setProperty(`height`, `100%`);
         }

--- a/projects/cdk/directives/auto-focus/handlers/sync.handler.ts
+++ b/projects/cdk/directives/auto-focus/handlers/sync.handler.ts
@@ -12,10 +12,10 @@ export class TuiSynchronousAutofocusHandler extends AbstractTuiAutofocusHandler 
         @Optional()
         @Self()
         @Inject(TUI_FOCUSABLE_ITEM_ACCESSOR)
-        tuiFocusableComponent: TuiFocusableElementAccessor | null,
-        @Inject(ElementRef) elementRef: ElementRef<HTMLElement>,
+        focusable: TuiFocusableElementAccessor | null,
+        @Inject(ElementRef) el: ElementRef<HTMLElement>,
     ) {
-        super(tuiFocusableComponent, elementRef);
+        super(focusable, el);
     }
 
     setFocus(): void {

--- a/projects/cdk/directives/checked/checked.directive.ts
+++ b/projects/cdk/directives/checked/checked.directive.ts
@@ -23,8 +23,7 @@ export class TuiCheckedDirective {
     readonly tuiCheckedChange = new EventEmitter<boolean>();
 
     constructor(
-        @Inject(ElementRef)
-        private readonly element: ElementRef<HTMLInputElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLInputElement>,
         @Inject(Renderer2) private readonly renderer: Renderer2,
     ) {
         this.updateProperty('checked', false);
@@ -37,6 +36,6 @@ export class TuiCheckedDirective {
     }
 
     private updateProperty(property: 'checked' | 'indeterminate', value: boolean): void {
-        this.renderer.setProperty(this.element.nativeElement, property, value);
+        this.renderer.setProperty(this.el.nativeElement, property, value);
     }
 }

--- a/projects/cdk/directives/copy-processor/copy-processor.directive.ts
+++ b/projects/cdk/directives/copy-processor/copy-processor.directive.ts
@@ -13,11 +13,11 @@ export class TuiCopyProcessorDirective {
     @tuiDefaultProp()
     tuiCopyProcessor: TuiStringHandler<string> = identity;
 
-    constructor(@Inject(WINDOW) private readonly windowRef: Window) {}
+    constructor(@Inject(WINDOW) private readonly win: Window) {}
 
     @HostListener('copy.prevent', ['$event'])
     onCopy(event: ClipboardEvent): void {
-        const text = tuiGetSelectedText(this.windowRef);
+        const text = tuiGetSelectedText(this.win);
 
         if (text) {
             event.clipboardData?.setData('text/plain', this.tuiCopyProcessor(text));

--- a/projects/cdk/directives/drag/drag.directive.ts
+++ b/projects/cdk/directives/drag/drag.directive.ts
@@ -10,7 +10,7 @@ import {filter, map} from 'rxjs/operators';
     selector: '[tuiDragStart], [tuiDragContinues], [tuiDragEnd]',
 })
 export class TuiDragDirective {
-    private readonly dragAndDropFrom$ = tuiDragAndDropFrom(this.elementRef.nativeElement);
+    private readonly dragAndDropFrom$ = tuiDragAndDropFrom(this.el.nativeElement);
 
     @Output('tuiDragStart')
     // eslint-disable-next-line @angular-eslint/no-output-native
@@ -32,5 +32,5 @@ export class TuiDragDirective {
         map(({event}) => event),
     );
 
-    constructor(@Inject(ElementRef) private readonly elementRef: ElementRef<Element>) {}
+    constructor(@Inject(ElementRef) private readonly el: ElementRef<Element>) {}
 }

--- a/projects/cdk/directives/focus-trap/focus-trap.directive.ts
+++ b/projects/cdk/directives/focus-trap/focus-trap.directive.ts
@@ -21,12 +21,12 @@ import {
     },
 })
 export class TuiFocusTrapDirective implements OnDestroy {
-    private readonly activeElement = tuiGetNativeFocused(this.documentRef);
+    private readonly activeElement = tuiGetNativeFocused(this.doc);
 
     constructor(
-        @Inject(DOCUMENT) private readonly documentRef: Document,
+        @Inject(DOCUMENT) private readonly doc: Document,
         @Inject(ElementRef)
-        private readonly elementRef: ElementRef<HTMLElement>,
+        private readonly el: ElementRef<HTMLElement>,
         @Inject(Renderer2) private readonly renderer: Renderer2,
     ) {
         /**
@@ -36,18 +36,18 @@ export class TuiFocusTrapDirective implements OnDestroy {
          */
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         Promise.resolve().then(() => {
-            this.elementRef.nativeElement.focus();
+            this.el.nativeElement.focus();
         });
     }
 
     @HostListener('blur')
     onBlur(): void {
-        this.renderer.removeAttribute(this.elementRef.nativeElement, 'tabIndex');
+        this.renderer.removeAttribute(this.el.nativeElement, 'tabIndex');
     }
 
     @HostListener('window:focusin.silent', ['$event.target'])
     onFocusIn(node: Node): void {
-        const {nativeElement} = this.elementRef;
+        const {nativeElement} = this.el;
 
         if (tuiContainsOrAfter(nativeElement, node)) {
             return;
@@ -64,7 +64,7 @@ export class TuiFocusTrapDirective implements OnDestroy {
     }
 
     ngOnDestroy(): void {
-        tuiBlurNativeFocused(this.documentRef);
+        tuiBlurNativeFocused(this.doc);
 
         /**
          * HostListeners are triggered even after ngOnDestroy

--- a/projects/cdk/directives/for-async/test/for.directive.spec.ts
+++ b/projects/cdk/directives/for-async/test/for.directive.spec.ts
@@ -12,7 +12,7 @@ describe(`TuiForAsync directive`, () => {
     abstract class AbstractTuiTestComponent {
         readonly items$ = new Subject<string[] | null | undefined>();
 
-        constructor(readonly elementRef: ElementRef<HTMLElement>) {}
+        constructor(readonly el: ElementRef<HTMLElement>) {}
     }
 
     describe(`Basic`, () => {
@@ -177,6 +177,6 @@ describe(`TuiForAsync directive`, () => {
     });
 
     function text(): string {
-        return testComponent.elementRef.nativeElement.textContent?.trim() || ``;
+        return testComponent.el.nativeElement.textContent?.trim() || ``;
     }
 });

--- a/projects/cdk/directives/for/test/for.directive.spec.ts
+++ b/projects/cdk/directives/for/test/for.directive.spec.ts
@@ -17,7 +17,7 @@ describe(`TuiFor directive`, () => {
     class TestComponent {
         readonly items$ = new Subject<string[]>();
 
-        constructor(@Inject(ElementRef) readonly elementRef: ElementRef<HTMLElement>) {}
+        constructor(@Inject(ElementRef) readonly el: ElementRef<HTMLElement>) {}
     }
 
     let fixture: ComponentFixture<TestComponent>;
@@ -55,6 +55,6 @@ describe(`TuiFor directive`, () => {
     });
 
     function text(): string {
-        return testComponent.elementRef.nativeElement.textContent?.trim() || ``;
+        return testComponent.el.nativeElement.textContent?.trim() || ``;
     }
 });

--- a/projects/cdk/directives/hovered/hovered.service.ts
+++ b/projects/cdk/directives/hovered/hovered.service.ts
@@ -16,21 +16,21 @@ function movedOut({currentTarget, relatedTarget}: MouseEvent): boolean {
 @Injectable()
 export class TuiHoveredService extends Observable<boolean> {
     private readonly stream$ = merge(
-        tuiTypedFromEvent(this.elementRef.nativeElement, `mouseenter`).pipe(
+        tuiTypedFromEvent(this.el.nativeElement, `mouseenter`).pipe(
             map(ALWAYS_TRUE_HANDLER),
         ),
-        tuiTypedFromEvent(this.elementRef.nativeElement, `mouseleave`).pipe(
+        tuiTypedFromEvent(this.el.nativeElement, `mouseleave`).pipe(
             map(ALWAYS_FALSE_HANDLER),
         ),
         // Hello, Safari
-        tuiTypedFromEvent(this.elementRef.nativeElement, `mouseout`).pipe(
+        tuiTypedFromEvent(this.el.nativeElement, `mouseout`).pipe(
             filter(movedOut),
             map(ALWAYS_FALSE_HANDLER),
         ),
     ).pipe(distinctUntilChanged(), tuiZoneOptimized(this.ngZone));
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<Element>,
+        @Inject(ElementRef) private readonly el: ElementRef<Element>,
         @Inject(NgZone) private readonly ngZone: NgZone,
     ) {
         super(subscriber => this.stream$.subscribe(subscriber));

--- a/projects/cdk/directives/let/test/let.directive.spec.ts
+++ b/projects/cdk/directives/let/test/let.directive.spec.ts
@@ -17,7 +17,7 @@ describe(`Let`, () => {
     })
     class TestComponent {
         @ViewChild(`test`)
-        elementRef!: ElementRef;
+        el!: ElementRef;
 
         counter = 0;
 
@@ -45,7 +45,7 @@ describe(`Let`, () => {
     });
 
     it(`Result is shown 3 times`, () => {
-        expect(testComponent.elementRef.nativeElement.textContent!.trim()).toBe(`!!!`);
+        expect(testComponent.el.nativeElement.textContent!.trim()).toBe(`!!!`);
     });
 
     it(`Getter is called once`, () => {

--- a/projects/cdk/directives/media/media.directive.ts
+++ b/projects/cdk/directives/media/media.directive.ts
@@ -41,34 +41,34 @@ export class TuiMediaDirective {
 
     constructor(
         @Inject(ElementRef)
-        private readonly elementRef: ElementRef<HTMLMediaElement>,
+        private readonly el: ElementRef<HTMLMediaElement>,
     ) {}
 
     @Input()
     @tuiRequiredSetter(nonNegativeFiniteAssertion)
     set currentTime(currentTime: number) {
         if (Math.abs(currentTime - this.currentTime) > 0.05) {
-            this.elementRef.nativeElement.currentTime = currentTime;
+            this.el.nativeElement.currentTime = currentTime;
         }
     }
 
     get currentTime(): number {
-        return this.elementRef.nativeElement.currentTime;
+        return this.el.nativeElement.currentTime;
     }
 
     @Input()
     set paused(paused: boolean) {
         if (paused) {
-            this.elementRef.nativeElement.pause();
+            this.el.nativeElement.pause();
         } else {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            this.elementRef.nativeElement.play();
+            this.el.nativeElement.play();
             this.updatePlaybackRate(this.playbackRate);
         }
     }
 
     get paused(): boolean {
-        return this.elementRef.nativeElement.paused;
+        return this.el.nativeElement.paused;
     }
 
     // @bad TODO: Make sure no other events can affect this like network issues etc.
@@ -82,7 +82,7 @@ export class TuiMediaDirective {
 
     @HostListener('volumechange')
     onVolumeChange(): void {
-        this.volume = this.elementRef.nativeElement.volume;
+        this.volume = this.el.nativeElement.volume;
         this.volumeChange.emit(this.volume);
     }
 
@@ -100,7 +100,7 @@ export class TuiMediaDirective {
 
     private updatePlaybackRate(playbackRate: number): void {
         this.playbackRate = playbackRate;
-        this.elementRef.nativeElement.playbackRate = this.playbackRate;
+        this.el.nativeElement.playbackRate = this.playbackRate;
     }
 }
 

--- a/projects/cdk/directives/pressed/pressed.directive.ts
+++ b/projects/cdk/directives/pressed/pressed.directive.ts
@@ -7,12 +7,12 @@ import {TUI_TAKE_ONLY_TRUSTED_EVENTS} from '@taiga-ui/cdk/tokens';
 })
 export class TuiPressedDirective {
     @Output()
-    readonly tuiPressedChange = tuiPressedObservable(this.elementRef.nativeElement, {
+    readonly tuiPressedChange = tuiPressedObservable(this.el.nativeElement, {
         onlyTrusted: this.takeOnlyTrustedEvents,
     });
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<Element>,
+        @Inject(ElementRef) private readonly el: ElementRef<Element>,
         @Inject(TUI_TAKE_ONLY_TRUSTED_EVENTS)
         private readonly takeOnlyTrustedEvents: boolean,
     ) {}

--- a/projects/cdk/directives/prevent-default/prevent-default.directive.ts
+++ b/projects/cdk/directives/prevent-default/prevent-default.directive.ts
@@ -18,13 +18,13 @@ export class TuiPreventDefaultDirective implements OnInit {
     eventName = '';
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(NgZone) private readonly ngZone: NgZone,
         @Self() @Inject(TuiDestroyService) private readonly destroy$: Observable<void>,
     ) {}
 
     ngOnInit(): void {
-        fromEvent(this.elementRef.nativeElement, this.eventName, {passive: false})
+        fromEvent(this.el.nativeElement, this.eventName, {passive: false})
             .pipe(tuiZonefree(this.ngZone), tuiPreventDefault(), takeUntil(this.destroy$))
             .subscribe();
     }

--- a/projects/cdk/interfaces/focusable-element-accessor.ts
+++ b/projects/cdk/interfaces/focusable-element-accessor.ts
@@ -4,6 +4,7 @@ export interface TuiNativeFocusableElement extends Element, HTMLOrSVGElement {}
 
 /**
  * Public interface for any focusable component or directive
+ * TODO: shorten `nativeFocusableElement` in 4.0
  */
 export interface TuiFocusableElementAccessor {
     nativeFocusableElement: TuiNativeFocusableElement | null;

--- a/projects/cdk/observables/watch.ts
+++ b/projects/cdk/observables/watch.ts
@@ -2,10 +2,8 @@ import {ChangeDetectorRef} from '@angular/core';
 import {MonoTypeOperatorFunction} from 'rxjs';
 import {tap} from 'rxjs/operators';
 
-export function tuiWatch<T>(
-    changeDetectorRef: ChangeDetectorRef,
-): MonoTypeOperatorFunction<T> {
+export function tuiWatch<T>(cdr: ChangeDetectorRef): MonoTypeOperatorFunction<T> {
     return tap(() => {
-        changeDetectorRef.markForCheck();
+        cdr.markForCheck();
     });
 }

--- a/projects/cdk/services/focus-visible.service.ts
+++ b/projects/cdk/services/focus-visible.service.ts
@@ -16,13 +16,13 @@ export class TuiFocusVisibleService extends Observable<boolean> {
 
     constructor(
         @Inject(ElementRef) {nativeElement}: ElementRef<Element>,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
     ) {
         super(subscriber => this.focusVisible$.subscribe(subscriber));
 
         this.focusVisible$ = tuiFocusVisibleObservable(nativeElement).pipe(
-            tuiWatch(changeDetectorRef),
+            tuiWatch(cdr),
             takeUntil(destroy$),
         );
     }

--- a/projects/cdk/services/obscured.service.ts
+++ b/projects/cdk/services/obscured.service.ts
@@ -32,7 +32,7 @@ export class TuiObscuredService extends Observable<readonly Element[] | null> {
         parentsScroll$: TuiParentsScrollService,
         @Inject(ElementRef) {nativeElement}: ElementRef<Element>,
         @Inject(NgZone) ngZone: NgZone,
-        @Inject(WINDOW) windowRef: Window,
+        @Inject(WINDOW) win: Window,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
         @Inject(ANIMATION_FRAME) animationFrame$: Observable<number>,
     ) {
@@ -40,7 +40,7 @@ export class TuiObscuredService extends Observable<readonly Element[] | null> {
 
         this.obscured$ = merge(
             // delay is added so it will not interfere with other listeners
-            merge(parentsScroll$, fromEvent(windowRef, `resize`)).pipe(delay(0)),
+            merge(parentsScroll$, fromEvent(win, `resize`)).pipe(delay(0)),
             animationFrame$.pipe(throttleTime(POLLING_TIME)),
         ).pipe(
             map(() => tuiGetElementObscures(nativeElement)),

--- a/projects/cdk/services/pan.service.ts
+++ b/projects/cdk/services/pan.service.ts
@@ -8,7 +8,7 @@ import {filter, map, pairwise, repeat, switchMap, takeUntil} from 'rxjs/operator
 export class TuiPanService extends Observable<readonly [number, number]> {
     constructor(
         @Inject(ElementRef) {nativeElement}: ElementRef<Element>,
-        @Inject(DOCUMENT) documentRef: Document,
+        @Inject(DOCUMENT) doc: Document,
     ) {
         super(subscriber => {
             merge(
@@ -18,13 +18,13 @@ export class TuiPanService extends Observable<readonly [number, number]> {
                 .pipe(
                     switchMap(() =>
                         merge(
-                            tuiTypedFromEvent(documentRef, `touchmove`, {
+                            tuiTypedFromEvent(doc, `touchmove`, {
                                 passive: true,
                             }).pipe(
                                 filter(({touches}) => touches.length < 2),
                                 map(({touches}) => touches[0]),
                             ),
-                            tuiTypedFromEvent(documentRef, `mousemove`),
+                            tuiTypedFromEvent(doc, `mousemove`),
                         ),
                     ),
                     pairwise(),
@@ -37,8 +37,8 @@ export class TuiPanService extends Observable<readonly [number, number]> {
                     // eslint-disable-next-line rxjs/no-unsafe-takeuntil
                     takeUntil(
                         merge(
-                            tuiTypedFromEvent(documentRef, `touchend`),
-                            tuiTypedFromEvent(documentRef, `mouseup`),
+                            tuiTypedFromEvent(doc, `touchend`),
+                            tuiTypedFromEvent(doc, `mouseup`),
                         ),
                     ),
                     repeat(),

--- a/projects/cdk/services/parents-scroll.service.ts
+++ b/projects/cdk/services/parents-scroll.service.ts
@@ -11,14 +11,14 @@ export class TuiParentsScrollService extends Observable<Event> {
     private readonly callback$: Observable<Event>;
 
     constructor(
-        @Inject(ElementRef) elementRef: ElementRef<Element>,
-        @Inject(WINDOW) windowRef: Window,
+        @Inject(ElementRef) el: ElementRef<Element>,
+        @Inject(WINDOW) win: Window,
     ) {
         super(subscriber => this.callback$.subscribe(subscriber));
 
         this.callback$ = defer(() => {
-            let {nativeElement} = elementRef;
-            const eventTargets: Array<Element | Window> = [windowRef, nativeElement];
+            let {nativeElement} = el;
+            const eventTargets: Array<Element | Window> = [win, nativeElement];
 
             while (nativeElement.parentElement) {
                 nativeElement = nativeElement.parentElement;

--- a/projects/cdk/services/resize.service.ts
+++ b/projects/cdk/services/resize.service.ts
@@ -23,14 +23,14 @@ import {TuiDestroyService} from './destroy.service';
 @Injectable()
 export class TuiResizeService extends ResizeObserverService {
     constructor(
-        @Inject(ElementRef) elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) el: ElementRef<HTMLElement>,
         @Inject(NgZone) ngZone: NgZone,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
         @Inject(RESIZE_OBSERVER_SUPPORT) support: boolean,
         @Inject(RESIZE_OPTION_BOX) box: ResizeObserverBoxOptions,
         @Inject(ANIMATION_FRAME) animationFrame$: Observable<number>,
     ) {
-        super(elementRef, ngZone, support, box);
+        super(el, ngZone, support, box);
 
         return this.pipe(
             catchError(() =>
@@ -42,7 +42,7 @@ export class TuiResizeService extends ResizeObserverService {
                     throttleTime(POLLING_TIME),
                     map(
                         () =>
-                            `${elementRef.nativeElement.clientWidth} ${elementRef.nativeElement.clientHeight}`,
+                            `${el.nativeElement.clientWidth} ${el.nativeElement.clientHeight}`,
                     ),
                     distinctUntilChanged(),
                     map(() => EMPTY_ARRAY),

--- a/projects/cdk/services/swipe.service.ts
+++ b/projects/cdk/services/swipe.service.ts
@@ -12,12 +12,12 @@ export class TuiSwipeService extends Observable<TuiSwipe> {
     constructor(
         @Inject(ElementRef) {nativeElement}: ElementRef<Element>,
         @Inject(TUI_SWIPE_OPTIONS) {timeout, threshold}: TuiSwipeOptions,
-        @Inject(DOCUMENT) documentRef: Document,
+        @Inject(DOCUMENT) doc: Document,
     ) {
         super(subscriber => {
             merge(
                 tuiTypedFromEvent(nativeElement, `touchstart`, {passive: true}),
-                tuiTypedFromEvent(documentRef, `touchend`),
+                tuiTypedFromEvent(doc, `touchend`),
             )
                 .pipe(
                     pairwise(),

--- a/projects/cdk/tokens/active-element.ts
+++ b/projects/cdk/tokens/active-element.ts
@@ -27,13 +27,13 @@ export const TUI_ACTIVE_ELEMENT = new InjectionToken<Observable<EventTarget | nu
     {
         factory: () => {
             const removedElement$ = inject(TUI_REMOVED_ELEMENT);
-            const windowRef = inject(WINDOW);
-            const documentRef = inject(DOCUMENT);
-            const focusout$ = tuiTypedFromEvent(windowRef, `focusout`);
-            const focusin$ = tuiTypedFromEvent(windowRef, `focusin`);
-            const blur$ = tuiTypedFromEvent(windowRef, `blur`);
-            const mousedown$ = tuiTypedFromEvent(windowRef, `mousedown`);
-            const mouseup$ = tuiTypedFromEvent(windowRef, `mouseup`);
+            const win = inject(WINDOW);
+            const doc = inject(DOCUMENT);
+            const focusout$ = tuiTypedFromEvent(win, `focusout`);
+            const focusin$ = tuiTypedFromEvent(win, `focusin`);
+            const blur$ = tuiTypedFromEvent(win, `blur`);
+            const mousedown$ = tuiTypedFromEvent(win, `mousedown`);
+            const mouseup$ = tuiTypedFromEvent(win, `mouseup`);
 
             return merge(
                 focusout$.pipe(
@@ -53,7 +53,7 @@ export const TUI_ACTIVE_ELEMENT = new InjectionToken<Observable<EventTarget | nu
                     map(([{relatedTarget}]) => relatedTarget),
                 ),
                 blur$.pipe(
-                    map(() => documentRef.activeElement),
+                    map(() => doc.activeElement),
                     filter(element => !!element?.matches(`iframe`)),
                 ),
                 focusin$.pipe(
@@ -61,7 +61,7 @@ export const TUI_ACTIVE_ELEMENT = new InjectionToken<Observable<EventTarget | nu
                         const target = tuiGetActualTarget(event);
                         const root = tuiGetDocumentOrShadowRoot(target) as Document;
 
-                        return root === documentRef
+                        return root === doc
                             ? of(target)
                             : shadowRootActiveElement(root).pipe(startWith(target));
                     }),
@@ -70,8 +70,7 @@ export const TUI_ACTIVE_ELEMENT = new InjectionToken<Observable<EventTarget | nu
                     switchMap(event => {
                         const actualTargetInCurrentTime = tuiGetActualTarget(event);
 
-                        return !documentRef.activeElement ||
-                            documentRef.activeElement === documentRef.body
+                        return !doc.activeElement || doc.activeElement === doc.body
                             ? of(actualTargetInCurrentTime)
                             : focusout$.pipe(
                                   take(1),

--- a/projects/cdk/tokens/window-height.ts
+++ b/projects/cdk/tokens/window-height.ts
@@ -11,11 +11,11 @@ export const TUI_WINDOW_HEIGHT = new InjectionToken<Observable<number>>(
     `[TUI_WINDOW_HEIGHT]`,
     {
         factory: () => {
-            const windowRef = inject(WINDOW);
+            const win = inject(WINDOW);
 
-            return tuiTypedFromEvent(windowRef, `resize`).pipe(
+            return tuiTypedFromEvent(win, `resize`).pipe(
                 startWith(null),
-                map(() => windowRef.innerHeight),
+                map(() => win.innerHeight),
                 shareReplay({bufferSize: 1, refCount: true}),
             );
         },

--- a/projects/cdk/utils/browser/is-safari.ts
+++ b/projects/cdk/utils/browser/is-safari.ts
@@ -1,15 +1,14 @@
-export function tuiIsSafari({ownerDocument: documentRef}: Element): boolean {
-    const windowRef = documentRef?.defaultView as unknown as Window & {safari?: any};
+export function tuiIsSafari({ownerDocument: doc}: Element): boolean {
+    const win = doc?.defaultView as unknown as Window & {safari?: any};
 
     const isMacOsSafari =
-        typeof windowRef.safari !== `undefined` &&
-        windowRef.safari?.pushNotification?.toString() ===
-            `[object SafariRemoteNotification]`;
+        typeof win.safari !== `undefined` &&
+        win.safari?.pushNotification?.toString() === `[object SafariRemoteNotification]`;
 
     const isIosSafari =
-        !!windowRef.navigator?.vendor?.includes(`Apple`) &&
-        !windowRef.navigator?.userAgent?.includes(`CriOS`) &&
-        !windowRef.navigator?.userAgent?.includes(`FxiOS`);
+        !!win.navigator?.vendor?.includes(`Apple`) &&
+        !win.navigator?.userAgent?.includes(`CriOS`) &&
+        !win.navigator?.userAgent?.includes(`FxiOS`);
 
     return isMacOsSafari || isIosSafari;
 }

--- a/projects/cdk/utils/dom/get-element-obscurers.ts
+++ b/projects/cdk/utils/dom/get-element-obscurers.ts
@@ -20,7 +20,7 @@ export function tuiGetElementObscures(element: Element): readonly Element[] | nu
     }
 
     const {innerWidth, innerHeight} = ownerDocument.defaultView;
-    const documentRef = tuiGetDocumentOrShadowRoot(element);
+    const doc = tuiGetDocumentOrShadowRoot(element);
     const rect = element.getBoundingClientRect();
     const left = tuiClamp(Math.round(rect.left) + 2, 0, innerWidth);
     const top = tuiClamp(Math.round(rect.top) + 2, 0, innerHeight);
@@ -37,10 +37,10 @@ export function tuiGetElementObscures(element: Element): readonly Element[] | nu
         innerHeight,
     );
     const elements = [
-        documentRef.elementFromPoint(horizontalMiddle, top),
-        documentRef.elementFromPoint(horizontalMiddle, bottom),
-        documentRef.elementFromPoint(left, verticalMiddle),
-        documentRef.elementFromPoint(right, verticalMiddle),
+        doc.elementFromPoint(horizontalMiddle, top),
+        doc.elementFromPoint(horizontalMiddle, bottom),
+        doc.elementFromPoint(left, verticalMiddle),
+        doc.elementFromPoint(right, verticalMiddle),
     ];
     const nonNull = elements.filter(tuiIsPresent);
 

--- a/projects/cdk/utils/dom/is-inside-iframe.ts
+++ b/projects/cdk/utils/dom/is-inside-iframe.ts
@@ -1,6 +1,6 @@
 /**
  * Checks if an app is running inside <iframe /> tag
  */
-export function tuiIsInsideIframe(windowRef: Window): boolean {
-    return windowRef.parent !== windowRef;
+export function tuiIsInsideIframe(win: Window): boolean {
+    return win.parent !== win;
 }

--- a/projects/cdk/utils/focus/blur-native-focused.ts
+++ b/projects/cdk/utils/focus/blur-native-focused.ts
@@ -5,8 +5,8 @@ import {tuiGetNativeFocused} from './get-native-focused';
 /**
  * Finds and blurs current active element, including shadow DOM
  */
-export function tuiBlurNativeFocused(documentRef: Document): void {
-    const activeElement = tuiGetNativeFocused(documentRef);
+export function tuiBlurNativeFocused(doc: Document): void {
+    const activeElement = tuiGetNativeFocused(doc);
 
     if (tuiIsHTMLElement(activeElement)) {
         activeElement.blur();

--- a/projects/cdk/utils/focus/get-native-focused.ts
+++ b/projects/cdk/utils/focus/get-native-focused.ts
@@ -3,12 +3,12 @@
  *
  * @return element or null
  */
-export function tuiGetNativeFocused(documentRef: Document): Element | null {
-    if (!documentRef.activeElement?.shadowRoot) {
-        return documentRef.activeElement;
+export function tuiGetNativeFocused(doc: Document): Element | null {
+    if (!doc.activeElement?.shadowRoot) {
+        return doc.activeElement;
     }
 
-    let element = documentRef.activeElement.shadowRoot.activeElement;
+    let element = doc.activeElement.shadowRoot.activeElement;
 
     while (element?.shadowRoot) {
         element = element.shadowRoot.activeElement;

--- a/projects/core/components/alert/alert.component.ts
+++ b/projects/core/components/alert/alert.component.ts
@@ -42,7 +42,7 @@ export class TuiAlertComponent<O, I> implements OnInit {
     readonly animation = {value: '', ...this.animationOptions} as const;
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Self() @Inject(TuiDestroyService) private readonly destroy$: TuiDestroyService,
         @Inject(TUI_NOTIFICATION_OPTIONS)
         private readonly options: TuiNotificationDefaultOptions,
@@ -70,17 +70,17 @@ export class TuiAlertComponent<O, I> implements OnInit {
                 : this.options.defaultAutoCloseTime,
         )
             .pipe(
-                takeUntil(fromEvent(this.elementRef.nativeElement, 'mouseenter')),
+                takeUntil(fromEvent(this.el.nativeElement, 'mouseenter')),
                 /**
                  * TODO: replace to
                  * repeat({
-                 *    delay: () => fromEvent(this.elementRef.nativeElement, 'mouseleave'),
+                 *    delay: () => fromEvent(this.el.nativeElement, 'mouseleave'),
                  * })
                  *
                  * in RxJS 7
                  */
                 // eslint-disable-next-line rxjs/no-ignored-notifier
-                repeatWhen(() => fromEvent(this.elementRef.nativeElement, 'mouseleave')),
+                repeatWhen(() => fromEvent(this.el.nativeElement, 'mouseleave')),
                 takeUntil(this.destroy$),
             )
             .subscribe(() => this.closeNotification());

--- a/projects/core/components/button/button.component.ts
+++ b/projects/core/components/button/button.component.ts
@@ -83,7 +83,7 @@ export class TuiButtonComponent
         @Optional()
         @Inject(TuiModeDirective)
         private readonly mode: TuiModeDirective | null,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TuiFocusVisibleService) focusVisible$: TuiFocusVisibleService,
         @Inject(TUI_BUTTON_OPTIONS) private readonly options: TuiButtonOptions,
     ) {
@@ -94,11 +94,11 @@ export class TuiButtonComponent
     }
 
     get nativeFocusableElement(): HTMLElement | null {
-        return this.nativeDisabled ? null : this.elementRef.nativeElement;
+        return this.nativeDisabled ? null : this.el.nativeElement;
     }
 
     get focused(): boolean {
-        return !this.showLoader && tuiIsNativeFocused(this.elementRef.nativeElement);
+        return !this.showLoader && tuiIsNativeFocused(this.el.nativeElement);
     }
 
     get loaderSize(): TuiSizeS {

--- a/projects/core/components/data-list/data-list.component.ts
+++ b/projects/core/components/data-list/data-list.component.ts
@@ -75,7 +75,7 @@ export class TuiDataListComponent<T> implements TuiDataListAccessor<T> {
         @Optional()
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         private readonly controller: TuiTextfieldController | null,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_NOTHING_FOUND_MESSAGE)
         readonly defaultEmptyContent$: Observable<string>,
     ) {}
@@ -106,7 +106,7 @@ export class TuiDataListComponent<T> implements TuiDataListAccessor<T> {
     // TODO: Consider aria-activedescendant for proper accessibility implementation
     @HostListener('wheel.silent.passive')
     @HostListener('mouseleave', ['$event.target'])
-    handleFocusLossIfNecessary(element: Element = this.elementRef.nativeElement): void {
+    handleFocusLossIfNecessary(element: Element = this.el.nativeElement): void {
         if (this.origin && tuiIsNativeFocusedIn(element)) {
             tuiSetNativeMouseFocused(this.origin, true, true);
         }
@@ -131,6 +131,6 @@ export class TuiDataListComponent<T> implements TuiDataListAccessor<T> {
     }
 
     private get elements(): readonly HTMLElement[] {
-        return Array.from(this.elementRef.nativeElement.querySelectorAll('[tuiOption]'));
+        return Array.from(this.el.nativeElement.querySelectorAll('[tuiOption]'));
     }
 }

--- a/projects/core/components/data-list/option/option.component.ts
+++ b/projects/core/components/data-list/option/option.component.ts
@@ -72,7 +72,7 @@ export class TuiOptionComponent<T = unknown> implements OnDestroy {
         > | null,
         @Inject(forwardRef(() => TuiDataListComponent))
         private readonly dataList: TuiDataListComponent<T>,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Optional()
         @Inject(TUI_DATA_LIST_HOST)
         private readonly host: TuiDataListHost<T> | null,
@@ -103,6 +103,6 @@ export class TuiOptionComponent<T = unknown> implements OnDestroy {
 
     // Preventing focus loss upon focused option removal
     ngOnDestroy(): void {
-        this.dataList.handleFocusLossIfNecessary(this.elementRef.nativeElement);
+        this.dataList.handleFocusLossIfNecessary(this.el.nativeElement);
     }
 }

--- a/projects/core/components/dialog/dialog-close.service.ts
+++ b/projects/core/components/dialog/dialog-close.service.ts
@@ -20,7 +20,7 @@ export class TuiDialogCloseService extends Observable<unknown> {
         filter(tuiIsCurrentTarget),
     );
 
-    private readonly esc$ = tuiTypedFromEvent(this.documentRef, `keydown`).pipe(
+    private readonly esc$ = tuiTypedFromEvent(this.doc, `keydown`).pipe(
         filter(event => {
             const key = event.key;
             const target = tuiGetActualTarget(event);
@@ -34,19 +34,19 @@ export class TuiDialogCloseService extends Observable<unknown> {
         }),
     );
 
-    private readonly mousedown$ = tuiTypedFromEvent(this.documentRef, `mousedown`).pipe(
+    private readonly mousedown$ = tuiTypedFromEvent(this.doc, `mousedown`).pipe(
         filter(event => {
             const target = tuiGetActualTarget(event);
             const clientX = event.clientX;
 
             return (
                 tuiIsElement(target) &&
-                tuiGetViewportWidth(this.windowRef) - clientX > SCROLLBAR_PLACEHOLDER &&
+                tuiGetViewportWidth(this.win) - clientX > SCROLLBAR_PLACEHOLDER &&
                 !tuiContainsOrAfter(this.element, target)
             );
         }),
         switchMap(() =>
-            tuiTypedFromEvent(this.documentRef, `mouseup`).pipe(
+            tuiTypedFromEvent(this.doc, `mouseup`).pipe(
                 take(1),
                 map(tuiGetActualTarget),
                 filter(
@@ -58,9 +58,9 @@ export class TuiDialogCloseService extends Observable<unknown> {
     );
 
     constructor(
-        @Inject(WINDOW) private readonly windowRef: Window,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(WINDOW) private readonly win: Window,
+        @Inject(DOCUMENT) private readonly doc: Document,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
     ) {
         super(subscriber =>
             merge(this.click$, this.esc$, this.mousedown$).subscribe(subscriber),
@@ -68,6 +68,6 @@ export class TuiDialogCloseService extends Observable<unknown> {
     }
 
     private get element(): HTMLElement {
-        return this.elementRef.nativeElement;
+        return this.el.nativeElement;
     }
 }

--- a/projects/core/components/expand/expand.component.ts
+++ b/projects/core/components/expand/expand.component.ts
@@ -70,9 +70,7 @@ export class TuiExpandComponent {
     @HostBinding('attr.aria-expanded')
     expanded: boolean | null = null;
 
-    constructor(
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
-    ) {}
+    constructor(@Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef) {}
 
     @HostBinding('class._overflow')
     get overflow(): boolean {
@@ -140,7 +138,7 @@ export class TuiExpandComponent {
             }
 
             this.state = state;
-            this.changeDetectorRef.markForCheck();
+            this.cdr.markForCheck();
         });
     }
 }

--- a/projects/core/components/hosted-dropdown/hosted-dropdown.component.ts
+++ b/projects/core/components/hosted-dropdown/hosted-dropdown.component.ts
@@ -117,7 +117,7 @@ export class TuiHostedDropdownComponent implements TuiFocusableElementAccessor {
         @Optional()
         @Inject(TuiDropdownHoverDirective)
         private readonly hover$: TuiDropdownHoverDirective | null,
-        @Inject(ElementRef) private readonly elementRef: ElementRef,
+        @Inject(ElementRef) private readonly el: ElementRef,
     ) {}
 
     @Input()
@@ -131,14 +131,14 @@ export class TuiHostedDropdownComponent implements TuiFocusableElementAccessor {
     }
 
     get host(): HTMLElement {
-        return this.dropdownHost?.nativeElement || this.elementRef.nativeElement;
+        return this.dropdownHost?.nativeElement || this.el.nativeElement;
     }
 
     get computedHost(): HTMLElement {
         return (
             this.dropdownHost?.nativeElement ||
             this.nativeFocusableElement ||
-            this.elementRef.nativeElement
+            this.el.nativeElement
         );
     }
 
@@ -151,7 +151,7 @@ export class TuiHostedDropdownComponent implements TuiFocusableElementAccessor {
             ? this.host
             : tuiGetClosestFocusable({
                   initial: this.host,
-                  root: this.elementRef.nativeElement,
+                  root: this.el.nativeElement,
               });
     }
 

--- a/projects/core/components/link/link.component.ts
+++ b/projects/core/components/link/link.component.ts
@@ -69,17 +69,17 @@ export class TuiLinkComponent implements TuiFocusableElementAccessor {
     focusVisible = false;
 
     readonly focusedChange = merge(
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'focusin').pipe(
+        tuiTypedFromEvent(this.el.nativeElement, 'focusin').pipe(
             map(ALWAYS_TRUE_HANDLER),
         ),
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'focusout').pipe(
+        tuiTypedFromEvent(this.el.nativeElement, 'focusout').pipe(
             map(ALWAYS_FALSE_HANDLER),
         ),
     );
 
     constructor(
         @Inject(ElementRef)
-        private readonly elementRef: ElementRef<TuiNativeFocusableElement>,
+        private readonly el: ElementRef<TuiNativeFocusableElement>,
         @Inject(TUI_MODE) readonly mode$: Observable<TuiBrightness | null>,
         @Inject(TuiFocusVisibleService)
         focusVisible$: TuiFocusVisibleService,
@@ -90,7 +90,7 @@ export class TuiLinkComponent implements TuiFocusableElementAccessor {
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement {
-        return this.elementRef.nativeElement;
+        return this.el.nativeElement;
     }
 
     get focused(): boolean {

--- a/projects/core/components/loader/loader.component.ts
+++ b/projects/core/components/loader/loader.component.ts
@@ -48,7 +48,7 @@ export class TuiLoaderComponent {
     set showLoader(value: boolean) {
         // @bad TODO: https://github.com/angular/angular/issues/32083 think of a better way
         if (value && this.focused) {
-            tuiBlurNativeFocused(this.documentRef);
+            tuiBlurNativeFocused(this.doc);
         }
 
         this.loading = value;
@@ -57,11 +57,11 @@ export class TuiLoaderComponent {
     @HostBinding('class._loading')
     loading = true;
 
-    readonly isApple = tuiIsSafari(this.elementRef.nativeElement) || this.isIos;
+    readonly isApple = tuiIsSafari(this.el.nativeElement) || this.isIos;
 
     constructor(
-        @Inject(DOCUMENT) private readonly documentRef: Document,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(DOCUMENT) private readonly doc: Document,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_IS_IOS) private readonly isIos: boolean,
         @Inject(TUI_LOADER_OPTIONS) private readonly options: TuiLoaderOptions,
     ) {}
@@ -79,6 +79,6 @@ export class TuiLoaderComponent {
     }
 
     get focused(): boolean {
-        return tuiIsNativeFocusedIn(this.elementRef.nativeElement);
+        return tuiIsNativeFocusedIn(this.el.nativeElement);
     }
 }

--- a/projects/core/components/primitive-textfield/primitive-textfield.component.ts
+++ b/projects/core/components/primitive-textfield/primitive-textfield.component.ts
@@ -126,7 +126,7 @@ export class TuiPrimitiveTextfieldComponent
         readonly hintOptions: TuiHintOptionsDirective | null,
         @Inject(TUI_TEXTFIELD_OPTIONS)
         readonly options: TuiTextfieldOptions,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
     ) {
         super();
     }
@@ -155,7 +155,7 @@ export class TuiPrimitiveTextfieldComponent
     }
 
     get focused(): boolean {
-        return tuiIsNativeFocusedIn(this.elementRef.nativeElement);
+        return tuiIsNativeFocusedIn(this.el.nativeElement);
     }
 
     get appearance(): string {

--- a/projects/core/components/primitive-textfield/textfield/textfield.component.ts
+++ b/projects/core/components/primitive-textfield/textfield/textfield.component.ts
@@ -31,18 +31,18 @@ export class TuiTextfieldComponent {
         @Inject(TUI_TEXTFIELD_HOST) readonly host: TuiTextfieldHost,
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         readonly controller: TuiTextfieldController,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLInputElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLInputElement>,
         @Inject(TuiIdService)
         private readonly idService: TuiIdService,
     ) {
-        this.host.process(this.elementRef.nativeElement);
+        this.host.process(this.el.nativeElement);
     }
 
     get id(): string {
-        return this.elementRef.nativeElement.id || this.idService.generate();
+        return this.el.nativeElement.id || this.idService.generate();
     }
 
     get inputMode(): string {
-        return this.elementRef.nativeElement.inputMode || this.host.inputMode;
+        return this.el.nativeElement.inputMode || this.host.inputMode;
     }
 }

--- a/projects/core/components/root/root.component.ts
+++ b/projects/core/components/root/root.component.ts
@@ -2,7 +2,6 @@ import {DOCUMENT} from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
-    ElementRef,
     Inject,
     ViewEncapsulation,
 } from '@angular/core';
@@ -40,7 +39,6 @@ export class TuiRootComponent {
 
     constructor(
         @Inject(TUI_ANIMATIONS_DURATION) readonly duration: number,
-        @Inject(ElementRef) readonly elementRef: ElementRef<HTMLElement>,
         @Inject(TUI_DIALOGS)
         readonly dialogs: ReadonlyArray<Observable<readonly unknown[]>>,
         @Inject(TUI_IS_MOBILE) private readonly isMobile: boolean,

--- a/projects/core/components/scroll-controls/scroll-controls.component.ts
+++ b/projects/core/components/scroll-controls/scroll-controls.component.ts
@@ -45,7 +45,7 @@ export class TuiScrollControlsComponent {
     constructor(
         @Inject(TUI_ANIMATION_OPTIONS) private readonly options: AnimationOptions,
         @Inject(NgZone) private readonly ngZone: NgZone,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
+        @Inject(DOCUMENT) private readonly doc: Document,
         @Optional()
         @Inject(TUI_SCROLL_REF)
         private readonly scrollRef: ElementRef<HTMLElement> | null,
@@ -56,7 +56,7 @@ export class TuiScrollControlsComponent {
     private get scrollbars(): [boolean, boolean] {
         const {clientHeight, scrollHeight, clientWidth, scrollWidth} = this.scrollRef
             ? this.scrollRef.nativeElement
-            : this.documentRef.documentElement;
+            : this.doc.documentElement;
 
         return [
             Math.ceil((clientHeight / scrollHeight) * 100) < 100,

--- a/projects/core/components/scroll-controls/scrollbar.directive.ts
+++ b/projects/core/components/scroll-controls/scrollbar.directive.ts
@@ -42,15 +42,15 @@ export class TuiScrollbarDirective {
         @Optional()
         @Inject(TUI_SCROLL_REF)
         private readonly container: ElementRef<HTMLElement> | null,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
-        @Inject(WINDOW) private readonly windowRef: Window,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(DOCUMENT) private readonly doc: Document,
+        @Inject(WINDOW) private readonly win: Window,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(ViewportScroller) private readonly viewportScroller: ViewportScroller,
     ) {
-        const {nativeElement} = this.elementRef;
+        const {nativeElement} = this.el;
         const mousedown$ = tuiTypedFromEvent(nativeElement, 'mousedown');
-        const mousemove$ = tuiTypedFromEvent(this.documentRef, 'mousemove');
-        const mouseup$ = tuiTypedFromEvent(this.documentRef, 'mouseup');
+        const mousemove$ = tuiTypedFromEvent(this.doc, 'mousemove');
+        const mouseup$ = tuiTypedFromEvent(this.doc, 'mouseup');
         const mousedownWrapper$ = tuiTypedFromEvent(wrapper.nativeElement, 'mousedown');
 
         merge(
@@ -102,10 +102,7 @@ export class TuiScrollbarDirective {
             });
 
         merge(
-            fromEvent(
-                this.container ? this.container.nativeElement : this.windowRef,
-                'scroll',
-            ),
+            fromEvent(this.container ? this.container.nativeElement : this.win, 'scroll'),
             animationFrame$.pipe(throttleTime(POLLING_TIME)),
         )
             .pipe(tuiZonefree(ngZone), takeUntil(destroy$))
@@ -169,7 +166,7 @@ export class TuiScrollbarDirective {
     }
 
     private get computedContainer(): Element {
-        return this.container?.nativeElement || this.documentRef.documentElement;
+        return this.container?.nativeElement || this.doc.documentElement;
     }
 
     private getScrolled(
@@ -177,7 +174,7 @@ export class TuiScrollbarDirective {
         offsetVertical: number,
         offsetHorizontal: number,
     ): [number, number] {
-        const {offsetHeight, offsetWidth} = this.elementRef.nativeElement;
+        const {offsetHeight, offsetWidth} = this.el.nativeElement;
         const {top, left, width, height} =
             this.wrapper.nativeElement.getBoundingClientRect();
 

--- a/projects/core/components/scrollbar/scrollable.directive.ts
+++ b/projects/core/components/scrollbar/scrollable.directive.ts
@@ -5,15 +5,13 @@ import {TUI_SCROLLABLE} from '@taiga-ui/core/constants';
     selector: '[tuiScrollable]',
 })
 export class TuiScrollableDirective implements OnInit {
-    constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
-    ) {}
+    constructor(@Inject(ElementRef) private readonly el: ElementRef<HTMLElement>) {}
 
     ngOnInit(): void {
-        this.elementRef.nativeElement.dispatchEvent(
+        this.el.nativeElement.dispatchEvent(
             new CustomEvent(TUI_SCROLLABLE, {
                 bubbles: true,
-                detail: this.elementRef.nativeElement,
+                detail: this.el.nativeElement,
             }),
         );
     }

--- a/projects/core/components/scrollbar/scrollbar.component.ts
+++ b/projects/core/components/scrollbar/scrollbar.component.ts
@@ -45,12 +45,12 @@ export class TuiScrollbarComponent {
     @tuiDefaultProp()
     hidden = false;
 
-    readonly browserScrollRef = new ElementRef(this.elementRef.nativeElement);
+    readonly browserScrollRef = new ElementRef(this.el.nativeElement);
 
     constructor(
         @Inject(CSS_TOKEN)
         private readonly cssRef: TuiInjectionTokenType<typeof CSS_TOKEN>,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(USER_AGENT) private readonly userAgent: string,
         @Inject(TUI_IS_IOS) private readonly isIos: boolean,
     ) {}

--- a/projects/core/components/svg/svg.component.ts
+++ b/projects/core/components/svg/svg.component.ts
@@ -48,8 +48,8 @@ export class TuiSvgComponent {
     readonly innerHTML$: Observable<SafeHtml>;
 
     constructor(
-        @Inject(DOCUMENT) private readonly documentRef: Document,
-        @Inject(WINDOW) private readonly windowRef: Window,
+        @Inject(DOCUMENT) private readonly doc: Document,
+        @Inject(WINDOW) private readonly win: Window,
         @Inject(TUI_SVG_OPTIONS) private readonly options: TuiSvgOptions,
         @Optional()
         @Inject(TUI_SANITIZER)
@@ -58,7 +58,7 @@ export class TuiSvgComponent {
         @Inject(TuiStaticRequestService)
         private readonly staticRequestService: TuiStaticRequestService,
         @Inject(DomSanitizer) private readonly sanitizer: DomSanitizer,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<Element>,
+        @Inject(ElementRef) private readonly el: ElementRef<Element>,
     ) {
         this.innerHTML$ = this.src$.pipe(
             switchMap(() => {
@@ -108,9 +108,7 @@ export class TuiSvgComponent {
     }
 
     private get isShadowDOM(): boolean {
-        return (
-            tuiGetDocumentOrShadowRoot(this.elementRef.nativeElement) !== this.documentRef
-        );
+        return tuiGetDocumentOrShadowRoot(this.el.nativeElement) !== this.doc;
     }
 
     private get isUse(): boolean {
@@ -134,13 +132,10 @@ export class TuiSvgComponent {
     }
 
     private get isCrossDomain(): boolean {
-        const {use, isUse, windowRef} = this;
+        const {use, isUse, win} = this;
 
         return (
-            isUse &&
-            use.startsWith('http') &&
-            !!windowRef.origin &&
-            !use.startsWith(windowRef.origin)
+            isUse && use.startsWith('http') && !!win.origin && !use.startsWith(win.origin)
         );
     }
 
@@ -155,7 +150,7 @@ export class TuiSvgComponent {
         });
 
         tuiAssert.assert(false, message, icon);
-        this.elementRef.nativeElement.dispatchEvent(event);
+        this.el.nativeElement.dispatchEvent(event);
     }
 
     @tuiPure

--- a/projects/core/directives/dropdown/dropdown-selection.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-selection.directive.ts
@@ -58,7 +58,7 @@ export class TuiDropdownSelectionDirective
         ),
     ]).pipe(
         map(([handler, range]) => {
-            const contained = this.elementRef.nativeElement.contains(
+            const contained = this.el.nativeElement.contains(
                 range.commonAncestorContainer,
             );
 
@@ -88,10 +88,10 @@ export class TuiDropdownSelectionDirective
 
     constructor(
         @Inject(TUI_RANGE) private range: Range,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
+        @Inject(DOCUMENT) private readonly doc: Document,
         @Inject(TUI_SELECTION_STREAM) private readonly selection$: Observable<unknown>,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
-        @Inject(ViewContainerRef) private readonly viewContainerRef: ViewContainerRef,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
+        @Inject(ViewContainerRef) private readonly vcr: ViewContainerRef,
         @Inject(TuiDropdownDirective) private readonly dropdown: TuiDropdownDirective,
     ) {
         super(subscriber => this.stream$.subscribe(subscriber));
@@ -118,16 +118,15 @@ export class TuiDropdownSelectionDirective
 
     ngOnDestroy(): void {
         if (this.ghost) {
-            this.viewContainerRef.element.nativeElement.removeChild(this.ghost);
+            this.vcr.element.nativeElement.removeChild(this.ghost);
         }
     }
 
     private getRange(): Range {
-        const {nativeElement} = this.elementRef;
-        const active = tuiGetNativeFocused(this.documentRef);
-        const selection = this.documentRef.getSelection();
+        const active = tuiGetNativeFocused(this.doc);
+        const selection = this.doc.getSelection();
 
-        if (active && tuiIsTextfield(active) && nativeElement.contains(active)) {
+        if (active && tuiIsTextfield(active) && this.el.nativeElement.contains(active)) {
             return this.veryVerySadInputFix(active);
         }
 
@@ -146,7 +145,7 @@ export class TuiDropdownSelectionDirective
      */
     private inDropdown(range: Range): boolean {
         const {startContainer, endContainer} = range;
-        const {nativeElement} = this.elementRef;
+        const {nativeElement} = this.el;
         const inDropdown = this.boxContains(range.commonAncestorContainer);
         const hostToDropdown =
             this.boxContains(endContainer) && nativeElement.contains(startContainer);
@@ -160,8 +159,8 @@ export class TuiDropdownSelectionDirective
         const {ghost = this.initGhost(element)} = this;
         const {top, left, width, height} = element.getBoundingClientRect();
         const {selectionStart, selectionEnd, value} = element;
-        const range = this.documentRef.createRange();
-        const hostRect = this.elementRef.nativeElement.getBoundingClientRect();
+        const range = this.doc.createRange();
+        const hostRect = this.el.nativeElement.getBoundingClientRect();
 
         ghost.style.top = tuiPx(top - hostRect.top);
         ghost.style.left = tuiPx(left - hostRect.left);
@@ -179,8 +178,7 @@ export class TuiDropdownSelectionDirective
      * Create an invisible DIV styled exactly like input/textarea element inside directive
      */
     private initGhost(element: HTMLInputElement | HTMLTextAreaElement): HTMLElement {
-        const ghost = this.documentRef.createElement('div');
-        const {nativeElement} = this.viewContainerRef.element;
+        const ghost = this.doc.createElement('div');
         const {font, letterSpacing, textTransform, padding} = getComputedStyle(element);
 
         ghost.style.position = 'absolute';
@@ -192,7 +190,7 @@ export class TuiDropdownSelectionDirective
         ghost.style.textTransform = textTransform;
         ghost.style.padding = padding;
 
-        nativeElement.appendChild(ghost);
+        this.vcr.element.nativeElement.appendChild(ghost);
         this.ghost = ghost;
 
         return ghost;

--- a/projects/core/directives/dropdown/dropdown.component.ts
+++ b/projects/core/directives/dropdown/dropdown.component.ts
@@ -66,11 +66,11 @@ export class TuiDropdownComponent implements OnDestroy {
         @Inject(TuiPositionService) position$: Observable<TuiPoint>,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
         @Inject(TuiDropdownDirective) readonly directive: TuiDropdownDirective,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(AbstractTuiPortalHostComponent)
         private readonly host: AbstractTuiPortalHostComponent,
         @Inject(TuiRectAccessor) private readonly accessor: TuiRectAccessor,
-        @Inject(WINDOW) private readonly windowRef: Window,
+        @Inject(WINDOW) private readonly win: Window,
         @Inject(TUI_ANIMATION_OPTIONS)
         private readonly animationOptions: AnimationOptions,
         @Inject(TUI_DROPDOWN_OPTIONS) private readonly options: TuiDropdownOptions,
@@ -114,10 +114,10 @@ export class TuiDropdownComponent implements OnDestroy {
     }
 
     private update(top: number, left: number): void {
-        const {style} = this.elementRef.nativeElement;
-        const {right} = this.elementRef.nativeElement.getBoundingClientRect();
+        const {style} = this.el.nativeElement;
+        const {right} = this.el.nativeElement.getBoundingClientRect();
         const {maxHeight, offset} = this.options;
-        const {innerHeight} = this.windowRef;
+        const {innerHeight} = this.win;
         const {clientRect} = this.host;
         const {position} = this.directive;
         const rect = this.accessor.getClientRect();
@@ -144,7 +144,7 @@ export class TuiDropdownComponent implements OnDestroy {
     }
 
     private updateWidth(): void {
-        const {style} = this.elementRef.nativeElement;
+        const {style} = this.el.nativeElement;
         const rect = this.accessor.getClientRect();
         const {limitWidth} = this.options;
 
@@ -161,7 +161,7 @@ export class TuiDropdownComponent implements OnDestroy {
     }
 
     private moveFocusOutside(previous: boolean): void {
-        const {nativeElement} = this.directive.elementRef;
+        const {nativeElement} = this.directive.el;
         const {ownerDocument} = nativeElement;
         const root = ownerDocument ? ownerDocument.body : nativeElement;
         let focusable = tuiGetClosestFocusable({initial: nativeElement, root, previous});

--- a/projects/core/directives/dropdown/dropdown.directive.ts
+++ b/projects/core/directives/dropdown/dropdown.directive.ts
@@ -60,7 +60,7 @@ export class TuiDropdownDirective
     readonly component = new PolymorpheusComponent(this.hapica, this.injector);
 
     constructor(
-        @Inject(ElementRef) readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_DROPDOWN_COMPONENT) private readonly hapica: Type<unknown>,
         @Inject(INJECTOR) private readonly injector: Injector,
         @Inject(TuiDropdownPortalService)
@@ -69,9 +69,7 @@ export class TuiDropdownDirective
 
     @tuiPure
     get position(): 'absolute' | 'fixed' {
-        return tuiCheckFixedPosition(this.elementRef.nativeElement)
-            ? 'fixed'
-            : 'absolute';
+        return tuiCheckFixedPosition(this.el.nativeElement) ? 'fixed' : 'absolute';
     }
 
     ngAfterViewChecked(): void {
@@ -90,7 +88,7 @@ export class TuiDropdownDirective
     }
 
     getClientRect(): ClientRect {
-        return this.elementRef.nativeElement.getBoundingClientRect();
+        return this.el.nativeElement.getBoundingClientRect();
     }
 
     toggle(show: boolean): void {

--- a/projects/core/directives/hint/hint-describe.directive.ts
+++ b/projects/core/directives/hint/hint-describe.directive.ts
@@ -22,14 +22,14 @@ import {
     providers: [tuiAsDriver(TuiHintDescribeDirective)],
 })
 export class TuiHintDescribeDirective extends TuiDriver {
-    private readonly stream$ = tuiTypedFromEvent(this.documentRef, 'keydown', {
+    private readonly stream$ = tuiTypedFromEvent(this.doc, 'keydown', {
         capture: true,
     }).pipe(
         switchMap(() =>
             this.focused
                 ? of(false)
                 : merge(
-                      tuiTypedFromEvent(this.documentRef, 'keyup'),
+                      tuiTypedFromEvent(this.doc, 'keyup'),
                       tuiTypedFromEvent(this.element, 'blur'),
                   ).pipe(map(() => this.focused)),
         ),
@@ -47,8 +47,8 @@ export class TuiHintDescribeDirective extends TuiDriver {
 
     constructor(
         @Inject(NgZone) private readonly ngZone: NgZone,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(DOCUMENT) private readonly doc: Document,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
     ) {
         super(subscriber => this.stream$.subscribe(subscriber));
     }
@@ -59,9 +59,6 @@ export class TuiHintDescribeDirective extends TuiDriver {
 
     @tuiPure
     private get element(): HTMLElement {
-        return (
-            this.documentRef.getElementById(this.tuiHintDescribe) ||
-            this.elementRef.nativeElement
-        );
+        return this.doc.getElementById(this.tuiHintDescribe) || this.el.nativeElement;
     }
 }

--- a/projects/core/directives/hint/hint-hover.directive.ts
+++ b/projects/core/directives/hint/hint-hover.directive.ts
@@ -50,7 +50,7 @@ export class TuiHintHoverDirective extends TuiDriver {
     constructor(
         @Inject(TuiHoveredService) private readonly hovered$: Observable<boolean>,
         @Inject(TUI_HINT_OPTIONS) private readonly options: TuiHintOptions,
-        @Inject(ElementRef) readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) readonly el: ElementRef<HTMLElement>,
     ) {
         super(subscriber => this.stream$.subscribe(subscriber));
     }

--- a/projects/core/directives/hint/hint.component.ts
+++ b/projects/core/directives/hint/hint.component.ts
@@ -70,7 +70,7 @@ export class TuiHintComponent<C = any> {
         @Inject(TuiPositionService) position$: Observable<TuiPoint>,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
         @Inject(TuiRectAccessor) protected readonly accessor: TuiRectAccessor,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_ANIMATION_OPTIONS) private readonly options: AnimationOptions,
         @Inject(POLYMORPHEUS_CONTEXT)
         private readonly polymorpheus: TuiContextWithImplicit<TuiPortalItem<C>>,
@@ -105,8 +105,8 @@ export class TuiHintComponent<C = any> {
     @HostListener('document:click', ['$event.target'])
     onClick(target: HTMLElement): void {
         if (
-            !this.elementRef.nativeElement.contains(target) &&
-            !this.hover.elementRef.nativeElement.contains(target)
+            !this.el.nativeElement.contains(target) &&
+            !this.hover.el.nativeElement.contains(target)
         ) {
             this.hover.toggle(false);
         }
@@ -114,9 +114,8 @@ export class TuiHintComponent<C = any> {
 
     @tuiPure
     private update(top: number, left: number): void {
-        const {nativeElement} = this.elementRef;
-        const {height, width} = nativeElement.getBoundingClientRect();
-        const {style} = nativeElement;
+        const {height, width} = this.el.nativeElement.getBoundingClientRect();
+        const {style} = this.el.nativeElement;
         const rect = this.accessor.getClientRect();
         const safeLeft = Math.max(left, 4);
         const [beakTop, beakLeft] = this.visualViewportService.correct([

--- a/projects/core/directives/hint/hint.directive.ts
+++ b/projects/core/directives/hint/hint.directive.ts
@@ -52,7 +52,7 @@ export class TuiHintDirective<C>
     readonly type = 'hint';
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(PolymorpheusComponent)
         readonly component: PolymorpheusComponent<unknown, any>,
         @Inject(TuiHintService) private readonly hintService: TuiHintService,
@@ -77,7 +77,7 @@ export class TuiHintDirective<C>
     }
 
     getClientRect(): ClientRect {
-        return this.elementRef.nativeElement.getBoundingClientRect();
+        return this.el.nativeElement.getBoundingClientRect();
     }
 
     toggle(show: boolean): void {

--- a/projects/core/directives/scroll-into-view/scroll-into-view.directive.ts
+++ b/projects/core/directives/scroll-into-view/scroll-into-view.directive.ts
@@ -24,17 +24,17 @@ export class TuiScrollIntoViewDirective {
         timer(0)
             .pipe(takeUntil(this.destroy$))
             .subscribe(() => {
-                this.elementRef.nativeElement.dispatchEvent(
+                this.el.nativeElement.dispatchEvent(
                     new CustomEvent<Element>(TUI_SCROLL_INTO_VIEW, {
                         bubbles: true,
-                        detail: this.elementRef.nativeElement,
+                        detail: this.el.nativeElement,
                     }),
                 );
             });
     }
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<Element>,
+        @Inject(ElementRef) private readonly el: ElementRef<Element>,
         @Self() @Inject(TuiDestroyService) private readonly destroy$: Observable<void>,
     ) {}
 }

--- a/projects/core/directives/textfield-controller/textfield-controller.provider.ts
+++ b/projects/core/directives/textfield-controller/textfield-controller.provider.ts
@@ -65,7 +65,7 @@ export const TEXTFIELD_CONTROLLER_PROVIDER: Provider = [
             TUI_TEXTFIELD_FILLER,
         ],
         useFactory: (
-            changeDetectorRef: ChangeDetectorRef,
+            cdr: ChangeDetectorRef,
             destroy$: Observable<void>,
             options: TuiTextfieldOptions,
             legacyAppearance: string,
@@ -84,7 +84,7 @@ export const TEXTFIELD_CONTROLLER_PROVIDER: Provider = [
         ) => {
             const change$ = merge(
                 ...controllers.map(({change$}) => change$ || NEVER),
-            ).pipe(tuiWatch(changeDetectorRef), takeUntil(destroy$));
+            ).pipe(tuiWatch(cdr), takeUntil(destroy$));
 
             change$.subscribe();
 

--- a/projects/core/internal/svg-defs-host/svg-defs-host.component.ts
+++ b/projects/core/internal/svg-defs-host/svg-defs-host.component.ts
@@ -26,7 +26,7 @@ export class TuiSvgDefsHostComponent implements OnInit {
 
     constructor(
         @Inject(TuiSvgService) private readonly svgService: TuiSvgService,
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
         @Self()
         @Inject(TuiDestroyService)
         private readonly destroy$: TuiDestroyService,
@@ -39,7 +39,7 @@ export class TuiSvgDefsHostComponent implements OnInit {
     ngOnInit(): void {
         this.svgService.items$.pipe(takeUntil(this.destroy$)).subscribe(defsMap => {
             this.items = defsMap.values();
-            this.changeDetectorRef.detectChanges();
+            this.cdr.detectChanges();
         });
     }
 }

--- a/projects/core/providers/watched-controller-provider-factory.ts
+++ b/projects/core/providers/watched-controller-provider-factory.ts
@@ -5,10 +5,10 @@ import {takeUntil} from 'rxjs/operators';
 
 export function tuiWatchedControllerFactory(
     controller: AbstractTuiController,
-    changeDetectorRef: ChangeDetectorRef,
+    cdr: ChangeDetectorRef,
     destroy$: Observable<void>,
 ): AbstractTuiController {
-    controller.change$.pipe(tuiWatch(changeDetectorRef), takeUntil(destroy$)).subscribe();
+    controller.change$.pipe(tuiWatch(cdr), takeUntil(destroy$)).subscribe();
 
     return controller;
 }

--- a/projects/core/services/breakpoint.service.ts
+++ b/projects/core/services/breakpoint.service.ts
@@ -12,14 +12,14 @@ import {map, shareReplay, startWith} from 'rxjs/operators';
     providedIn: `root`,
 })
 export class TuiBreakpointService extends Observable<MediaKey | null> {
-    constructor(@Inject(TUI_MEDIA) media: TuiMedia, @Inject(WINDOW) windowRef: Window) {
+    constructor(@Inject(TUI_MEDIA) media: TuiMedia, @Inject(WINDOW) win: Window) {
         const breakpoints = getBreakpoints(media);
         const events$ = breakpoints.map(({query}) =>
-            fromEvent<MediaQueryListEvent>(windowRef.matchMedia(query), `change`),
+            fromEvent<MediaQueryListEvent>(win.matchMedia(query), `change`),
         );
         const media$ = merge(...events$).pipe(
-            map(() => currentBreakpoint(breakpoints, windowRef.innerWidth).name),
-            startWith(currentBreakpoint(breakpoints, windowRef.innerWidth).name),
+            map(() => currentBreakpoint(breakpoints, win.innerWidth).name),
+            startWith(currentBreakpoint(breakpoints, win.innerWidth).name),
             shareReplay({bufferSize: 1, refCount: true}),
         );
 

--- a/projects/core/services/night-theme.service.ts
+++ b/projects/core/services/night-theme.service.ts
@@ -7,8 +7,8 @@ import {map, share, startWith} from 'rxjs/operators';
     providedIn: `root`,
 })
 export class TuiNightThemeService extends Observable<boolean> {
-    constructor(@Inject(WINDOW) windowRef: Window) {
-        const media = windowRef.matchMedia(`(prefers-color-scheme: dark)`);
+    constructor(@Inject(WINDOW) win: Window) {
+        const media = win.matchMedia(`(prefers-color-scheme: dark)`);
         const media$ = fromEvent(media, `change`).pipe(
             startWith(null),
             map(() => media.matches),

--- a/projects/core/services/visual-viewport.service.ts
+++ b/projects/core/services/visual-viewport.service.ts
@@ -8,7 +8,7 @@ import {TuiPoint} from '@taiga-ui/core/types';
 })
 export class TuiVisualViewportService {
     constructor(
-        @Inject(WINDOW) private readonly windowRef: Window,
+        @Inject(WINDOW) private readonly win: Window,
         @Inject(TUI_IS_WEBKIT) private readonly isWebkit: boolean,
     ) {}
 
@@ -16,8 +16,8 @@ export class TuiVisualViewportService {
     correct(point: TuiPoint): TuiPoint {
         return this.isWebkit
             ? [
-                  point[0] + (this.windowRef.visualViewport?.offsetTop ?? 0),
-                  point[1] + (this.windowRef.visualViewport?.offsetLeft ?? 0),
+                  point[0] + (this.win.visualViewport?.offsetTop ?? 0),
+                  point[1] + (this.win.visualViewport?.offsetLeft ?? 0),
               ]
             : point;
     }

--- a/projects/core/tokens/is-mobile-resolution.ts
+++ b/projects/core/tokens/is-mobile-resolution.ts
@@ -16,13 +16,13 @@ export const TUI_IS_MOBILE_RES = new InjectionToken<Observable<boolean>>(
     `[TUI_IS_MOBILE_RES]`,
     {
         factory: () => {
-            const windowRef = inject(WINDOW);
+            const win = inject(WINDOW);
             const media = inject(TUI_MEDIA);
 
-            return tuiTypedFromEvent(windowRef, `resize`).pipe(
+            return tuiTypedFromEvent(win, `resize`).pipe(
                 share(),
                 startWith(null),
-                map(() => tuiIsMobile(windowRef, media)),
+                map(() => tuiIsMobile(win, media)),
                 distinctUntilChanged(),
                 tuiZoneOptimized(inject(NgZone)),
             );

--- a/projects/core/tokens/selection-stream.ts
+++ b/projects/core/tokens/selection-stream.ts
@@ -11,20 +11,20 @@ export const TUI_SELECTION_STREAM = new InjectionToken<Observable<unknown>>(
     `[TUI_SELECTION_STREAM]`,
     {
         factory: () => {
-            const documentRef = inject(DOCUMENT);
+            const doc = inject(DOCUMENT);
 
             return merge(
-                tuiTypedFromEvent(documentRef, `selectionchange`),
-                tuiTypedFromEvent(documentRef, `mouseup`),
-                tuiTypedFromEvent(documentRef, `mousedown`).pipe(
+                tuiTypedFromEvent(doc, `selectionchange`),
+                tuiTypedFromEvent(doc, `mouseup`),
+                tuiTypedFromEvent(doc, `mousedown`).pipe(
                     switchMap(() =>
-                        tuiTypedFromEvent(documentRef, `mousemove`).pipe(
-                            takeUntil(tuiTypedFromEvent(documentRef, `mouseup`)),
+                        tuiTypedFromEvent(doc, `mousemove`).pipe(
+                            takeUntil(tuiTypedFromEvent(doc, `mouseup`)),
                         ),
                     ),
                 ),
-                tuiTypedFromEvent(documentRef, `keydown`),
-                tuiTypedFromEvent(documentRef, `keyup`),
+                tuiTypedFromEvent(doc, `keydown`),
+                tuiTypedFromEvent(doc, `keyup`),
             ).pipe(share());
         },
     },

--- a/projects/core/tokens/viewport.ts
+++ b/projects/core/tokens/viewport.ts
@@ -7,7 +7,7 @@ import {TuiRectAccessor} from '@taiga-ui/core/abstract';
  */
 export const TUI_VIEWPORT = new InjectionToken<TuiRectAccessor>(`[TUI_VIEWPORT]`, {
     factory: () => {
-        const windowRef = inject(WINDOW);
+        const win = inject(WINDOW);
 
         return {
             type: `viewport`,
@@ -15,10 +15,10 @@ export const TUI_VIEWPORT = new InjectionToken<TuiRectAccessor>(`[TUI_VIEWPORT]`
                 return {
                     top: 0,
                     left: 0,
-                    right: windowRef.innerWidth,
-                    bottom: windowRef.innerHeight,
-                    width: windowRef.innerWidth,
-                    height: windowRef.innerHeight,
+                    right: win.innerWidth,
+                    bottom: win.innerHeight,
+                    width: win.innerWidth,
+                    height: win.innerHeight,
                 };
             },
         };

--- a/projects/core/utils/dom/get-screen-width.ts
+++ b/projects/core/utils/dom/get-screen-width.ts
@@ -1,6 +1,6 @@
-export function tuiGetScreenWidth(documentRef: Document): number {
+export function tuiGetScreenWidth(doc: Document): number {
     return Math.max(
-        documentRef.documentElement.clientWidth,
-        documentRef.defaultView ? documentRef.defaultView.innerWidth : 0,
+        doc.documentElement.clientWidth,
+        doc.defaultView ? doc.defaultView.innerWidth : 0,
     );
 }

--- a/projects/core/utils/mobile/is-mobile.ts
+++ b/projects/core/utils/mobile/is-mobile.ts
@@ -1,6 +1,6 @@
 import {TuiMedia} from '@taiga-ui/core/interfaces';
 import {tuiGetViewportWidth} from '@taiga-ui/core/utils/dom';
 
-export function tuiIsMobile(windowRef: Window, {mobile}: TuiMedia): boolean {
-    return tuiGetViewportWidth(windowRef) < mobile;
+export function tuiIsMobile(win: Window, {mobile}: TuiMedia): boolean {
+    return tuiGetViewportWidth(win) < mobile;
 }

--- a/projects/demo-integrations/cypress/support/helpers/visit.ts
+++ b/projects/demo-integrations/cypress/support/helpers/visit.ts
@@ -40,13 +40,13 @@ interface TuiVisitOptions {
 }
 
 const setBeforeLoadOptions = (
-    windowRef: Window,
+    win: Window,
     {inIframe}: Pick<Required<TuiVisitOptions>, 'inIframe'>,
 ): void => {
     if (!inIframe) {
         // @ts-ignore window.parent is readonly property
         // eslint-disable-next-line @typescript-eslint/dot-notation
-        windowRef[`parent`] = windowRef;
+        win[`parent`] = win;
     }
 };
 

--- a/projects/demo/src/modules/app/app.component.ts
+++ b/projects/demo/src/modules/app/app.component.ts
@@ -52,7 +52,7 @@ export class AppComponent extends AbstractDemoComponent implements OnInit {
         @Inject(LOCAL_STORAGE) protected readonly storage: Storage,
         @Self() @Inject(TuiDestroyService) private readonly destroy$: Observable<void>,
         @Inject(Injector) private readonly injector: Injector,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
+        @Inject(DOCUMENT) private readonly doc: Document,
         @Inject(APP_BASE_HREF) private readonly appBaseHref: string,
     ) {
         super(isCypress, pageLoaded$, selectedVersion);
@@ -96,13 +96,13 @@ export class AppComponent extends AbstractDemoComponent implements OnInit {
      * we use fallback for correct processing of routing
      */
     private setBaseHrefIfNotPresent(): void {
-        if (this.documentRef.getElementsByTagName('base')?.[0]?.href) {
+        if (this.doc.getElementsByTagName('base')?.[0]?.href) {
             return;
         }
 
-        const base = this.documentRef.createElement('base');
+        const base = this.doc.createElement('base');
 
         base.href = this.appBaseHref;
-        this.documentRef.getElementsByTagName('head')?.[0]?.appendChild(base);
+        this.doc.getElementsByTagName('head')?.[0]?.appendChild(base);
     }
 }

--- a/projects/demo/src/modules/app/customization/customization.providers.ts
+++ b/projects/demo/src/modules/app/customization/customization.providers.ts
@@ -21,10 +21,10 @@ export const TUI_DOC_CUSTOMIZATION_PROVIDERS: Provider[] = [
         provide: TUI_DOC_CUSTOMIZATION_VARS,
         deps: [WINDOW, CSS_VARS],
         useFactory: (
-            windowRef: Window,
+            win: Window,
             variables: readonly string[],
         ): Record<string, string> => {
-            const styles = windowRef.getComputedStyle(windowRef.document.documentElement);
+            const styles = win.getComputedStyle(win.document.documentElement);
 
             return variables.reduce(
                 (dictionary, variable) => ({

--- a/projects/demo/src/modules/app/home/examples/app-template.md
+++ b/projects/demo/src/modules/app/home/examples/app-template.md
@@ -12,7 +12,7 @@
     <!-- Content over dialogs -->
   </ng-container>
   <ng-container ngProjectAs="tuiOverAlerts">
-    <!-- Content over notifications -->
+    <!-- Content over alerts -->
   </ng-container>
   <ng-container ngProjectAs="tuiOverPortals">
     <!-- Content over dropdowns -->

--- a/projects/demo/src/modules/charts/legend-item/examples/2/index.ts
+++ b/projects/demo/src/modules/charts/legend-item/examples/2/index.ts
@@ -20,7 +20,7 @@ export class TuiLegendItemExample2 {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     get value(): readonly number[] {
@@ -37,7 +37,7 @@ export class TuiLegendItemExample2 {
 
     onClick(index: number): void {
         if (this.isEnabled(index)) {
-            this.alertService
+            this.alerts
                 .open(`Category spendings: ${tuiFormatNumber(this.data[index])} ₽`, {
                     label: this.labels[index],
                 })

--- a/projects/demo/src/modules/components/action/examples/1/index.ts
+++ b/projects/demo/src/modules/components/action/examples/1/index.ts
@@ -13,10 +13,10 @@ import {TuiAlertService} from '@taiga-ui/core';
 export class TuiActionExample1 {
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     onClick(result: string): void {
-        this.alertService.open(result).subscribe();
+        this.alerts.open(result).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/calendar-month/calendar-month.component.ts
+++ b/projects/demo/src/modules/components/calendar-month/calendar-month.component.ts
@@ -71,10 +71,10 @@ export class ExampleTuiCalendarMonthComponent {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     onMonthClick(month: TuiMonth): void {
-        this.alertService.open(String(month)).subscribe();
+        this.alerts.open(String(month)).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/calendar/calendar.component.ts
+++ b/projects/demo/src/modules/components/calendar/calendar.component.ts
@@ -116,10 +116,10 @@ export class ExampleTuiCalendarComponent {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     onDayClick(day: TuiDay): void {
-        this.alertService.open(String(day)).subscribe();
+        this.alerts.open(String(day)).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/data-list/examples/2/index.ts
+++ b/projects/demo/src/modules/components/data-list/examples/2/index.ts
@@ -16,12 +16,10 @@ export class TuiDataListExample2 {
     readonly burgers = ['Classic', 'Cheeseburger', 'Royal Cheeseburger'];
     readonly drinks = ['Cola', 'Tea', 'Coffee', 'Slurm'];
 
-    constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
-    ) {}
+    constructor(@Inject(TuiDialogService) private readonly dialogs: TuiDialogService) {}
 
     selectOption(item: string): void {
         this.dropdownOpen = false;
-        this.dialogService.open(`You selected ${item}`).subscribe();
+        this.dialogs.open(`You selected ${item}`).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/dialog/dialog.component.ts
+++ b/projects/demo/src/modules/components/dialog/dialog.component.ts
@@ -143,17 +143,17 @@ export class ExampleTuiDialogComponent {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
         @Inject(TuiDialogService)
-        private readonly dialogService: TuiDialogService,
+        private readonly dialogs: TuiDialogService,
     ) {}
 
     showDialog(content: TemplateRef<TuiDialogContext<number, number>>): void {
         const {data, label, required, closeable, dismissible, size} = this;
 
-        this.dialogService
+        this.dialogs
             .open(content, {data, label, required, closeable, dismissible, size})
-            .pipe(switchMap(response => this.alertService.open(String(response))))
+            .pipe(switchMap(response => this.alerts.open(String(response))))
             .subscribe();
     }
 }

--- a/projects/demo/src/modules/components/dialog/examples/1/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/1/index.ts
@@ -10,18 +10,16 @@ import {TuiDialogService} from '@taiga-ui/core';
     encapsulation,
 })
 export class TuiDialogExampleComponent1 {
-    constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
-    ) {}
+    constructor(@Inject(TuiDialogService) private readonly dialogs: TuiDialogService) {}
 
     showDialog(): void {
-        this.dialogService
+        this.dialogs
             .open('This is a plain string dialog', {label: 'Heading', size: 's'})
             .subscribe();
     }
 
     showDialogWithCustomButton(): void {
-        this.dialogService
+        this.dialogs
             .open('Good, Anakin, Good!', {
                 label: 'Star wars. Episode III',
                 size: 's',

--- a/projects/demo/src/modules/components/dialog/examples/2/dialog-example/dialog-example.component.ts
+++ b/projects/demo/src/modules/components/dialog/examples/2/dialog-example/dialog-example.component.ts
@@ -15,7 +15,7 @@ export class DialogExampleComponent {
     items = [10, 50, 100];
 
     constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+        @Inject(TuiDialogService) private readonly dialogs: TuiDialogService,
         @Inject(POLYMORPHEUS_CONTEXT)
         private readonly context: TuiDialogContext<number, number>,
     ) {}
@@ -35,6 +35,6 @@ export class DialogExampleComponent {
     }
 
     showDialog(content: TemplateRef<TuiDialogContext>): void {
-        this.dialogService.open(content, {dismissible: true}).subscribe();
+        this.dialogs.open(content, {dismissible: true}).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/dialog/examples/2/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/2/index.ts
@@ -13,7 +13,7 @@ import {DialogExampleComponent} from './dialog-example/dialog-example.component'
     encapsulation,
 })
 export class TuiDialogExampleComponent2 {
-    private readonly dialog = this.dialogService.open<number>(
+    private readonly dialog = this.dialogs.open<number>(
         new PolymorpheusComponent(DialogExampleComponent, this.injector),
         {
             data: 237,
@@ -23,7 +23,7 @@ export class TuiDialogExampleComponent2 {
     );
 
     constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+        @Inject(TuiDialogService) private readonly dialogs: TuiDialogService,
         @Inject(Injector) private readonly injector: Injector,
     ) {}
 

--- a/projects/demo/src/modules/components/dialog/examples/3/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/3/index.ts
@@ -13,12 +13,10 @@ import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 export class TuiDialogExampleComponent3 {
     money = 1000;
 
-    constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
-    ) {}
+    constructor(@Inject(TuiDialogService) private readonly dialogs: TuiDialogService) {}
 
     showDialog(content: PolymorpheusContent<TuiDialogContext>): void {
-        this.dialogService.open(content).subscribe();
+        this.dialogs.open(content).subscribe();
     }
 
     withdraw(): void {

--- a/projects/demo/src/modules/components/dialog/examples/4/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/4/index.ts
@@ -18,7 +18,7 @@ export class TuiDialogExampleComponent4 {
     scale = 1;
 
     constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+        @Inject(TuiDialogService) private readonly dialogs: TuiDialogService,
         @Inject(TuiDropdownPortalService)
         private readonly portalService: TuiDropdownPortalService,
     ) {}
@@ -37,7 +37,7 @@ export class TuiDialogExampleComponent4 {
 
     onFilterClick(): void {
         this.filters = true;
-        this.dialogService.open('Dialog with filters').subscribe({
+        this.dialogs.open('Dialog with filters').subscribe({
             complete: () => {
                 this.filters = false;
             },
@@ -50,7 +50,7 @@ export class TuiDialogExampleComponent4 {
     ): void {
         const templateRef = this.portalService.addTemplate(button);
 
-        this.dialogService.open(content).subscribe({
+        this.dialogs.open(content).subscribe({
             complete: () => {
                 this.portalService.removeTemplate(templateRef);
             },

--- a/projects/demo/src/modules/components/dialog/examples/5/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/5/index.ts
@@ -12,16 +12,14 @@ import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
     encapsulation,
 })
 export class TuiDialogExampleComponent5 {
-    constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
-    ) {}
+    constructor(@Inject(TuiDialogService) private readonly dialogs: TuiDialogService) {}
 
     onClick(
         content: PolymorpheusContent<TuiDialogContext>,
         header: PolymorpheusContent,
         size: TuiDialogSize,
     ): void {
-        this.dialogService
+        this.dialogs
             .open(content, {
                 label: 'What a cool library set',
                 header,

--- a/projects/demo/src/modules/components/dialog/examples/7/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/7/index.ts
@@ -14,12 +14,12 @@ import {SearchDialogExampleComponent} from './search-example/search-dialog-examp
 })
 export class TuiDialogExampleComponent7 {
     constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+        @Inject(TuiDialogService) private readonly dialogs: TuiDialogService,
         @Inject(Injector) private readonly injector: Injector,
     ) {}
 
     showDialog(): void {
-        this.dialogService
+        this.dialogs
             .open(
                 new PolymorpheusComponent(SearchDialogExampleComponent, this.injector),
                 {

--- a/projects/demo/src/modules/components/dialog/examples/8/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/8/index.ts
@@ -17,7 +17,7 @@ export class TuiDialogExampleComponent8 {
 
     constructor(
         @Inject(TuiDialogFormService) private readonly dialogForm: TuiDialogFormService,
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+        @Inject(TuiDialogService) private readonly dialogs: TuiDialogService,
     ) {}
 
     onModelChange(value: string): void {
@@ -33,7 +33,7 @@ export class TuiDialogExampleComponent8 {
             },
         });
 
-        this.dialogService.open(content, {closeable, dismissible: closeable}).subscribe({
+        this.dialogs.open(content, {closeable, dismissible: closeable}).subscribe({
             complete: () => {
                 this.value = '';
                 this.dialogForm.markAsPristine();

--- a/projects/demo/src/modules/components/dialog/examples/9/index.ts
+++ b/projects/demo/src/modules/components/dialog/examples/9/index.ts
@@ -21,12 +21,12 @@ export class TuiDialogExampleComponent9 {
     readonly amountControl = new FormControl(100);
 
     constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+        @Inject(TuiDialogService) private readonly dialogs: TuiDialogService,
         @Self() @Inject(TuiDestroyService) private readonly destroy$: TuiDestroyService,
     ) {}
 
     payByCard(): void {
-        this.dialogService
+        this.dialogs
             .open(new PolymorpheusComponent(PayModalComponent), {
                 size: 'auto',
                 closeable: true,

--- a/projects/demo/src/modules/components/dialog/examples/import/lazy-module.md
+++ b/projects/demo/src/modules/components/dialog/examples/import/lazy-module.md
@@ -12,12 +12,12 @@ import {MyDialogComponent} from './my-dialog.component.ts';
 export class MyComponent {
   constructor(
     @Inject(Injector) private readonly injector: Injector,
-    @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+    @Inject(TuiDialogService) private readonly dialogs: TuiDialogService,
   ) {}
 
   // ...
   open() {
-    this.dialogService
+    this.dialogs
       .open(
         // this.injector is optional
         new PolymorpheusComponent(MyDialogComponent, this.injector),

--- a/projects/demo/src/modules/components/dialog/examples/import/service-usage.md
+++ b/projects/demo/src/modules/components/dialog/examples/import/service-usage.md
@@ -7,13 +7,13 @@ import {TuiDialogService} from '@taiga-ui/core';
 export class MyComponent {
   constructor(
     @Inject(TuiDialogService)
-    private readonly dialogService: TuiDialogService,
+    private readonly dialogs: TuiDialogService,
   ) {}
 
   // ...
 
   open() {
-    this.dialogService.open('Hello!').subscribe();
+    this.dialogs.open('Hello!').subscribe();
   }
 }
 ```

--- a/projects/demo/src/modules/components/editor/images/preview/examples/1/image-preview/image-preview.component.ts
+++ b/projects/demo/src/modules/components/editor/images/preview/examples/1/image-preview/image-preview.component.ts
@@ -19,11 +19,11 @@ export class ImagePreviewExampleComponent {
 
     constructor(
         @Inject(TuiPreviewDialogService)
-        private readonly dialogService: TuiPreviewDialogService,
+        private readonly dialogs: TuiPreviewDialogService,
     ) {}
 
     showImage(image: HTMLImageElement): void {
         this.image = image;
-        this.dialogService.open(this.template || '').subscribe();
+        this.dialogs.open(this.template || '').subscribe();
     }
 }

--- a/projects/demo/src/modules/components/editor/images/upload/examples/1/index.ts
+++ b/projects/demo/src/modules/components/editor/images/upload/examples/1/index.ts
@@ -63,7 +63,7 @@ export class TuiEditorUploadingImagesExample1 {
     control = new FormControl('');
 
     constructor(
-        @Inject(DOCUMENT) readonly documentRef: Document,
+        @Inject(DOCUMENT) readonly doc: Document,
         @Inject(ImgbbService) readonly imgbbService: ImgbbService,
     ) {
         this.control.patchValue(
@@ -77,7 +77,7 @@ export class TuiEditorUploadingImagesExample1 {
     readonly validator = ({value}: AbstractControl): ValidationErrors | null =>
         this.editor.focused ||
         this.imgbbService.isLoading ||
-        !this.documentRef.hasFocus() || // possible that file dialog is open
+        !this.doc.hasFocus() || // possible that file dialog is open
         value.length
             ? null
             : {

--- a/projects/demo/src/modules/components/expand/expand.component.ts
+++ b/projects/demo/src/modules/components/expand/expand.component.ts
@@ -27,9 +27,7 @@ export class ExampleTuiExpandComponent {
 
     delayed = false;
 
-    constructor(
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
-    ) {}
+    constructor(@Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef) {}
 
     onExpandedChange(expanded: boolean): void {
         this.expanded = expanded;
@@ -43,7 +41,7 @@ export class ExampleTuiExpandComponent {
             const event = new CustomEvent(TUI_EXPAND_LOADED, {bubbles: true});
 
             this.delayed = false;
-            this.changeDetectorRef.detectChanges();
+            this.cdr.detectChanges();
 
             if (this.expand) {
                 this.expand.nativeElement.dispatchEvent(event);

--- a/projects/demo/src/modules/components/filter/filter.component.ts
+++ b/projects/demo/src/modules/components/filter/filter.component.ts
@@ -86,10 +86,10 @@ export class ExampleTuiFilterComponent {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     onToggledItemChange(item: unknown): void {
-        this.alertService.open(String(item)).subscribe();
+        this.alerts.open(String(item)).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/hosted-dropdown/examples/5/accessor.ts
+++ b/projects/demo/src/modules/components/hosted-dropdown/examples/5/accessor.ts
@@ -8,14 +8,12 @@ import {tuiAsPositionAccessor, TuiPoint, TuiPositionAccessor} from '@taiga-ui/co
 export class TopRightDirective extends TuiPositionAccessor {
     readonly type = `dropdown`;
 
-    constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
-    ) {
+    constructor(@Inject(ElementRef) private readonly el: ElementRef<HTMLElement>) {
         super();
     }
 
     getPosition({height}: ClientRect): TuiPoint {
-        const {right, top} = this.elementRef.nativeElement.getBoundingClientRect();
+        const {right, top} = this.el.nativeElement.getBoundingClientRect();
 
         return [top - height, right];
     }

--- a/projects/demo/src/modules/components/input-card-grouped/input-card-grouped.component.ts
+++ b/projects/demo/src/modules/components/input-card-grouped/input-card-grouped.component.ts
@@ -74,7 +74,7 @@ export class ExampleTuiInputCardGroupedComponent extends AbstractExampleTuiInter
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {
         super();
     }
@@ -98,7 +98,7 @@ export class ExampleTuiInputCardGroupedComponent extends AbstractExampleTuiInter
     }
 
     onBinChange(bin: string | null): void {
-        this.alertService.open(`bin: ${bin}`).subscribe();
+        this.alerts.open(`bin: ${bin}`).subscribe();
     }
 
     getContentVariants(

--- a/projects/demo/src/modules/components/input-card/input-card.component.ts
+++ b/projects/demo/src/modules/components/input-card/input-card.component.ts
@@ -75,7 +75,7 @@ export class ExampleTuiInputCardComponent extends AbstractExampleTuiControl {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {
         super();
     }
@@ -123,6 +123,6 @@ export class ExampleTuiInputCardComponent extends AbstractExampleTuiControl {
     }
 
     onBinChange(bin: string | null): void {
-        this.alertService.open(`bin: ${bin}`).subscribe();
+        this.alerts.open(`bin: ${bin}`).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/input-inline/examples/2/component.ts
+++ b/projects/demo/src/modules/components/input-inline/examples/2/component.ts
@@ -16,7 +16,7 @@ export class TuiInputInlineExample2 {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     toggle(): void {
@@ -31,6 +31,6 @@ export class TuiInputInlineExample2 {
     }
 
     private saveHeading(newHeading: string): void {
-        this.alertService.open(newHeading, {label: `New heading`}).subscribe();
+        this.alerts.open(newHeading, {label: `New heading`}).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/line-clamp/examples/3/index.ts
+++ b/projects/demo/src/modules/components/line-clamp/examples/3/index.ts
@@ -11,10 +11,10 @@ import {WINDOW} from '@ng-web-apis/common';
     encapsulation,
 })
 export class TuiLineClampExample3 {
-    constructor(@Inject(WINDOW) private readonly windowRef: Window) {}
+    constructor(@Inject(WINDOW) private readonly win: Window) {}
 
     getDynamicLineHeight(element: HTMLDivElement): number {
-        return parseInt(this.windowRef.getComputedStyle(element).lineHeight, 10);
+        return parseInt(this.win.getComputedStyle(element).lineHeight, 10);
     }
 
     getDynamicLineLimit(element: HTMLDivElement): number {

--- a/projects/demo/src/modules/components/mobile-calendar/examples/1/index.ts
+++ b/projects/demo/src/modules/components/mobile-calendar/examples/1/index.ts
@@ -29,7 +29,7 @@ export class TuiMobileCalendarExample1 {
     );
 
     constructor(
-        @Inject(TuiDialogService) dialogService: TuiDialogService,
+        @Inject(TuiDialogService) dialogs: TuiDialogService,
         @Inject(Injector) injector: Injector,
         @Inject(TUI_MONTHS) private readonly months: Observable<string[]>,
     ) {
@@ -48,7 +48,7 @@ export class TuiMobileCalendarExample1 {
             computedInjector,
         );
 
-        this.dialog$ = dialogService.open(content, {
+        this.dialog$ = dialogs.open(content, {
             size: 'fullscreen',
             closeable: false,
             data: {

--- a/projects/demo/src/modules/components/mobile-dialog/examples/1/index.ts
+++ b/projects/demo/src/modules/components/mobile-dialog/examples/1/index.ts
@@ -21,15 +21,15 @@ import {switchMap} from 'rxjs/operators';
 export class TuiMobileDialogExample1 {
     constructor(
         @Inject(TuiMobileDialogService)
-        private readonly dialogService: TuiMobileDialogService,
+        private readonly dialogs: TuiMobileDialogService,
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     show(): void {
         const actions = ['No thanks', 'Remind me later', 'Rate now'];
 
-        this.dialogService
+        this.dialogs
             .open(
                 'If you like this app, please take a moment to leave a positive rating.',
                 {
@@ -37,9 +37,7 @@ export class TuiMobileDialogExample1 {
                     actions,
                 },
             )
-            .pipe(
-                switchMap(index => this.alertService.open(`Selected: ${actions[index]}`)),
-            )
+            .pipe(switchMap(index => this.alerts.open(`Selected: ${actions[index]}`)))
             .subscribe();
     }
 }

--- a/projects/demo/src/modules/components/mobile-dialog/examples/import/insert-component.md
+++ b/projects/demo/src/modules/components/mobile-dialog/examples/import/insert-component.md
@@ -1,9 +1,9 @@
 ```ts
-constructor(private readonly dialogsService: TuiMobileDialogService) {}
+constructor(private readonly dialogs: TuiMobileDialogService) {}
 
 // ...
 
-this.dialogsService
+this.dialogs
     .open(
         'Text',
         {

--- a/projects/demo/src/modules/components/multi-select/examples/9/index.ts
+++ b/projects/demo/src/modules/components/multi-select/examples/9/index.ts
@@ -23,14 +23,12 @@ export class TuiMultiSelectExample9 {
         'Yoda',
     ];
 
-    constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
-    ) {}
+    constructor(@Inject(TuiDialogService) private readonly dialogs: TuiDialogService) {}
 
     showDialog(
         content: PolymorpheusContent<TuiDialogContext>,
         textFieldSize: TuiSizeL | TuiSizeS,
     ): void {
-        this.dialogService.open(content, {data: {textFieldSize}}).subscribe();
+        this.dialogs.open(content, {data: {textFieldSize}}).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/pdf-viewer/examples/2/index.ts
+++ b/projects/demo/src/modules/components/pdf-viewer/examples/2/index.ts
@@ -28,7 +28,7 @@ export type Buttons = ReadonlyArray<
 export class TuiPdfViewerExample2 {
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
         @Inject(TuiPdfViewerService) private readonly pdfService: TuiPdfViewerService,
     ) {}
 
@@ -50,7 +50,7 @@ export class TuiPdfViewerExample2 {
 
         this.pdfService
             .open<string>(new PolymorpheusComponent(PdfContentComponent), options)
-            .pipe(switchMap(response => this.alertService.open(response)))
+            .pipe(switchMap(response => this.alerts.open(response)))
             .subscribe();
     }
 }

--- a/projects/demo/src/modules/components/preview/examples/1/index.ts
+++ b/projects/demo/src/modules/components/preview/examples/1/index.ts
@@ -27,7 +27,7 @@ export class TuiPreviewExample1 {
         @Inject(TuiPreviewDialogService)
         private readonly previewService: TuiPreviewDialogService,
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     get title(): string {
@@ -47,11 +47,11 @@ export class TuiPreviewExample1 {
     }
 
     download(): void {
-        this.alertService.open('Downloading...').subscribe();
+        this.alerts.open('Downloading...').subscribe();
     }
 
     delete(): void {
-        this.alertService.open('Deleting...').subscribe();
+        this.alerts.open('Deleting...').subscribe();
     }
 
     onSwipe(swipe: TuiSwipe): void {

--- a/projects/demo/src/modules/components/primitive-textfield/examples/1/index.ts
+++ b/projects/demo/src/modules/components/primitive-textfield/examples/1/index.ts
@@ -30,9 +30,9 @@ export class TuiPrimitiveTextfieldExample1 extends AbstractTuiControl<string> {
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {

--- a/projects/demo/src/modules/components/primitive-textfield/examples/2/index.ts
+++ b/projects/demo/src/modules/components/primitive-textfield/examples/2/index.ts
@@ -31,9 +31,9 @@ export class TuiPrimitiveTextfieldExample2 extends AbstractTuiControl<string> {
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {

--- a/projects/demo/src/modules/components/pull-to-refresh/examples/1/index.ts
+++ b/projects/demo/src/modules/components/pull-to-refresh/examples/1/index.ts
@@ -31,11 +31,11 @@ const loaded$ = new Subject<void>();
 export class TuiPullToRefreshExample1 {
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     onPull(): void {
-        this.alertService.open('Loading...').subscribe();
+        this.alerts.open('Loading...').subscribe();
     }
 
     finishLoading(): void {

--- a/projects/demo/src/modules/components/pull-to-refresh/examples/2/index.ts
+++ b/projects/demo/src/modules/components/pull-to-refresh/examples/2/index.ts
@@ -31,11 +31,11 @@ const loaded$ = new Subject<void>();
 export class TuiPullToRefreshExample2 {
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     onPull(): void {
-        this.alertService.open('Loading...').subscribe();
+        this.alerts.open('Loading...').subscribe();
     }
 
     finishLoading(): void {

--- a/projects/demo/src/modules/components/select/examples/4/index.ts
+++ b/projects/demo/src/modules/components/select/examples/4/index.ts
@@ -26,11 +26,11 @@ export class TuiSelectExample4 {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     addMore(select: TuiSelectComponent<unknown>): void {
         select.handleOption(select.value);
-        this.alertService.open('Add more is clicked').subscribe();
+        this.alerts.open('Add more is clicked').subscribe();
     }
 }

--- a/projects/demo/src/modules/components/tabs/examples/3/index.ts
+++ b/projects/demo/src/modules/components/tabs/examples/3/index.ts
@@ -14,10 +14,10 @@ export class TuiTabsExample3 {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     onClick(item: string): void {
-        this.alertService.open(item).subscribe();
+        this.alerts.open(item).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/tabs/examples/4/index.ts
+++ b/projects/demo/src/modules/components/tabs/examples/4/index.ts
@@ -14,10 +14,10 @@ export class TuiTabsExample4 {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     onClick(item: string): void {
-        this.alertService.open(item).subscribe();
+        this.alerts.open(item).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/tabs/examples/6/index.ts
+++ b/projects/demo/src/modules/components/tabs/examples/6/index.ts
@@ -15,12 +15,9 @@ export class TuiTabsExample6 {
 
     readonly steps = ['Sales', 'Settings', 'News'];
 
-    constructor(
-        @Inject(TuiAlertService)
-        private readonly notifications: TuiAlertService,
-    ) {}
+    constructor(@Inject(TuiAlertService) private readonly alerts: TuiAlertService) {}
 
     onClick(item: string): void {
-        this.notifications.open(item).subscribe();
+        this.alerts.open(item).subscribe();
     }
 }

--- a/projects/demo/src/modules/components/tooltip/examples/1/index.ts
+++ b/projects/demo/src/modules/components/tooltip/examples/1/index.ts
@@ -20,10 +20,10 @@ export class TuiTooltipExample1 {
 
     constructor(
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
         interval(2000)
-            .pipe(tuiWatch(changeDetectorRef), takeUntil(destroy$))
+            .pipe(tuiWatch(cdr), takeUntil(destroy$))
             .subscribe(() => {
                 this.loader = !this.loader;
                 this.text = this.text ? '' : 'Error 502: Bad Gateway';

--- a/projects/demo/src/modules/customization/dialogs/examples/1/index.ts
+++ b/projects/demo/src/modules/customization/dialogs/examples/1/index.ts
@@ -15,7 +15,7 @@ import {PromptService} from './prompt/prompt.service';
 export class TuiDialogsExample1 {
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
         @Inject(PromptService) private readonly promptService: PromptService,
     ) {}
 
@@ -32,10 +32,10 @@ export class TuiDialogsExample1 {
             .pipe(
                 switchMap(response =>
                     response
-                        ? this.alertService.open(wisely, {
+                        ? this.alerts.open(wisely, {
                               status: TuiNotification.Success,
                           })
-                        : this.alertService.open(poorly, {
+                        : this.alerts.open(poorly, {
                               status: TuiNotification.Error,
                           }),
                 ),

--- a/projects/demo/src/modules/directives/copy-processor/examples/1/index.ts
+++ b/projects/demo/src/modules/directives/copy-processor/examples/1/index.ts
@@ -21,14 +21,12 @@ export class TuiCopyProcessorExample1 {
     constructor(
         @Inject(TUI_NUMBER_FORMAT) private readonly format: TuiNumberFormatSettings,
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     @HostListener('copy', ['$event'])
     onCopy(event: ClipboardEvent): void {
-        this.alertService
-            .open(event.clipboardData?.getData('text/plain') ?? '')
-            .subscribe();
+        this.alerts.open(event.clipboardData?.getData('text/plain') ?? '').subscribe();
     }
 
     readonly numberProcessor: TuiStringHandler<string> = text =>

--- a/projects/demo/src/modules/directives/dropdown-context/examples/2/index.ts
+++ b/projects/demo/src/modules/directives/dropdown-context/examples/2/index.ts
@@ -31,15 +31,11 @@ export class TuiDropdownContextExample2 {
 
     readonly moreOptions = ['Option 1', 'Option 2', 'Option 3'];
 
-    constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
-    ) {}
+    constructor(@Inject(TuiDialogService) private readonly dialogs: TuiDialogService) {}
 
     getObjectValues = (obj: Record<string, unknown>): unknown[] => Object.values(obj);
 
     printToConsole(action: string, contextInfo: unknown): void {
-        this.dialogService
-            .open(`[${action}]: ${JSON.stringify(contextInfo)}`)
-            .subscribe();
+        this.dialogs.open(`[${action}]: ${JSON.stringify(contextInfo)}`).subscribe();
     }
 }

--- a/projects/demo/src/modules/directives/dropdown/examples/3/index.ts
+++ b/projects/demo/src/modules/directives/dropdown/examples/3/index.ts
@@ -22,10 +22,10 @@ export class TuiDropdownExample3 {
 
     constructor(
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
         interval(3000)
-            .pipe(tuiWatch(changeDetectorRef), takeUntil(destroy$))
+            .pipe(tuiWatch(cdr), takeUntil(destroy$))
             .subscribe(() => {
                 this.showBigText = !this.showBigText;
             });

--- a/projects/demo/src/modules/directives/let/examples/2/index.ts
+++ b/projects/demo/src/modules/directives/let/examples/2/index.ts
@@ -12,11 +12,11 @@ import {TuiAlertService} from '@taiga-ui/core';
 export class TuiLetExample2 {
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     get getter(): string {
-        this.alertService.open('Getter called').subscribe();
+        this.alerts.open('Getter called').subscribe();
 
         return '🐳';
     }

--- a/projects/demo/src/modules/directives/value-changes/value-changes.component.ts
+++ b/projects/demo/src/modules/directives/value-changes/value-changes.component.ts
@@ -21,6 +21,4 @@ export class ExampleTuiValueChangesComponent {
         TypeScript: import('./examples/2/index.ts?raw'),
         HTML: import('./examples/2/index.html?raw'),
     };
-
-    readonly elementRefText = '{read: ElementRef}';
 }

--- a/projects/demo/src/modules/markup/colors/table/table.component.ts
+++ b/projects/demo/src/modules/markup/colors/table/table.component.ts
@@ -15,9 +15,7 @@ import {Color} from '../colors.constants';
     changeDetection,
 })
 export class TableComponent {
-    private readonly styles = this.windowRef.getComputedStyle(
-        this.documentRef.documentElement,
-    );
+    private readonly styles = this.win.getComputedStyle(this.doc.documentElement);
 
     @Input()
     colors: readonly Color[] = [];
@@ -30,8 +28,8 @@ export class TableComponent {
 
     constructor(
         @Inject(TuiThemeService) private readonly themeService: Observable<string>,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
-        @Inject(WINDOW) private readonly windowRef: Window,
+        @Inject(DOCUMENT) private readonly doc: Document,
+        @Inject(WINDOW) private readonly win: Window,
     ) {}
 
     getValue(variable: string): string {

--- a/projects/demo/src/modules/markup/icons/icons-group/icons-group.component.ts
+++ b/projects/demo/src/modules/markup/icons/icons-group/icons-group.component.ts
@@ -25,12 +25,12 @@ export class IconsGroupComponent {
 
     constructor(
         @Inject(Clipboard) private readonly clipboard: Clipboard,
-        @Inject(TuiAlertService) private readonly alertService: TuiAlertService,
+        @Inject(TuiAlertService) private readonly alerts: TuiAlertService,
     ) {}
 
     copyPath = (name: string): void => {
         this.clipboard.copy(name);
-        this.alertService
+        this.alerts
             .open(`The name ${name} copied`, {status: TuiNotification.Success})
             .subscribe();
     };

--- a/projects/demo/src/modules/services/alerts/alerts.component.ts
+++ b/projects/demo/src/modules/services/alerts/alerts.component.ts
@@ -131,7 +131,7 @@ export class ExampleTuiAlertsComponent {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
         @Inject(Injector) injector: Injector,
     ) {
         this.component = new PolymorpheusComponent(
@@ -147,7 +147,7 @@ export class ExampleTuiAlertsComponent {
     }
 
     showNotification(): void {
-        this.alertService
+        this.alerts
             .open(this.selectedContent, {
                 label: this.label,
                 data: this.data,
@@ -158,7 +158,7 @@ export class ExampleTuiAlertsComponent {
             })
             .pipe(
                 switchMap(response =>
-                    this.alertService.open(response, {
+                    this.alerts.open(response, {
                         label: 'Notification responded with:',
                     }),
                 ),

--- a/projects/demo/src/modules/services/alerts/examples/1/index.ts
+++ b/projects/demo/src/modules/services/alerts/examples/1/index.ts
@@ -12,10 +12,10 @@ import {TuiAlertService} from '@taiga-ui/core';
 export class TuiAlertsExampleComponent1 {
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     showNotification(): void {
-        this.alertService.open('A simple option', {label: 'With a heading!'}).subscribe();
+        this.alerts.open('A simple option', {label: 'With a heading!'}).subscribe();
     }
 }

--- a/projects/demo/src/modules/services/alerts/examples/2/index.ts
+++ b/projects/demo/src/modules/services/alerts/examples/2/index.ts
@@ -21,11 +21,11 @@ export class TuiAlertsExampleComponent2 {
 
     constructor(
         @Inject(TuiAlertService)
-        private readonly alertService: TuiAlertService,
+        private readonly alerts: TuiAlertService,
     ) {}
 
     showWithdrawAlert(): void {
-        this.alertService
+        this.alerts
             .open(this.withdrawTemplate || '', {
                 label: 'A template sample',
                 status: TuiNotification.Warning,
@@ -35,7 +35,7 @@ export class TuiAlertsExampleComponent2 {
     }
 
     showDepositAlert(): void {
-        this.alertService
+        this.alerts
             .open(this.depositTemplate || '', {
                 label: 'A template sample',
                 status: TuiNotification.Success,

--- a/projects/demo/src/modules/services/alerts/examples/3/index.ts
+++ b/projects/demo/src/modules/services/alerts/examples/3/index.ts
@@ -19,11 +19,11 @@ export class TuiAlertsExampleComponent3 {
     readonly notification: Observable<void>;
 
     constructor(
-        @Inject(TuiAlertService) alertService: TuiAlertService,
+        @Inject(TuiAlertService) alerts: TuiAlertService,
         @Inject(Router) router: Router,
         @Inject(Injector) private readonly injector: Injector,
     ) {
-        this.notification = alertService
+        this.notification = alerts
             .open<boolean>(
                 new PolymorpheusComponent(AlertExampleComponent, this.injector),
                 {
@@ -34,7 +34,7 @@ export class TuiAlertsExampleComponent3 {
             )
             .pipe(
                 switchMap(response =>
-                    alertService.open(`Got a value — ${response}`, {
+                    alerts.open(`Got a value — ${response}`, {
                         label: 'Information',
                     }),
                 ),

--- a/projects/demo/src/modules/services/alerts/examples/4/index.ts
+++ b/projects/demo/src/modules/services/alerts/examples/4/index.ts
@@ -19,11 +19,11 @@ export class TuiAlertsExampleComponent4 {
     readonly notification: Observable<void>;
 
     constructor(
-        @Inject(TuiAlertService) alertService: TuiAlertService,
+        @Inject(TuiAlertService) alerts: TuiAlertService,
         @Inject(Router) router: Router,
         @Inject(Injector) private readonly injector: Injector,
     ) {
-        this.notification = alertService
+        this.notification = alerts
             .open<number>(
                 new PolymorpheusComponent(AlertExampleWithDataComponent, this.injector),
                 {
@@ -35,7 +35,7 @@ export class TuiAlertsExampleComponent4 {
             )
             .pipe(
                 switchMap(response =>
-                    alertService.open(`Got a value — ${response}`, {
+                    alerts.open(`Got a value — ${response}`, {
                         label: 'Information',
                     }),
                 ),

--- a/projects/demo/src/modules/services/alerts/examples/5/index.ts
+++ b/projects/demo/src/modules/services/alerts/examples/5/index.ts
@@ -22,11 +22,11 @@ export class TuiAlertsExampleComponent5 {
     readonly notificationWithCustomLabel: Observable<void>;
 
     constructor(
-        @Inject(TuiAlertService) alertService: TuiAlertService,
+        @Inject(TuiAlertService) alerts: TuiAlertService,
         @Inject(Router) router: Router,
         @Inject(Injector) private readonly injector: Injector,
     ) {
-        this.notification = alertService
+        this.notification = alerts
             .open(
                 new PolymorpheusComponent(
                     AlertExampleWithCustomLabelComponent,
@@ -43,7 +43,7 @@ export class TuiAlertsExampleComponent5 {
             )
             .pipe(takeUntil(router.events));
 
-        this.notificationWithCustomLabel = alertService
+        this.notificationWithCustomLabel = alerts
             .open(
                 new PolymorpheusComponent(
                     AlertExampleWithCustomLabelComponent,

--- a/projects/demo/src/modules/services/alerts/examples/import/lazy-module.md
+++ b/projects/demo/src/modules/services/alerts/examples/import/lazy-module.md
@@ -9,10 +9,10 @@ import {CustomNotificationComponent} from './custom-notification.component';
 export class MyComponent {
   constructor(
     @Inject(Injector) private injector: Injector,
-    @Inject(TuiAlertService) private readonly alertService: TuiAlertService,
+    @Inject(TuiAlertService) private readonly alerts: TuiAlertService,
   ) {
     //...
-    this.alertService
+    this.alerts
       .open(new PolymorpheusComponent(CustomNotificationComponent, this.injector), {label: 'Heading'})
       .subscribe();
   }

--- a/projects/demo/src/modules/services/alerts/examples/import/service-usage-component.md
+++ b/projects/demo/src/modules/services/alerts/examples/import/service-usage-component.md
@@ -5,10 +5,10 @@ import {CustomNotificationComponent} from './custom-notification.component';
 //...
 
 export class MyComponent {
-  constructor(@Inject(TuiAlertService) private readonly alertService: TuiAlertService) {
+  constructor(@Inject(TuiAlertService) private readonly alerts: TuiAlertService) {
     //...
 
-    this.alertService.open(new PolymorpheusComponent(CustomNotificationComponent)).subscribe({
+    this.alerts.open(new PolymorpheusComponent(CustomNotificationComponent)).subscribe({
       complete: () => {
         console.log('Notification is closed');
       },

--- a/projects/demo/src/modules/services/alerts/examples/import/service-usage.md
+++ b/projects/demo/src/modules/services/alerts/examples/import/service-usage.md
@@ -3,10 +3,10 @@ import {TuiAlertService} from '@taiga-ui/core';
 //...
 
 export class MyComponent {
-  constructor(@Inject(TuiAlertService) private readonly alertService: TuiAlertService) {
+  constructor(@Inject(TuiAlertService) private readonly alerts: TuiAlertService) {
     //...
 
-    this.alertService.open('Notification').subscribe({
+    this.alerts.open('Notification').subscribe({
       complete: () => {
         console.log('Notification is closed');
       },

--- a/projects/demo/src/modules/utils/browser/examples/1/index.ts
+++ b/projects/demo/src/modules/utils/browser/examples/1/index.ts
@@ -13,7 +13,7 @@ import {tuiIsEdge, tuiIsEdgeOlderThan, tuiIsFirefox, tuiIsSafari} from '@taiga-u
 export class TuiBrowserExample1 {
     constructor(
         @Inject(USER_AGENT) private readonly userAgent: string,
-        @Inject(ElementRef) private readonly elementRef: ElementRef,
+        @Inject(ElementRef) private readonly el: ElementRef,
     ) {}
 
     get aboutMyBrowser(): string {
@@ -27,7 +27,7 @@ export class TuiBrowserExample1 {
             return 'Okay, you have Firefox!';
         }
 
-        if (tuiIsSafari(this.elementRef.nativeElement)) {
+        if (tuiIsSafari(this.el.nativeElement)) {
             return 'Okay, you have Safari!';
         }
 

--- a/projects/demo/src/modules/utils/tokens/examples/3/index.ts
+++ b/projects/demo/src/modules/utils/tokens/examples/3/index.ts
@@ -13,6 +13,6 @@ export class TuiTokensExample3 {
     constructor(
         @Optional()
         @Inject(TUI_FOCUSABLE_ITEM_ACCESSOR)
-        readonly tuiFocusableComponent: TuiFocusableElementAccessor | null,
+        readonly focusable: TuiFocusableElementAccessor | null,
     ) {}
 }

--- a/projects/kit/abstract/abstract-native-select.ts
+++ b/projects/kit/abstract/abstract-native-select.ts
@@ -22,7 +22,7 @@ export abstract class AbstractTuiNativeSelect<T = TuiTextfieldHost> {
     constructor(
         @Inject(TUI_TEXTFIELD_HOST) readonly host: T,
         @Inject(AbstractTuiControl) readonly control: AbstractTuiControl<unknown>,
-        @Inject(ElementRef) protected readonly elementRef: ElementRef<HTMLSelectElement>,
+        @Inject(ElementRef) protected readonly el: ElementRef<HTMLSelectElement>,
         @Inject(TuiIdService)
         private readonly idService: TuiIdService,
         @Inject(TUI_ITEMS_HANDLERS)
@@ -31,6 +31,6 @@ export abstract class AbstractTuiNativeSelect<T = TuiTextfieldHost> {
 
     @HostBinding(`id`)
     get id(): string {
-        return this.elementRef.nativeElement.id || this.idService.generate();
+        return this.el.nativeElement.id || this.idService.generate();
     }
 }

--- a/projects/kit/components/accordion/accordion-item/accordion-item-content.directive.ts
+++ b/projects/kit/components/accordion/accordion-item/accordion-item-content.directive.ts
@@ -11,8 +11,8 @@ export class TuiAccordionItemContentDirective extends PolymorpheusTemplate<
         @Inject(TemplateRef)
         @Self()
         templateRef: TemplateRef<Record<string, unknown>>,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
-        super(templateRef, changeDetectorRef);
+        super(templateRef, cdr);
     }
 }

--- a/projects/kit/components/accordion/accordion-item/accordion-item.component.ts
+++ b/projects/kit/components/accordion/accordion-item/accordion-item.component.ts
@@ -89,7 +89,7 @@ export class TuiAccordionItemComponent
     readonly lazyContent?: TuiAccordionItemContentDirective;
 
     constructor(
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
         @Inject(TUI_MODE) readonly mode$: Observable<TuiBrightness | null>,
     ) {
         super();
@@ -130,7 +130,7 @@ export class TuiAccordionItemComponent
 
     close(): void {
         this.updateOpen(false);
-        this.changeDetectorRef.markForCheck();
+        this.cdr.markForCheck();
     }
 
     private updateOpen(open: boolean): void {

--- a/projects/kit/components/action/action.component.ts
+++ b/projects/kit/components/action/action.component.ts
@@ -40,7 +40,7 @@ export class TuiActionComponent extends AbstractTuiInteractive {
 
     constructor(
         @Inject(TuiFocusVisibleService) focusVisible$: TuiFocusVisibleService,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
     ) {
         super();
 
@@ -50,7 +50,7 @@ export class TuiActionComponent extends AbstractTuiInteractive {
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {
-        return this.elementRef.nativeElement;
+        return this.el.nativeElement;
     }
 
     get focused(): boolean {

--- a/projects/kit/components/calendar-range/calendar-range.component.ts
+++ b/projects/kit/components/calendar-range/calendar-range.component.ts
@@ -94,7 +94,7 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
         @Optional()
         @Inject(TUI_CALENDAR_DATE_STREAM)
         valueChanges: Observable<TuiDayRange | null> | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
         @Inject(TUI_OTHER_DATE_TEXT) readonly otherDateText$: Observable<string>,
     ) {
@@ -102,11 +102,9 @@ export class TuiCalendarRangeComponent implements TuiWithOptionalMinMax<TuiDay> 
             return;
         }
 
-        valueChanges
-            .pipe(tuiWatch(changeDetectorRef), takeUntil(destroy$))
-            .subscribe(value => {
-                this.value = value;
-            });
+        valueChanges.pipe(tuiWatch(cdr), takeUntil(destroy$)).subscribe(value => {
+            this.value = value;
+        });
     }
 
     @HostListener('document:keydown.capture', ['$event'])

--- a/projects/kit/components/carousel/carousel-scroll.directive.ts
+++ b/projects/kit/components/carousel/carousel-scroll.directive.ts
@@ -7,20 +7,15 @@ import {filter, map, tap, throttleTime} from 'rxjs/operators';
 })
 export class TuiCarouselScrollDirective {
     @Output()
-    readonly tuiCarouselScroll = tuiTypedFromEvent(
-        this.elementRef.nativeElement,
-        'wheel',
-    ).pipe(
+    readonly tuiCarouselScroll = tuiTypedFromEvent(this.el.nativeElement, 'wheel').pipe(
         filter(({deltaX}) => Math.abs(deltaX) > 20),
         throttleTime(500),
         map(({deltaX}) => Math.sign(deltaX)),
         tap(() => {
             // So we always have space to scroll and overflow-behavior saves us from back nav
-            this.elementRef.nativeElement.scrollLeft = 10;
+            this.el.nativeElement.scrollLeft = 10;
         }),
     );
 
-    constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
-    ) {}
+    constructor(@Inject(ElementRef) private readonly el: ElementRef<HTMLElement>) {}
 }

--- a/projects/kit/components/carousel/carousel.component.ts
+++ b/projects/kit/components/carousel/carousel.component.ts
@@ -55,8 +55,8 @@ export class TuiCarouselComponent {
     transitioned = true;
 
     constructor(
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_IS_MOBILE) private readonly isMobile: boolean,
     ) {}
 
@@ -118,7 +118,7 @@ export class TuiCarouselComponent {
             return;
         }
 
-        const {clientWidth} = this.elementRef.nativeElement;
+        const {clientWidth} = this.el.nativeElement;
         const min = 1 - this.items.length / this.itemsCount;
 
         this.translate = tuiClamp(x / clientWidth + this.translate, min, 0);
@@ -147,6 +147,6 @@ export class TuiCarouselComponent {
     private updateIndex(index: number): void {
         this.index = tuiClamp(index, 0, this.items.length - 1);
         this.indexChange.emit(this.index);
-        this.changeDetectorRef.markForCheck();
+        this.cdr.markForCheck();
     }
 }

--- a/projects/kit/components/carousel/carousel.directive.ts
+++ b/projects/kit/components/carousel/carousel.directive.ts
@@ -16,16 +16,16 @@ export class TuiCarouselDirective extends Observable<unknown> {
     private readonly duration$ = new BehaviorSubject(0);
 
     private readonly running$ = merge(
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'mouseenter').pipe(
+        tuiTypedFromEvent(this.el.nativeElement, 'mouseenter').pipe(
             map(ALWAYS_FALSE_HANDLER),
         ),
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'touchstart').pipe(
+        tuiTypedFromEvent(this.el.nativeElement, 'touchstart').pipe(
             map(ALWAYS_FALSE_HANDLER),
         ),
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'touchend').pipe(
+        tuiTypedFromEvent(this.el.nativeElement, 'touchend').pipe(
             map(ALWAYS_TRUE_HANDLER),
         ),
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'mouseleave').pipe(
+        tuiTypedFromEvent(this.el.nativeElement, 'mouseleave').pipe(
             map(ALWAYS_TRUE_HANDLER),
         ),
         this.visible$,
@@ -49,7 +49,7 @@ export class TuiCarouselDirective extends Observable<unknown> {
     }
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(PAGE_VISIBILITY) private readonly visible$: Observable<boolean>,
     ) {
         super(subscriber => this.output$.subscribe(subscriber));

--- a/projects/kit/components/checkbox-block/checkbox-block.component.ts
+++ b/projects/kit/components/checkbox-block/checkbox-block.component.ts
@@ -65,12 +65,12 @@ export class TuiCheckboxBlockComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Optional()
         @Inject(TuiModeDirective)
         private readonly modeDirective: TuiModeDirective | null,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {

--- a/projects/kit/components/checkbox-labeled/checkbox-labeled.component.ts
+++ b/projects/kit/components/checkbox-labeled/checkbox-labeled.component.ts
@@ -55,14 +55,14 @@ export class TuiCheckboxLabeledComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Optional()
         @Inject(TuiModeDirective)
         private readonly modeDirective: TuiModeDirective | null,
         @Inject(TUI_CHECKBOX_OPTIONS)
         private readonly options: TuiCheckboxOptions,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get focused(): boolean {

--- a/projects/kit/components/checkbox/checkbox.component.ts
+++ b/projects/kit/components/checkbox/checkbox.component.ts
@@ -50,9 +50,9 @@ export class TuiCheckboxComponent
         control: NgControl | null,
         @Inject(TUI_CHECKBOX_OPTIONS)
         private readonly options: TuiCheckboxOptions,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {

--- a/projects/kit/components/combo-box/combo-box.component.ts
+++ b/projects/kit/components/combo-box/combo-box.component.ts
@@ -112,13 +112,13 @@ export class TuiComboBoxComponent<T>
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_ARROW_MODE)
         private readonly arrowMode: TuiArrowMode,
         @Inject(TUI_ITEMS_HANDLERS)
         private readonly itemsHandlers: TuiItemsHandlers<T>,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get arrow(): PolymorpheusContent<

--- a/projects/kit/components/elastic-container/elastic-container.directive.ts
+++ b/projects/kit/components/elastic-container/elastic-container.directive.ts
@@ -26,12 +26,12 @@ export class TuiElasticContainerDirective {
     @Output()
     readonly tuiElasticContainer = merge(this.resize$, this.mutation$).pipe(
         debounceTime(0),
-        map(() => this.elementRef.nativeElement.clientHeight),
+        map(() => this.el.nativeElement.clientHeight),
         distinctUntilChanged(),
     );
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(ResizeObserverService) private readonly resize$: Observable<unknown>,
         @Inject(MutationObserverService) private readonly mutation$: Observable<unknown>,
     ) {}

--- a/projects/kit/components/filter/filter.component.ts
+++ b/projects/kit/components/filter/filter.component.ts
@@ -60,10 +60,10 @@ export class TuiFilterComponent<T> extends AbstractTuiMultipleControl<T> {
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     @Input()
@@ -76,7 +76,7 @@ export class TuiFilterComponent<T> extends AbstractTuiMultipleControl<T> {
     badgeHandler: TuiHandler<T, number> = item => Number(item);
 
     get focused(): boolean {
-        return tuiIsNativeFocusedIn(this.elementRef.nativeElement);
+        return tuiIsNativeFocusedIn(this.el.nativeElement);
     }
 
     onCheckbox(value: boolean, item: T): void {

--- a/projects/kit/components/input-copy/input-copy.component.ts
+++ b/projects/kit/components/input-copy/input-copy.component.ts
@@ -69,13 +69,13 @@ export class TuiInputCopyComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
-        @Inject(DOCUMENT) private readonly documentRef: Document,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
+        @Inject(DOCUMENT) private readonly doc: Document,
         @Inject(TUI_TEXTFIELD_SIZE)
         private readonly textfieldSize: TuiTextfieldSizeDirective,
         @Inject(TUI_COPY_TEXTS) private readonly copyTexts$: Observable<[string, string]>,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     @HostBinding('class._has-value')
@@ -128,7 +128,7 @@ export class TuiInputCopyComponent
         }
 
         this.textfield.nativeFocusableElement.select();
-        this.documentRef.execCommand('copy');
+        this.doc.execCommand('copy');
         this.copy$.next();
     }
 

--- a/projects/kit/components/input-count/input-count.component.ts
+++ b/projects/kit/components/input-count/input-count.component.ts
@@ -93,7 +93,7 @@ export class TuiInputCountComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         private readonly textfieldController: TuiTextfieldController,
         @Inject(TUI_PLUS_MINUS_TEXTS)
@@ -104,7 +104,7 @@ export class TuiInputCountComponent
         @Inject(TUI_NUMBER_FORMAT)
         private readonly numberFormat: TuiNumberFormatSettings,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     @tuiPure

--- a/projects/kit/components/input-date-range/input-date-range.component.ts
+++ b/projects/kit/components/input-date-range/input-date-range.component.ts
@@ -136,10 +136,10 @@ export class TuiInputDateRangeComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(Injector) private readonly injector: Injector,
         @Inject(TUI_IS_MOBILE) private readonly isMobile: boolean,
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+        @Inject(TuiDialogService) private readonly dialogs: TuiDialogService,
         @Optional()
         @Inject(TUI_MOBILE_CALENDAR)
         private readonly mobileCalendar: Type<Record<string, any>> | null,
@@ -155,7 +155,7 @@ export class TuiInputDateRangeComponent
         @Inject(TUI_INPUT_DATE_OPTIONS)
         private readonly options: TuiInputDateOptions,
     ) {
-        super(control, changeDetectorRef, valueTransformer);
+        super(control, cdr, valueTransformer);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {
@@ -258,7 +258,7 @@ export class TuiInputDateRangeComponent
             return;
         }
 
-        this.dialogService
+        this.dialogs
             .open<TuiDayRange>(
                 new PolymorpheusComponent(this.mobileCalendar, this.injector),
                 {

--- a/projects/kit/components/input-date-time/input-date-time.component.ts
+++ b/projects/kit/components/input-date-time/input-date-time.component.ts
@@ -121,7 +121,7 @@ export class TuiInputDateTimeComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_TEXTFIELD_SIZE)
         private readonly textfieldSize: TuiTextfieldSizeDirective,
         @Inject(TUI_DATE_FORMAT) readonly dateFormat: TuiDateMode,
@@ -138,7 +138,7 @@ export class TuiInputDateTimeComponent
         @Inject(TUI_INPUT_DATE_OPTIONS)
         private readonly options: TuiInputDateOptions,
     ) {
-        super(control, changeDetectorRef, valueTransformer);
+        super(control, cdr, valueTransformer);
     }
 
     get fillerLength(): number {

--- a/projects/kit/components/input-date/input-date.component.ts
+++ b/projects/kit/components/input-date/input-date.component.ts
@@ -129,10 +129,10 @@ export class TuiInputDateComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(Injector) private readonly injector: Injector,
         @Inject(TUI_IS_MOBILE) readonly isMobile: boolean,
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+        @Inject(TuiDialogService) private readonly dialogs: TuiDialogService,
         @Optional()
         @Inject(TUI_MOBILE_CALENDAR)
         private readonly mobileCalendar: Type<Record<string, any>> | null,
@@ -148,7 +148,7 @@ export class TuiInputDateComponent
         @Inject(TUI_INPUT_DATE_OPTIONS)
         private readonly options: TuiInputDateOptions,
     ) {
-        super(control, changeDetectorRef, valueTransformer);
+        super(control, cdr, valueTransformer);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {
@@ -248,7 +248,7 @@ export class TuiInputDateComponent
             return;
         }
 
-        this.dialogService
+        this.dialogs
             .open<TuiDay>(new PolymorpheusComponent(this.mobileCalendar, this.injector), {
                 size: 'fullscreen',
                 closeable: false,

--- a/projects/kit/components/input-files/input-files.component.ts
+++ b/projects/kit/components/input-files/input-files.component.ts
@@ -108,7 +108,7 @@ export class TuiInputFilesComponent
         @Inject(NgControl)
         control: NgControl | null,
         @Inject(ChangeDetectorRef)
-        changeDetectorRef: ChangeDetectorRef,
+        cdr: ChangeDetectorRef,
         @Inject(TUI_IS_MOBILE)
         readonly isMobile: boolean,
         @Inject(TUI_INPUT_FILE_TEXTS)
@@ -128,7 +128,7 @@ export class TuiInputFilesComponent
         @Inject(TUI_INPUT_FILES_OPTIONS)
         readonly options: TuiInputFilesOptions,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get computedMultiple(): boolean {

--- a/projects/kit/components/input-files/input-files.directive.ts
+++ b/projects/kit/components/input-files/input-files.directive.ts
@@ -15,7 +15,7 @@ import {TUI_INPUT_FILES_OPTIONS, TuiInputFilesOptions} from './input-files.optio
 export class TuiInputFilesDirective {
     constructor(
         @Inject(TuiInputFilesComponent) readonly host: TuiInputFilesComponent,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLInputElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLInputElement>,
         @Inject(TuiIdService) private readonly idService: TuiIdService,
         @Inject(TUI_INPUT_FILES_OPTIONS) private readonly options: TuiInputFilesOptions,
     ) {}
@@ -27,24 +27,24 @@ export class TuiInputFilesDirective {
 
     @HostBinding('id')
     get id(): string {
-        return this.elementRef.nativeElement.id || this.idService.generate();
+        return this.el.nativeElement.id || this.idService.generate();
     }
 
     @HostBinding('accept')
     get accept(): TuiInputFilesOptions['accepts'] {
-        return this.elementRef.nativeElement.accept ?? this.options.accepts;
+        return this.el.nativeElement.accept ?? this.options.accepts;
     }
 
     @HostBinding('multiple')
     get multiple(): TuiInputFilesOptions['multiple'] {
-        return this.elementRef.nativeElement.multiple ?? this.options.multiple;
+        return this.el.nativeElement.multiple ?? this.options.multiple;
     }
 
     @HostBinding('capture')
     get capture(): TuiInputFilesOptions['capture'] {
         return (
             (
-                this.elementRef.nativeElement as HTMLInputElement & {
+                this.el.nativeElement as HTMLInputElement & {
                     capture: TuiInputFilesOptions['capture'];
                 }
             ).capture ?? this.options.capture
@@ -52,6 +52,6 @@ export class TuiInputFilesDirective {
     }
 
     get input(): HTMLInputElement {
-        return this.elementRef.nativeElement;
+        return this.el.nativeElement;
     }
 }

--- a/projects/kit/components/input-inline/input-inline.component.ts
+++ b/projects/kit/components/input-inline/input-inline.component.ts
@@ -46,9 +46,9 @@ export class TuiInputInlineComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {

--- a/projects/kit/components/input-month-range/input-month-range.component.ts
+++ b/projects/kit/components/input-month-range/input-month-range.component.ts
@@ -82,13 +82,13 @@ export class TuiInputMonthRangeComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_MONTH_FORMATTER)
         readonly formatter: TuiHandler<TuiMonth | null, Observable<string>>,
         @Inject(TUI_INPUT_DATE_OPTIONS)
         private readonly options: TuiInputDateOptions,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {

--- a/projects/kit/components/input-month/input-month.component.ts
+++ b/projects/kit/components/input-month/input-month.component.ts
@@ -80,13 +80,13 @@ export class TuiInputMonthComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_MONTH_FORMATTER)
         readonly formatter: TuiHandler<TuiMonth | null, Observable<string>>,
         @Inject(TUI_INPUT_DATE_OPTIONS)
         private readonly options: TuiInputDateOptions,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {

--- a/projects/kit/components/input-number/input-number.component.ts
+++ b/projects/kit/components/input-number/input-number.component.ts
@@ -96,12 +96,12 @@ export class TuiInputNumberComponent
         @Inject(NgControl)
         control: NgControl | null,
         @Inject(ChangeDetectorRef)
-        changeDetectorRef: ChangeDetectorRef,
+        cdr: ChangeDetectorRef,
         @Inject(TUI_NUMBER_FORMAT)
         private readonly numberFormat: TuiNumberFormatSettings,
         @Inject(TUI_IS_IOS) private readonly isIOS: boolean,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {

--- a/projects/kit/components/input-password/input-password.component.ts
+++ b/projects/kit/components/input-password/input-password.component.ts
@@ -79,7 +79,7 @@ export class TuiInputPasswordComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_TEXTFIELD_SIZE)
         private readonly textfieldSize: TuiTextfieldSizeDirective,
         @Inject(TUI_PASSWORD_TEXTS)
@@ -92,7 +92,7 @@ export class TuiInputPasswordComponent
         @Inject(TUI_MODE)
         private readonly mode$: Observable<TuiBrightness | null>,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {

--- a/projects/kit/components/input-phone-international/input-phone-international.component.ts
+++ b/projects/kit/components/input-phone-international/input-phone-international.component.ts
@@ -101,7 +101,7 @@ export class TuiInputPhoneInternationalComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_COUNTRIES)
         readonly countriesNames$: Observable<Record<TuiCountryIsoCode, string>>,
         @Inject(TUI_COUNTRIES_MASKS)
@@ -111,7 +111,7 @@ export class TuiInputPhoneInternationalComponent
         @Inject(TuiFlagPipe)
         private readonly flagPipe: TuiFlagPipe,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLElement | null {
@@ -185,7 +185,7 @@ export class TuiInputPhoneInternationalComponent
         this.open = false;
         this.updateCountryIsoCode(isoCode);
         // recalculates mask inside inputPhone to prevent isoCode conflict
-        this.changeDetectorRef.detectChanges();
+        this.cdr.detectChanges();
 
         const maxLength = this.getMaxAllowedLength(isoCode);
 

--- a/projects/kit/components/input-phone/input-phone.component.ts
+++ b/projects/kit/components/input-phone/input-phone.component.ts
@@ -125,13 +125,13 @@ export class TuiInputPhoneComponent
     constructor(
         @Optional() @Self() @Inject(NgControl) control: NgControl | null,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<unknown>,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_SELECTION_STREAM) selection$: Observable<unknown>,
         @Inject(TUI_TEXTFIELD_CLEANER)
         private readonly textfieldCleaner: TuiTextfieldCleanerDirective,
         @Inject(TUI_INPUT_PHONE_OPTIONS) private readonly options: TuiInputPhoneOptions,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
 
         selection$.pipe(takeUntil(destroy$)).subscribe(() => {
             this.setCaretPosition();

--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -116,14 +116,14 @@ export class TuiInputRangeComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_IS_MOBILE)
         private readonly isMobile: boolean,
-        @Inject(ElementRef) private readonly elementRef: ElementRef,
+        @Inject(ElementRef) private readonly el: ElementRef,
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         readonly controller: TuiTextfieldController,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get leftFocusableElement(): HTMLInputElement | null {
@@ -141,7 +141,7 @@ export class TuiInputRangeComponent
     }
 
     get focused(): boolean {
-        return tuiIsNativeFocusedIn(this.elementRef.nativeElement);
+        return tuiIsNativeFocusedIn(this.el.nativeElement);
     }
 
     get appearance(): string {

--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -111,11 +111,11 @@ export class TuiInputSliderComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         readonly controller: TuiTextfieldController,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get prefix(): string {

--- a/projects/kit/components/input-tag/input-tag.component.ts
+++ b/projects/kit/components/input-tag/input-tag.component.ts
@@ -200,9 +200,9 @@ export class TuiInputTagComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TuiScrollService) private readonly tuiScrollService: TuiScrollService,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Optional()
         @Inject(TuiModeDirective)
         private readonly modeDirective: TuiModeDirective | null,
@@ -219,7 +219,7 @@ export class TuiInputTagComponent
         @Inject(TuiHostedDropdownComponent)
         private readonly parentHostedDropdown?: TuiHostedDropdownComponent,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {
@@ -230,8 +230,7 @@ export class TuiInputTagComponent
 
     get focused(): boolean {
         return (
-            tuiIsNativeFocusedIn(this.elementRef.nativeElement) ||
-            !!this.hostedDropdown?.focused
+            tuiIsNativeFocusedIn(this.el.nativeElement) || !!this.hostedDropdown?.focused
         );
     }
 

--- a/projects/kit/components/input-time/input-time.component.ts
+++ b/projects/kit/components/input-time/input-time.component.ts
@@ -98,13 +98,13 @@ export class TuiInputTimeComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_TIME_TEXTS)
         private readonly timeTexts$: Observable<Record<TuiTimeMode, string>>,
         @Inject(TUI_INPUT_TIME_OPTIONS)
         private readonly options: TuiInputTimeOptions,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {

--- a/projects/kit/components/input-year/input-year.component.ts
+++ b/projects/kit/components/input-year/input-year.component.ts
@@ -69,11 +69,11 @@ export class TuiInputYearComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_INPUT_DATE_OPTIONS)
         private readonly options: TuiInputDateOptions,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {

--- a/projects/kit/components/input/input.component.ts
+++ b/projects/kit/components/input/input.component.ts
@@ -67,9 +67,9 @@ export class TuiInputComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {

--- a/projects/kit/components/items-with-more/items-with-more.service.ts
+++ b/projects/kit/components/items-with-more/items-with-more.service.ts
@@ -18,7 +18,7 @@ export class TuiItemsWithMoreService extends Observable<number> {
 
     constructor(
         @Inject(NgZone) private readonly ngZone: NgZone,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(MutationObserverService) private readonly mutation$: Observable<unknown>,
         @Inject(TuiResizeService) private readonly resize$: Observable<unknown>,
         @Inject(TuiItemsWithMoreDirective)
@@ -28,7 +28,7 @@ export class TuiItemsWithMoreService extends Observable<number> {
     }
 
     private getOverflowIndex(): number {
-        const {clientWidth, children} = this.elementRef.nativeElement;
+        const {clientWidth, children} = this.el.nativeElement;
         const items = Array.from(children, ({clientWidth}) => clientWidth);
         const first = this.directive.required === -1 ? 0 : this.directive.required;
         const last = items.length - 1;

--- a/projects/kit/components/line-clamp/line-clamp.component.ts
+++ b/projects/kit/components/line-clamp/line-clamp.component.ts
@@ -86,7 +86,7 @@ export class TuiLineClampComponent implements DoCheck, AfterViewInit {
         switchMap(([prev, next]) =>
             next >= prev
                 ? of(next)
-                : tuiTypedFromEvent(this.elementRef.nativeElement, 'transitionend').pipe(
+                : tuiTypedFromEvent(this.el.nativeElement, 'transitionend').pipe(
                       filter(tuiIsCurrentTarget),
                       map(() => next),
                   ),
@@ -94,7 +94,7 @@ export class TuiLineClampComponent implements DoCheck, AfterViewInit {
     );
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(Renderer2) private readonly renderer: Renderer2,
         @Inject(ChangeDetectorRef) private readonly cd: ChangeDetectorRef,
         @Inject(NgZone) private readonly ngZone: NgZone,
@@ -109,7 +109,7 @@ export class TuiLineClampComponent implements DoCheck, AfterViewInit {
         }
 
         const {scrollHeight, scrollWidth} = this.outlet.nativeElement;
-        const {clientHeight, clientWidth} = this.elementRef.nativeElement;
+        const {clientHeight, clientWidth} = this.el.nativeElement;
 
         // 4px buffer for IE/Edge incorrectly rounding scrollHeight
         return scrollHeight - clientHeight > 4 || scrollWidth - clientWidth > 0;
@@ -137,7 +137,7 @@ export class TuiLineClampComponent implements DoCheck, AfterViewInit {
         timer(0)
             .pipe(tuiZonefree(this.ngZone))
             .subscribe(() => {
-                this.renderer.addClass(this.elementRef.nativeElement, '_initialized');
+                this.renderer.addClass(this.el.nativeElement, '_initialized');
                 this.cd.detectChanges();
             });
     }

--- a/projects/kit/components/multi-select/multi-select.component.ts
+++ b/projects/kit/components/multi-select/multi-select.component.ts
@@ -143,7 +143,7 @@ export class TuiMultiSelectComponent<T>
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_ARROW_MODE)
         private readonly arrowMode: TuiArrowMode,
         @Inject(TUI_ITEMS_HANDLERS)
@@ -155,7 +155,7 @@ export class TuiMultiSelectComponent<T>
         @Inject(TUI_IS_MOBILE)
         readonly isMobile: boolean,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     @HostBinding('attr.data-size')

--- a/projects/kit/components/multi-select/native-multi-select/native-multi-select.ts
+++ b/projects/kit/components/multi-select/native-multi-select/native-multi-select.ts
@@ -10,10 +10,8 @@ export abstract class AbstractTuiNativeMultiSelect extends AbstractTuiNativeSele
         value.includes(option);
 
     onValueChange(): void {
-        const {selectedOptions} = this.elementRef.nativeElement;
-
         this.host.onSelectionChange(
-            Array.from(selectedOptions).map(option => option.value),
+            Array.from(this.el.nativeElement.selectedOptions).map(option => option.value),
         );
     }
 }

--- a/projects/kit/components/pagination/pagination.component.ts
+++ b/projects/kit/components/pagination/pagination.component.ts
@@ -50,7 +50,7 @@ export class TuiPaginationComponent
     implements TuiFocusableElementAccessor
 {
     @ViewChildren('element', {read: TUI_FOCUSABLE_ITEM_ACCESSOR})
-    private readonly elements: QueryList<TuiFocusableElementAccessor> = EMPTY_QUERY;
+    private readonly els: QueryList<TuiFocusableElementAccessor> = EMPTY_QUERY;
 
     @Input()
     @tuiDefaultProp(nonNegativeInteger, 'Must be non-negative integer')
@@ -96,7 +96,7 @@ export class TuiPaginationComponent
     readonly indexChange = new EventEmitter<number>();
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Optional()
         @Inject(TuiModeDirective)
         private readonly modeDirective: TuiModeDirective | null,
@@ -125,15 +125,13 @@ export class TuiPaginationComponent
             }
         }
 
-        const activeElement = this.elements.find(
-            (_, index) => index === activeElementIndex,
-        );
+        const activeElement = this.els.find((_, index) => index === activeElementIndex);
 
         return activeElement ? activeElement.nativeFocusableElement : null;
     }
 
     get focused(): boolean {
-        return tuiIsNativeFocusedIn(this.elementRef.nativeElement);
+        return tuiIsNativeFocusedIn(this.el.nativeElement);
     }
 
     /**
@@ -218,13 +216,11 @@ export class TuiPaginationComponent
     }
 
     onElementKeyDownArrowLeft(element: TuiButtonComponent): void {
-        if (element === this.elements.first) {
+        if (element === this.els.first) {
             return;
         }
 
-        const previous = this.elements.find(
-            (_, index, array) => array[index + 1] === element,
-        );
+        const previous = this.els.find((_, index, array) => array[index + 1] === element);
 
         if (previous?.nativeFocusableElement) {
             previous.nativeFocusableElement.focus();
@@ -232,13 +228,11 @@ export class TuiPaginationComponent
     }
 
     onElementKeyDownArrowRight(element: TuiButtonComponent): void {
-        if (element === this.elements.last) {
+        if (element === this.els.last) {
             return;
         }
 
-        const next = this.elements.find(
-            (_, index, array) => array[index - 1] === element,
-        );
+        const next = this.els.find((_, index, array) => array[index - 1] === element);
 
         if (next?.nativeFocusableElement) {
             next.nativeFocusableElement.focus();

--- a/projects/kit/components/progress/progress-bar/progress-color-segments.directive.ts
+++ b/projects/kit/components/progress/progress-bar/progress-color-segments.directive.ts
@@ -47,14 +47,14 @@ export class TuiProgressColorSegmentsDirective {
                     ? this.colors[0]
                     : calculateColorSegments(
                           this.colors,
-                          this.elementRef.nativeElement.offsetWidth,
+                          this.el.nativeElement.offsetWidth,
                       ),
             ),
         );
     }
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLProgressElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLProgressElement>,
         @Inject(TuiResizeService) private readonly resize$: Observable<unknown>,
         @Inject(USER_AGENT) private readonly userAgent: string,
     ) {}

--- a/projects/kit/components/progress/progress-circle/progress-circle.component.ts
+++ b/projects/kit/components/progress/progress-circle/progress-circle.component.ts
@@ -55,17 +55,16 @@ export class TuiProgressCircleComponent {
         }
 
         const strokeWidth = parseInt(
-            this.windowRef.getComputedStyle(this.progressCircle.nativeElement)
-                .strokeWidth,
+            this.win.getComputedStyle(this.progressCircle.nativeElement).strokeWidth,
             10,
         );
 
-        return (this.elementRef.nativeElement.offsetWidth - strokeWidth) / 2;
+        return (this.el.nativeElement.offsetWidth - strokeWidth) / 2;
     }
 
     constructor(
         @Inject(USER_AGENT) private readonly userAgent: string,
-        @Inject(WINDOW) private readonly windowRef: Window,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(WINDOW) private readonly win: Window,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
     ) {}
 }

--- a/projects/kit/components/push/push-alert.directive.ts
+++ b/projects/kit/components/push/push-alert.directive.ts
@@ -30,11 +30,11 @@ export class TuiPushAlertDirective extends PolymorpheusTemplate {
 
     constructor(
         @Inject(TemplateRef) template: TemplateRef<any>,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<unknown>,
         @Inject(forwardRef(() => TuiPushService)) push: TuiPushService,
     ) {
-        super(template, changeDetectorRef);
+        super(template, cdr);
 
         this.show$
             .pipe(

--- a/projects/kit/components/radio-block/radio-block.component.ts
+++ b/projects/kit/components/radio-block/radio-block.component.ts
@@ -77,12 +77,12 @@ export class TuiRadioBlockComponent<T>
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Optional()
         @Inject(TuiModeDirective)
         private readonly modeDirective: TuiModeDirective | null,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {

--- a/projects/kit/components/radio-labeled/radio-labeled.component.ts
+++ b/projects/kit/components/radio-labeled/radio-labeled.component.ts
@@ -65,14 +65,14 @@ export class TuiRadioLabeledComponent<T>
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Optional()
         @Inject(TuiModeDirective)
         private readonly modeDirective: TuiModeDirective | null,
         @Inject(TUI_RADIO_OPTIONS)
         private readonly options: TuiRadioOptions,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {

--- a/projects/kit/components/radio-list/radio-list.component.ts
+++ b/projects/kit/components/radio-list/radio-list.component.ts
@@ -71,10 +71,10 @@ export class TuiRadioListComponent<T> extends AbstractTuiNullableControl<T> {
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     // @bad TODO: Remove & { index: number }
@@ -93,7 +93,7 @@ export class TuiRadioListComponent<T> extends AbstractTuiNullableControl<T> {
     }
 
     get focused(): boolean {
-        return tuiIsNativeFocusedIn(this.elementRef.nativeElement);
+        return tuiIsNativeFocusedIn(this.el.nativeElement);
     }
 
     computeId(index: number): string {

--- a/projects/kit/components/radio/radio.component.ts
+++ b/projects/kit/components/radio/radio.component.ts
@@ -73,7 +73,7 @@ export class TuiRadioComponent<T>
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_ANIMATION_OPTIONS)
         private readonly animationOptions: AnimationOptions,
         @Inject(TUI_RADIO_OPTIONS)
@@ -82,7 +82,7 @@ export class TuiRadioComponent<T>
         @Inject(TuiRadioGroupComponent)
         private readonly radioGroup: TuiRadioGroupComponent | null,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get appearance(): string {

--- a/projects/kit/components/range/range-change.directive.ts
+++ b/projects/kit/components/range/range-change.directive.ts
@@ -14,37 +14,37 @@ import {TuiRangeComponent} from './range.component';
 export class TuiRangeChangeDirective {
     /**
      * TODO replace with pointer events (when all supported browsers can handle them).
-     * Dont forget to use setPointerCapture instead of listening all documentRef events
+     * Dont forget to use setPointerCapture instead of listening all doc events
      */
     private readonly pointerDown$ = merge(
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'touchstart', {
+        tuiTypedFromEvent(this.el.nativeElement, 'touchstart', {
             passive: true,
         }).pipe(
             filter(({touches}) => touches.length === 1),
             map(({touches}) => touches[0]),
         ),
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'mousedown', {passive: true}),
+        tuiTypedFromEvent(this.el.nativeElement, 'mousedown', {passive: true}),
     );
 
     private readonly pointerMove$ = merge(
-        tuiTypedFromEvent(this.documentRef, 'touchmove').pipe(
+        tuiTypedFromEvent(this.doc, 'touchmove').pipe(
             filter(({touches}) => touches.length === 1),
             map(({touches}) => touches[0]),
         ),
-        tuiTypedFromEvent(this.documentRef, 'mousemove'),
+        tuiTypedFromEvent(this.doc, 'mousemove'),
     );
 
     private readonly pointerUp$ = merge(
-        tuiTypedFromEvent(this.documentRef, 'touchend', {passive: true}),
-        tuiTypedFromEvent(this.documentRef, 'mouseup', {passive: true}),
+        tuiTypedFromEvent(this.doc, 'touchend', {passive: true}),
+        tuiTypedFromEvent(this.doc, 'mouseup', {passive: true}),
     );
 
     @Output()
     readonly activeThumbChange = new EventEmitter<'left' | 'right'>();
 
     constructor(
-        @Inject(DOCUMENT) private readonly documentRef: Document,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(DOCUMENT) private readonly doc: Document,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TuiRangeComponent) private readonly range: TuiRangeComponent,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<unknown>,
     ) {
@@ -57,7 +57,7 @@ export class TuiRangeChangeDirective {
                     this.activeThumbChange.emit(activeThumb);
 
                     if (this.range.focusable) {
-                        elementRef.nativeElement.focus();
+                        el.nativeElement.focus();
                     }
                 }),
                 switchMap(event => this.pointerMove$.pipe(startWith(event))),
@@ -74,7 +74,7 @@ export class TuiRangeChangeDirective {
     }
 
     private getFractionFromEvents(clickClientX: number): number {
-        const hostRect = this.elementRef.nativeElement.getBoundingClientRect();
+        const hostRect = this.el.nativeElement.getBoundingClientRect();
         const value = clickClientX - hostRect.left;
         const total = hostRect.width;
 

--- a/projects/kit/components/range/range.component.ts
+++ b/projects/kit/components/range/range.component.ts
@@ -84,10 +84,10 @@ export class TuiRangeComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get nativeFocusableElement(): TuiNativeFocusableElement | null {
@@ -110,7 +110,7 @@ export class TuiRangeComponent
     }
 
     get focused(): boolean {
-        return tuiIsNativeFocusedIn(this.elementRef.nativeElement);
+        return tuiIsNativeFocusedIn(this.el.nativeElement);
     }
 
     get fractionStep(): number {
@@ -151,7 +151,7 @@ export class TuiRangeComponent
         const rightThumbElement = sliderRightRef.nativeElement;
 
         const isRightThumb =
-            target === this.elementRef.nativeElement
+            target === this.el.nativeElement
                 ? this.lastActiveThumb === 'right'
                 : target === rightThumbElement;
         const activeThumbElement = isRightThumb ? rightThumbElement : leftThumbElement;

--- a/projects/kit/components/range/test/range.component.spec.ts
+++ b/projects/kit/components/range/test/range.component.spec.ts
@@ -27,7 +27,7 @@ xdescribe(`Range`, () => {
         component!: TuiRangeComponent;
 
         @ViewChild(TuiRangeComponent, {static: true, read: ElementRef})
-        elementRef!: ElementRef<HTMLElement>;
+        el!: ElementRef<HTMLElement>;
 
         testValue = new FormControl([3, 5]);
         max = 11;
@@ -57,7 +57,7 @@ xdescribe(`Range`, () => {
     }
 
     function getFilledRangeOffeset(): {left: string; right: string} {
-        const computedStyles = testComponent.elementRef.nativeElement;
+        const computedStyles = testComponent.el.nativeElement;
 
         return {
             left: getComputedStyle(computedStyles).getPropertyValue(`--left`),

--- a/projects/kit/components/rating/rating.component.ts
+++ b/projects/kit/components/rating/rating.component.ts
@@ -62,11 +62,11 @@ export class TuiRatingComponent
         @Inject(NgControl)
         ngControl: NgControl | null,
         @Inject(ChangeDetectorRef)
-        changeDetectorRef: ChangeDetectorRef,
+        cdr: ChangeDetectorRef,
         @Inject(TUI_RATING_OPTIONS)
         private readonly options: TuiRatingOptions,
     ) {
-        super(ngControl, changeDetectorRef);
+        super(ngControl, cdr);
     }
 
     get nativeFocusableElement(): HTMLInputElement | null {

--- a/projects/kit/components/routable-dialog/routable-dialog.component.ts
+++ b/projects/kit/components/routable-dialog/routable-dialog.component.ts
@@ -15,11 +15,11 @@ export class TuiRoutableDialogComponent {
     constructor(
         @Inject(ActivatedRoute) private readonly route: ActivatedRoute,
         @Inject(Router) private readonly router: Router,
-        @Inject(TuiDialogService) dialogService: TuiDialogService,
+        @Inject(TuiDialogService) dialogs: TuiDialogService,
         @Inject(Injector) injector: Injector,
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
     ) {
-        dialogService
+        dialogs
             .open(
                 new PolymorpheusComponent(this.route.snapshot.data['dialog'], injector),
                 this.route.snapshot.data['dialogOptions'],

--- a/projects/kit/components/select-option/select-option.component.ts
+++ b/projects/kit/components/select-option/select-option.component.ts
@@ -39,7 +39,7 @@ export class TuiSelectOptionComponent<T> implements OnInit, DoCheck {
     readonly selected$ = merge(
         this.changeDetection$,
         this.control.valueChanges || EMPTY,
-        tuiTypedFromEvent(this.elementRef.nativeElement, 'animationstart'),
+        tuiTypedFromEvent(this.el.nativeElement, 'animationstart'),
     ).pipe(
         startWith(null),
         map(() => this.selected),
@@ -51,7 +51,7 @@ export class TuiSelectOptionComponent<T> implements OnInit, DoCheck {
         readonly context: TuiContextWithImplicit<TemplateRef<Record<string, unknown>>>,
         @Inject(TUI_DATA_LIST_HOST)
         private readonly host: TuiDataListHost<T>,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TuiOptionComponent) protected readonly option: TuiOptionComponent<T>,
         @Optional()
         @Inject(TuiDataListComponent)

--- a/projects/kit/components/select/select.component.ts
+++ b/projects/kit/components/select/select.component.ts
@@ -94,7 +94,7 @@ export class TuiSelectComponent<T>
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_TEXTFIELD_CLEANER)
         private readonly textfieldCleaner: TuiTextfieldCleanerDirective,
         @Inject(TUI_ARROW_MODE)
@@ -106,7 +106,7 @@ export class TuiSelectComponent<T>
         @Inject(TUI_IS_MOBILE)
         readonly isMobile: boolean,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get arrow(): PolymorpheusContent<

--- a/projects/kit/components/slider/helpers/slider-key-steps.directive.ts
+++ b/projects/kit/components/slider/helpers/slider-key-steps.directive.ts
@@ -43,7 +43,7 @@ export class TuiSliderKeyStepsDirective
     keySteps!: TuiKeySteps;
 
     get nativeFocusableElement(): HTMLInputElement | null {
-        return this.computedDisabled ? null : this.elementRef.nativeElement;
+        return this.computedDisabled ? null : this.el.nativeElement;
     }
 
     get focused(): boolean {
@@ -63,12 +63,12 @@ export class TuiSliderKeyStepsDirective
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLInputElement>,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLInputElement>,
         @Inject(forwardRef(() => TuiSliderComponent))
         private readonly slider: TuiSliderComponent,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     @HostListener('input')

--- a/projects/kit/components/slider/helpers/slider-readonly.directive.ts
+++ b/projects/kit/components/slider/helpers/slider-readonly.directive.ts
@@ -36,19 +36,19 @@ export class TuiSliderReadonlyDirective {
     readonly: boolean | string = true;
 
     constructor(
-        @Inject(ElementRef) elementRef: ElementRef<HTMLInputElement>,
-        @Inject(DOCUMENT) documentRef: Document,
+        @Inject(ElementRef) el: ElementRef<HTMLInputElement>,
+        @Inject(DOCUMENT) doc: Document,
         @Self()
         @Inject(TuiDestroyService)
         destroy$: Observable<unknown>,
     ) {
-        const touchStart$ = tuiTypedFromEvent(elementRef.nativeElement, 'touchstart', {
+        const touchStart$ = tuiTypedFromEvent(el.nativeElement, 'touchstart', {
             passive: false,
         });
-        const touchMove$ = tuiTypedFromEvent(documentRef, 'touchmove', {
+        const touchMove$ = tuiTypedFromEvent(doc, 'touchmove', {
             passive: false,
         });
-        const touchEnd$ = tuiTypedFromEvent(documentRef, 'touchend', {
+        const touchEnd$ = tuiTypedFromEvent(doc, 'touchend', {
             passive: true,
         });
 

--- a/projects/kit/components/slider/helpers/slider-thumb-label/slider-thumb-label.component.ts
+++ b/projects/kit/components/slider/helpers/slider-thumb-label/slider-thumb-label.component.ts
@@ -32,7 +32,7 @@ export class TuiSliderThumbLabelComponent implements AfterContentInit {
     }
 
     get ghostLeft(): number {
-        return this.ratio * (this.slider?.elementRef.nativeElement.offsetWidth || 0);
+        return this.ratio * (this.slider?.el.nativeElement.offsetWidth || 0);
     }
 
     ngAfterContentInit(): void {

--- a/projects/kit/components/slider/slider.component.ts
+++ b/projects/kit/components/slider/slider.component.ts
@@ -60,33 +60,33 @@ export class TuiSliderComponent {
     segments = 1;
 
     get min(): number {
-        return Number(this.elementRef.nativeElement.min);
+        return Number(this.el.nativeElement.min);
     }
 
     get max(): number {
-        return Number(this.elementRef.nativeElement.max || 100);
+        return Number(this.el.nativeElement.max || 100);
     }
 
     get step(): number {
-        return Number(this.elementRef.nativeElement.step) || 1;
+        return Number(this.el.nativeElement.step) || 1;
     }
 
     get value(): number {
-        const {elementRef, control, hasKeySteps} = this;
+        const {el, control, hasKeySteps} = this;
 
         if (!hasKeySteps && control instanceof NgModel) {
             /**
              * If developer uses `[(ngModel)]` and programmatically change value,
-             * the `elementRef.nativeElement.value` is equal to the previous value at this moment.
+             * the `el.nativeElement.value` is equal to the previous value at this moment.
              */
             return control.viewModel;
         }
 
-        return Number(elementRef.nativeElement.value) || 0;
+        return Number(el.nativeElement.value) || 0;
     }
 
     set value(newValue: number) {
-        this.elementRef.nativeElement.value = `${newValue}`;
+        this.el.nativeElement.value = `${newValue}`;
     }
 
     @HostBinding('style.--tui-slider-fill-percentage.%')
@@ -115,9 +115,9 @@ export class TuiSliderComponent {
         @Self()
         @Inject(NgControl)
         private readonly control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_SLIDER_OPTIONS) readonly options: TuiSliderOptions,
-        @Inject(ElementRef) readonly elementRef: ElementRef<HTMLInputElement>,
+        @Inject(ElementRef) readonly el: ElementRef<HTMLInputElement>,
         @Inject(USER_AGENT) private readonly userAgent: string,
         @Inject(Injector) private readonly injector: Injector,
     ) {
@@ -129,7 +129,7 @@ export class TuiSliderComponent {
              * ___
              * See this {@link https://github.com/angular/angular/issues/14988 issue}
              */
-            control.valueChanges?.pipe(tuiWatch(changeDetectorRef), take(1)).subscribe();
+            control.valueChanges?.pipe(tuiWatch(cdr), take(1)).subscribe();
         }
     }
 }

--- a/projects/kit/components/stepper/step/step.component.ts
+++ b/projects/kit/components/stepper/step/step.component.ts
@@ -44,7 +44,7 @@ export class TuiStepComponent {
         @Inject(TuiFocusVisibleService) focusVisible$: TuiFocusVisibleService,
         @Inject(TuiRouterLinkActiveService) routerLinkActive$: Observable<boolean>,
         @Inject(TuiStepperComponent) private readonly stepper: TuiStepperComponent,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
     ) {
         routerLinkActive$.pipe(filter(identity)).subscribe(() => {
             this.activate();
@@ -71,7 +71,7 @@ export class TuiStepComponent {
     }
 
     get index(): number {
-        return this.stepper.indexOf(this.elementRef.nativeElement);
+        return this.stepper.indexOf(this.el.nativeElement);
     }
 
     @HostListener('click')

--- a/projects/kit/components/stepper/stepper.component.ts
+++ b/projects/kit/components/stepper/stepper.component.ts
@@ -61,8 +61,8 @@ export class TuiStepperComponent {
     activeItemIndex = 0;
 
     constructor(
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TuiScrollService) private readonly scrollService: TuiScrollService,
         @Inject(TuiResizeService) resize$: Observable<void>,
     ) {
@@ -115,7 +115,7 @@ export class TuiStepperComponent {
 
         this.activeItemIndex = index;
         this.activeItemIndexChange.emit(index);
-        this.changeDetectorRef.markForCheck();
+        this.cdr.markForCheck();
         this.scrollIntoView(index);
     }
 
@@ -144,7 +144,7 @@ export class TuiStepperComponent {
             return;
         }
 
-        const {nativeElement} = this.elementRef;
+        const {nativeElement} = this.el;
         const {clientHeight, clientWidth, offsetTop, offsetLeft} = nativeElement;
         const {
             offsetHeight,

--- a/projects/kit/components/tabs/tab/tab.component.ts
+++ b/projects/kit/components/tabs/tab/tab.component.ts
@@ -45,7 +45,7 @@ export class TuiTabComponent implements OnDestroy {
         @Optional()
         @Inject(RouterLinkActive)
         private readonly routerLinkActive: RouterLinkActive | null,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_MODE) readonly mode$: Observable<TuiBrightness | null>,
         @Inject(TUI_TAB_EVENT) readonly event$: Observable<Event>,
         @Inject(TUI_TAB_MARGIN) readonly margin: number,
@@ -62,8 +62,8 @@ export class TuiTabComponent implements OnDestroy {
     }
 
     ngOnDestroy(): void {
-        if (tuiIsNativeFocused(this.elementRef.nativeElement)) {
-            this.elementRef.nativeElement.blur();
+        if (tuiIsNativeFocused(this.el.nativeElement)) {
+            this.el.nativeElement.blur();
         }
     }
 }

--- a/projects/kit/components/tabs/tabs-with-more/tabs-with-more.component.ts
+++ b/projects/kit/components/tabs/tabs-with-more/tabs-with-more.component.ts
@@ -82,15 +82,15 @@ export class TuiTabsWithMoreComponent implements AfterViewInit {
         @Inject(TUI_TABS_OPTIONS) private readonly options: TuiTabsOptions,
         @Inject(TUI_TAB_MARGIN) private readonly margin: number,
         @Inject(TUI_TABS_REFRESH) private readonly refresh$: Observable<unknown>,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
         @Inject(TUI_MORE_WORD) readonly moreWord$: Observable<string>,
     ) {}
 
     // TODO: Improve performance
     get tabs(): readonly HTMLElement[] {
         return Array.from<HTMLElement>(
-            this.elementRef.nativeElement.querySelectorAll('[tuiTab]'),
+            this.el.nativeElement.querySelectorAll('[tuiTab]'),
         );
     }
 
@@ -143,7 +143,7 @@ export class TuiTabsWithMoreComponent implements AfterViewInit {
             )
             .subscribe(maxIndex => {
                 this.maxIndex = maxIndex;
-                this.changeDetectorRef.detectChanges();
+                this.cdr.detectChanges();
             });
     }
 
@@ -209,7 +209,7 @@ export class TuiTabsWithMoreComponent implements AfterViewInit {
         }
 
         const {exposeActive, minMoreWidth} = this.options;
-        const {clientWidth} = this.elementRef.nativeElement;
+        const {clientWidth} = this.el.nativeElement;
         const activeWidth = tabs[activeItemIndex] ? tabs[activeItemIndex].scrollWidth : 0;
         const moreWidth = Math.max(tabs[tabs.length - 1].scrollWidth, minMoreWidth);
         let maxIndex = tabs.length - 2;

--- a/projects/kit/components/tabs/tabs-with-more/tabs-with-more.providers.ts
+++ b/projects/kit/components/tabs/tabs-with-more/tabs-with-more.providers.ts
@@ -39,12 +39,9 @@ export const TUI_TABS_PROVIDERS: Provider[] = [
             destroy$: Observable<unknown>,
             {body}: Document,
             {nativeElement}: ElementRef<Node>,
-            changeDetectorRef: ChangeDetectorRef,
+            cdr: ChangeDetectorRef,
         ): Observable<unknown> => {
-            return merge(
-                resize$,
-                mutations$.pipe(tap(() => changeDetectorRef.detectChanges())),
-            ).pipe(
+            return merge(resize$, mutations$.pipe(tap(() => cdr.detectChanges()))).pipe(
                 // Ignoring cases when host is detached from DOM
                 filter(() => body.contains(nativeElement)),
                 debounceTime(0),

--- a/projects/kit/components/tabs/tabs.directive.ts
+++ b/projects/kit/components/tabs/tabs.directive.ts
@@ -23,13 +23,11 @@ export class TuiTabsDirective implements AfterViewChecked {
     @Output()
     readonly activeItemIndexChange = new EventEmitter<number>();
 
-    constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
-    ) {}
+    constructor(@Inject(ElementRef) private readonly el: ElementRef<HTMLElement>) {}
 
     get tabs(): readonly HTMLElement[] {
         return Array.from(
-            this.elementRef.nativeElement.querySelectorAll<HTMLElement>('[tuiTab]'),
+            this.el.nativeElement.querySelectorAll<HTMLElement>('[tuiTab]'),
         );
     }
 

--- a/projects/kit/components/tabs/tabs/tabs.component.ts
+++ b/projects/kit/components/tabs/tabs/tabs.component.ts
@@ -58,13 +58,13 @@ export class TuiTabsComponent implements AfterViewChecked {
 
     constructor(
         @Inject(TUI_TABS_OPTIONS) private readonly options: TuiTabsOptions,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TuiTabsDirective) private readonly tabs: TuiTabsDirective,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TuiResizeService) resize$: Observable<void>,
     ) {
         resize$.pipe(filter(() => this.underline)).subscribe(() => {
-            changeDetectorRef.detectChanges();
+            cdr.detectChanges();
         });
     }
 
@@ -101,7 +101,7 @@ export class TuiTabsComponent implements AfterViewChecked {
         }
 
         const {offsetLeft, offsetWidth} = element;
-        const {nativeElement} = this.elementRef;
+        const {nativeElement} = this.el;
 
         if (offsetLeft < nativeElement.scrollLeft) {
             nativeElement.scrollLeft = offsetLeft;

--- a/projects/kit/components/tabs/underline/underline.component.ts
+++ b/projects/kit/components/tabs/underline/underline.component.ts
@@ -25,9 +25,9 @@ import {debounceTime, map, share, switchMap} from 'rxjs/operators';
     },
 })
 export class TuiUnderlineComponent {
-    private readonly element$ = new ReplaySubject<HTMLElement | null>(1);
+    private readonly el$ = new ReplaySubject<HTMLElement | null>(1);
 
-    private readonly refresh$ = this.element$.pipe(
+    private readonly refresh$ = this.el$.pipe(
         switchMap(element =>
             element
                 ? this.animationFrame$.pipe(
@@ -42,12 +42,12 @@ export class TuiUnderlineComponent {
     @Input()
     @tuiDefaultProp()
     set element(element: HTMLElement | null) {
-        this.element$.next(element);
+        this.el$.next(element);
     }
 
     @HostListener('$.style.transitionProperty')
     readonly transition$ = asCallable(
-        this.element$.pipe(
+        this.el$.pipe(
             map(element => element && 'all'),
             debounceTime(50),
         ),

--- a/projects/kit/components/tag/tag.component.ts
+++ b/projects/kit/components/tag/tag.component.ts
@@ -111,7 +111,7 @@ export class TuiTagComponent {
     }
 
     constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TUI_MODE) readonly mode$: Observable<TuiBrightness | null>,
         @Inject(TUI_TAG_OPTIONS) private readonly options: TuiTagOptions,
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
@@ -185,7 +185,7 @@ export class TuiTagComponent {
             case 'esc':
                 event.preventDefault();
                 this.stopEditing();
-                this.elementRef.nativeElement.focus();
+                this.el.nativeElement.focus();
                 break;
             default:
                 break;

--- a/projects/kit/components/text-area/text-area.component.ts
+++ b/projects/kit/components/text-area/text-area.component.ts
@@ -87,7 +87,7 @@ export class TuiTextAreaComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Inject(TUI_IS_IOS) readonly isIOS: boolean,
         @Inject(TUI_MODE) readonly mode$: Observable<TuiBrightness | null>,
         @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
@@ -96,7 +96,7 @@ export class TuiTextAreaComponent
         @Inject(TuiHintOptionsDirective)
         readonly hintOptions: TuiHintOptionsDirective | null,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     @HostBinding('class._label-outside')

--- a/projects/kit/components/tiles/tile.component.ts
+++ b/projects/kit/components/tiles/tile.component.ts
@@ -56,7 +56,7 @@ export class TuiTileComponent {
 
     constructor(
         @Inject(NgZone) private readonly ngZone: NgZone,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(TuiTilesComponent) private readonly tiles: TuiTilesComponent,
         @Inject(TuiResizeService) private readonly resize$: Observable<unknown>,
         @Inject(MutationObserverService) private readonly mutation$: Observable<unknown>,
@@ -73,7 +73,7 @@ export class TuiTileComponent {
     }
 
     get element(): HTMLElement {
-        return this.elementRef.nativeElement;
+        return this.el.nativeElement;
     }
 
     @HostListener('pointerenter')

--- a/projects/kit/components/tiles/tiles.component.ts
+++ b/projects/kit/components/tiles/tiles.component.ts
@@ -36,7 +36,7 @@ import {debounce, filter, map} from 'rxjs/operators';
     ],
 })
 export class TuiTilesComponent {
-    private readonly element$ = new Subject<Element | undefined>();
+    private readonly el$ = new Subject<Element | undefined>();
 
     @Input()
     @tuiDefaultProp()
@@ -53,7 +53,7 @@ export class TuiTilesComponent {
     }
 
     @Output()
-    readonly orderChange = this.element$.pipe(
+    readonly orderChange = this.el$.pipe(
         debounce(() => timer(this.debounce)),
         filter(this.filter.bind(this)),
         map(element => this.reorder(element)),
@@ -64,11 +64,11 @@ export class TuiTilesComponent {
 
     readonly order$ = new BehaviorSubject(new Map<number, number>());
 
-    constructor(@Inject(ElementRef) private readonly elementRef: ElementRef<Element>) {}
+    constructor(@Inject(ElementRef) private readonly el: ElementRef<Element>) {}
 
     @HostListener('pointerleave.silent')
     rearrange(element?: Element): void {
-        this.element$.next(element);
+        this.el$.next(element);
     }
 
     private filter(element?: Element): element is Element {
@@ -76,7 +76,7 @@ export class TuiTilesComponent {
     }
 
     private reorder(element: Element): Map<number, number> {
-        const elements = Array.from(this.elementRef.nativeElement.children);
+        const elements = Array.from(this.el.nativeElement.children);
         const currentIndex = elements.indexOf(this.element || element);
         const newIndex = elements.indexOf(element);
         const order = this.order.size

--- a/projects/kit/components/toggle/toggle.component.ts
+++ b/projects/kit/components/toggle/toggle.component.ts
@@ -72,14 +72,14 @@ export class TuiToggleComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Optional()
         @Inject(TuiModeDirective)
         private readonly modeDirective: TuiModeDirective | null,
         @Inject(TUI_TOGGLE_OPTIONS)
         readonly options: TuiToggleOptions,
     ) {
-        super(control, changeDetectorRef);
+        super(control, cdr);
     }
 
     get iconOn(): PolymorpheusContent<TuiContextWithImplicit<TuiSizeL>> {

--- a/projects/kit/components/tree/components/tree-item/tree-item.component.ts
+++ b/projects/kit/components/tree/components/tree-item/tree-item.component.ts
@@ -49,13 +49,13 @@ export class TuiTreeItemComponent implements DoCheck {
     );
 
     readonly attached$ = this.change$.pipe(
-        map(() => this.elementRef.nativeElement.isConnected),
+        map(() => this.el.nativeElement.isConnected),
         distinctUntilChanged(),
     );
 
     constructor(
         @Inject(ElementRef)
-        private readonly elementRef: ElementRef<HTMLElement>,
+        private readonly el: ElementRef<HTMLElement>,
         @Inject(forwardRef(() => TUI_TREE_CONTROLLER))
         private readonly controller: TuiTreeController,
         @Inject(forwardRef(() => TUI_TREE_LEVEL))

--- a/projects/kit/directives/data-list-dropdown-manager/data-list-dropdown-manager.directive.ts
+++ b/projects/kit/directives/data-list-dropdown-manager/data-list-dropdown-manager.directive.ts
@@ -38,7 +38,7 @@ export class TuiDataListDropdownManagerDirective implements AfterViewInit {
     private readonly dropdowns: QueryList<TuiDropdownDirective> = EMPTY_QUERY;
 
     @ContentChildren(TuiDropdownDirective, {read: ElementRef, descendants: true})
-    private readonly elements: QueryList<ElementRef<HTMLElement>> = EMPTY_QUERY;
+    private readonly els: QueryList<ElementRef<HTMLElement>> = EMPTY_QUERY;
 
     constructor(
         @Self() @Inject(TuiDestroyService) private readonly destroy$: TuiDestroyService,
@@ -56,7 +56,7 @@ export class TuiDataListDropdownManagerDirective implements AfterViewInit {
                         dropdown.toggle(index === active);
                     });
 
-                    const element = this.elements.get(active);
+                    const element = this.els.get(active);
                     const dropdown = this.dropdowns.get(active);
 
                     if (!element || !dropdown?.dropdownBoxRef) {
@@ -91,7 +91,7 @@ export class TuiDataListDropdownManagerDirective implements AfterViewInit {
 
     @tuiPure
     private get elements$(): Observable<readonly HTMLElement[]> {
-        return tuiQueryListChanges(this.elements).pipe(
+        return tuiQueryListChanges(this.els).pipe(
             map(array => array.map(({nativeElement}) => nativeElement)),
             shareReplay({bufferSize: 1, refCount: true}),
         );

--- a/projects/kit/directives/highlight/highlight.directive.ts
+++ b/projects/kit/directives/highlight/highlight.directive.ts
@@ -20,8 +20,8 @@ import {Observable} from 'rxjs';
 export class TuiHighlightDirective implements OnChanges {
     private readonly highlight: HTMLElement = this.setUpHighlight();
 
-    private readonly treeWalker = this.documentRef.createTreeWalker(
-        this.elementRef.nativeElement,
+    private readonly treeWalker = this.doc.createTreeWalker(
+        this.el.nativeElement,
         NodeFilter.SHOW_TEXT,
         svgNodeFilter,
     );
@@ -34,8 +34,8 @@ export class TuiHighlightDirective implements OnChanges {
     tuiHighlightColor = 'var(--tui-selection)';
 
     constructor(
-        @Inject(DOCUMENT) private readonly documentRef: Document,
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
+        @Inject(DOCUMENT) private readonly doc: Document,
+        @Inject(ElementRef) private readonly el: ElementRef<HTMLElement>,
         @Inject(Renderer2) private readonly renderer: Renderer2,
         @Inject(TuiResizeService) resize$: Observable<unknown>,
     ) {
@@ -45,7 +45,7 @@ export class TuiHighlightDirective implements OnChanges {
     }
 
     get match(): boolean {
-        return this.indexOf(this.elementRef.nativeElement.textContent) !== -1;
+        return this.indexOf(this.el.nativeElement.textContent) !== -1;
     }
 
     ngOnChanges(): void {
@@ -59,7 +59,7 @@ export class TuiHighlightDirective implements OnChanges {
             return;
         }
 
-        this.treeWalker.currentNode = this.elementRef.nativeElement;
+        this.treeWalker.currentNode = this.el.nativeElement;
 
         do {
             const index = this.indexOf(this.treeWalker.currentNode.nodeValue);
@@ -68,12 +68,12 @@ export class TuiHighlightDirective implements OnChanges {
                 continue;
             }
 
-            const range = this.documentRef.createRange();
+            const range = this.doc.createRange();
 
             range.setStart(this.treeWalker.currentNode, index);
             range.setEnd(this.treeWalker.currentNode, index + this.tuiHighlight.length);
 
-            const hostRect = this.elementRef.nativeElement.getBoundingClientRect();
+            const hostRect = this.el.nativeElement.getBoundingClientRect();
             const {left, top, width, height} = range.getBoundingClientRect();
             const {style} = this.highlight;
 
@@ -101,7 +101,7 @@ export class TuiHighlightDirective implements OnChanges {
         style.background = this.tuiHighlightColor;
         style.zIndex = '-1';
         style.position = 'absolute';
-        this.renderer.appendChild(this.elementRef.nativeElement, highlight);
+        this.renderer.appendChild(this.el.nativeElement, highlight);
 
         return highlight;
     }

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -36,7 +36,7 @@ export class TuiLazyLoadingDirective {
         @Inject(TuiLazyLoadingService)
         private readonly src$: TuiLazyLoadingService,
         @Inject(ElementRef)
-        private readonly elementRef: ElementRef<HTMLImageElement>,
+        private readonly el: ElementRef<HTMLImageElement>,
     ) {
         if (!this.supported) {
             this.src$.subscribe(src => {
@@ -46,7 +46,7 @@ export class TuiLazyLoadingDirective {
     }
 
     private get supported(): boolean {
-        return 'loading' in this.elementRef.nativeElement;
+        return 'loading' in this.el.nativeElement;
     }
 
     @HostListener('load')

--- a/projects/kit/directives/lazy-loading/lazy-loading.service.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.service.ts
@@ -10,7 +10,7 @@ export class TuiLazyLoadingService extends Observable<SafeResourceUrl | string> 
     private readonly src$ = new Subject<SafeResourceUrl | string>();
 
     constructor(
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
         @Inject(IntersectionObserverService)
         intersections$: Observable<IntersectionObserverEntry[]>,
@@ -23,7 +23,7 @@ export class TuiLazyLoadingService extends Observable<SafeResourceUrl | string> 
                             filter(([{isIntersecting}]) => isIntersecting),
                             map(() => src),
                             catchError(() => of(src)),
-                            tuiWatch(changeDetectorRef),
+                            tuiWatch(cdr),
                             take(1),
                         ),
                     ),

--- a/projects/kit/directives/project-class/project-class.directive.ts
+++ b/projects/kit/directives/project-class/project-class.directive.ts
@@ -12,13 +12,11 @@ export class TuiProjectClassDirective implements AfterViewChecked {
     @tuiDefaultProp()
     classNames: readonly string[] = [];
 
-    constructor(
-        @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
-    ) {}
+    constructor(@Inject(ElementRef) private readonly el: ElementRef<HTMLElement>) {}
 
     ngAfterViewChecked(): void {
         this.classNames.forEach(className => {
-            const hostElement = this.elementRef.nativeElement;
+            const hostElement = this.el.nativeElement;
 
             hostElement.classList.toggle(
                 className,

--- a/projects/kit/internal/primitive-calendar-range/primitive-calendar-range.component.ts
+++ b/projects/kit/internal/primitive-calendar-range/primitive-calendar-range.component.ts
@@ -79,19 +79,17 @@ export class TuiPrimitiveCalendarRangeComponent implements OnInit {
         @Inject(TUI_CALENDAR_DATE_STREAM)
         @Optional()
         valueChanges: Observable<TuiDayRange | null> | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
     ) {
         if (!valueChanges) {
             return;
         }
 
-        valueChanges
-            .pipe(tuiWatch(changeDetectorRef), takeUntil(destroy$))
-            .subscribe(value => {
-                this.value = value;
-                this.updateViewedMonths();
-            });
+        valueChanges.pipe(tuiWatch(cdr), takeUntil(destroy$)).subscribe(value => {
+            this.value = value;
+            this.updateViewedMonths();
+        });
     }
 
     get cappedUserViewedMonthSecond(): TuiMonth {

--- a/projects/kit/services/dialog-form.service.ts
+++ b/projects/kit/services/dialog-form.service.ts
@@ -7,9 +7,7 @@ import {defer, Observable, of} from 'rxjs';
 export class TuiDialogFormService {
     private dirty = false;
 
-    constructor(
-        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
-    ) {}
+    constructor(@Inject(TuiDialogService) private readonly dialogs: TuiDialogService) {}
 
     markAsDirty(): void {
         this.dirty = true;
@@ -22,7 +20,7 @@ export class TuiDialogFormService {
     withPrompt(options: Partial<TuiDialogOptions<TuiPromptData>>): Observable<boolean> {
         return defer(() =>
             this.dirty
-                ? this.dialogService.open<boolean>(TUI_PROMPT, {
+                ? this.dialogs.open<boolean>(TUI_PROMPT, {
                       size: `s`,
                       ...options,
                   })


### PR DESCRIPTION
Testing for bundle size improvements

## Naming convention

elementRef - el
changeDetectorRef - cdr
viewContainerRef - vcr
documentRef - doc
windowRef - win