### PR TITLE
fix(cdk): support `autofill` values when trigger autofocus on `iOS`

### DIFF
--- a/projects/demo/src/modules/components/dialog/examples/9/pay-modal/pay-modal.component.html
+++ b/projects/demo/src/modules/components/dialog/examples/9/pay-modal/pay-modal.component.html
@@ -34,15 +34,26 @@
         </ng-container>
 
         <div class="form-block">
-            <ng-container *tuiLet="(loading$ | async) ?? false as loading">
-                <p *ngIf="loading">Please wait, we are loading fake cards...</p>
-
-                <!-- hack: open keyboard on iOS before focus target input -->
+            <ng-container *ngIf="iOS">
+                <!-- hack: open keyboard on iOS before focus target card input -->
+                <!-- hack: use autocomplete/inputmode attrs if you want autofill in keyboard  -->
                 <input
                     tuiAutoFocus
                     maxlength="0"
+                    inputmode="numeric"
+                    autocomplete="cc-number"
                     class="fake-input"
                 />
+                <!-- required:
+                    You don't need to use this hack for iOS if your input-card elements
+                    already exist in DOM, because you don't need to wait for them asynchronously.
+
+                    In our example we wait loading$ state before focus real card number / card cvc.
+                -->
+            </ng-container>
+
+            <ng-container *tuiLet="(loading$ | async) ?? false as loading">
+                <p *ngIf="loading">Please wait, we are loading fake cards...</p>
 
                 <tui-loader
                     [overlay]="true"
@@ -51,6 +62,7 @@
                     <tui-input-card-grouped
                         #cardGroupedInput
                         formControlName="card"
+                        [autocompleteEnabled]="true"
                         [cardValidator]="cardValidator"
                         [class.without-date]="paymentMode === PAYMENT_MODE.BySavedCard"
                         [tuiTextfieldCleaner]="paymentMode === PAYMENT_MODE.ByNewCard"

--- a/projects/demo/src/modules/components/dialog/examples/9/pay-modal/pay-modal.component.ts
+++ b/projects/demo/src/modules/components/dialog/examples/9/pay-modal/pay-modal.component.ts
@@ -12,7 +12,7 @@ import {
     tuiDefaultCardValidator,
     TuiInputCardGroupedComponent,
 } from '@taiga-ui/addon-commerce';
-import {TuiDestroyService} from '@taiga-ui/cdk';
+import {TUI_IS_IOS, TuiDestroyService} from '@taiga-ui/cdk';
 import {TuiDialogContext} from '@taiga-ui/core';
 import {POLYMORPHEUS_CONTEXT} from '@tinkoff/ng-polymorpheus';
 import {BehaviorSubject} from 'rxjs';
@@ -56,6 +56,7 @@ export class PayModalComponent implements OnInit {
     constructor(
         @Inject(POLYMORPHEUS_CONTEXT)
         readonly context: TuiDialogContext<void, DataForPayCardModal>,
+        @Inject(TUI_IS_IOS) readonly iOS: boolean,
         @Inject(PayService) private readonly payService: PayService,
         @Self() @Inject(TuiDestroyService) private readonly destroy$: TuiDestroyService,
     ) {}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4129

## What is the new behavior?

MacOS safari

https://user-images.githubusercontent.com/12021443/230723010-f16bfe0b-7fe8-4564-b4b6-766da65c282d.mov

<br>

iOS safari:

<img src="https://user-images.githubusercontent.com/12021443/230723116-80863903-be11-47bf-9fa2-199267b51fd9.png" width="300px" />

<br>

https://user-images.githubusercontent.com/12021443/230723120-7754aa92-4e11-4a8d-a9d3-fd36a35ec8f9.MOV



