### PR TITLE
refactor(eslint-plugin): refactor no-assert-without-ng-dev-mode rule

### DIFF
--- a/projects/eslint-plugin/utils/get-node-by-name-from-logical-expression.js
+++ b/projects/eslint-plugin/utils/get-node-by-name-from-logical-expression.js
@@ -1,0 +1,19 @@
+const traverseLogicalExpression = require('./traverse-logical-expression');
+
+/**
+ * Return a node from the provided logical expression with the provided name.
+ * @param expression {import('@types/estree').LogicalExpression}
+ * @param name {string}
+ * @returns {import('@types/estree').Node}
+ */
+module.exports = function getNodeByNameFromLogicalExpression(expression, name) {
+    let node = null;
+
+    traverseLogicalExpression(expression, leaf => {
+        if (leaf.name === name) {
+            node = leaf;
+        }
+    });
+
+    return node;
+};


### PR DESCRIPTION
1. Add console as a default option
2. Create a getNodeByNameFromLogicalExpression shared function
3. Replace hardcoded ngDevMode strings with a variable

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4150 

## What is the new behavior?

The rule is refactored according to the comments from the previous PR

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
