### PR TITLE
fix(cdk): class constructor `ElementRef` cannot be invoked without `new`

### DIFF
--- a/projects/cdk/directives/element/element.directive.ts
+++ b/projects/cdk/directives/element/element.directive.ts
@@ -1,11 +1,29 @@
 import {Directive, ElementRef, Inject} from '@angular/core';
 
 @Directive({
-    selector: '[tuiElement]',
-    exportAs: 'elementRef',
+    selector: `[tuiElement]`,
+    exportAs: `elementRef`,
 })
-export class TuiElementDirective<T extends Element = HTMLElement> extends ElementRef<T> {
+export class TuiElementDirective<T extends Element = HTMLElement>
+    implements ElementRef<T>
+{
+    nativeElement!: T;
+
     constructor(@Inject(ElementRef) {nativeElement}: ElementRef<T>) {
-        super(nativeElement);
+        /**
+         * @note:
+         * Typically, when your constructor is invoked with new,
+         * an object is created, its constructor is assigned to
+         * the invoked constructor and the object is then assigned
+         * to this before executing any operations specified
+         * in your constructor method.
+         *
+         * ERROR TypeError: Class constructor ElementRef cannot be invoked without 'new'
+         * https://github.com/Tinkoff/taiga-ui/issues/3072
+         *
+         * This way we can instantiate object creation
+         * without additional prototype chain for possible fix bug.
+         */
+        return new ElementRef<T>(nativeElement);
     }
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

![image](https://user-images.githubusercontent.com/12021443/230911579-58dc706e-bc95-4fba-b297-0a1af28d7da7.png)

