### PR TITLE
fix(kit): `InputPhoneInternational` change Cameroon phone pattern

### DIFF
--- a/projects/kit/components/input-phone-international/tokens/countries-masks.ts
+++ b/projects/kit/components/input-phone-international/tokens/countries-masks.ts
@@ -44,7 +44,7 @@ export const TUI_COUNTRIES_MASKS: InjectionToken<Record<TuiCountryIsoCode, strin
             [TuiCountryIsoCode.CH]: `+41##-###-####`,
             [TuiCountryIsoCode.CI]: `+225##-###-###`,
             [TuiCountryIsoCode.CL]: `+56#-####-####`,
-            [TuiCountryIsoCode.CM]: `+237####-####`,
+            [TuiCountryIsoCode.CM]: `+237#####-####`,
             [TuiCountryIsoCode.CN]: `+86(###) ####-####`,
             [TuiCountryIsoCode.CO]: `+57(###) ###-####`,
             [TuiCountryIsoCode.CR]: `+506####-####`,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4185

## What is the new behavior?
allow input 9-digit number 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
