### PR TITLE
fix(kit): correct detect iso code for `Kazakhstan` when phone number start with `+7`

### DIFF
--- a/projects/demo/src/modules/components/input-phone-international/examples/1/index.ts
+++ b/projects/demo/src/modules/components/input-phone-international/examples/1/index.ts
@@ -13,7 +13,7 @@ import {TuiCountryIsoCode} from '@taiga-ui/i18n';
 })
 export class TuiInputPhoneExample1 {
     readonly testForm = new FormGroup({
-        testValue: new FormControl('+77777777777', Validators.required),
+        testValue: new FormControl('+79777777777', Validators.required),
     });
 
     readonly countries: readonly TuiCountryIsoCode[] = [

--- a/projects/kit/components/input-phone-international/index.ts
+++ b/projects/kit/components/input-phone-international/index.ts
@@ -4,3 +4,4 @@ export * from './input-phone-international.module';
 export * from './input-phone-international.options';
 export * from './tokens/countries-masks';
 export * from './utils/extract-value-from-event';
+export * from './utils/not-kz-region';

--- a/projects/kit/components/input-phone-international/input-phone-international.component.ts
+++ b/projects/kit/components/input-phone-international/input-phone-international.component.ts
@@ -47,6 +47,7 @@ import {
 } from './input-phone-international.options';
 import {TUI_COUNTRIES_MASKS} from './tokens/countries-masks';
 import {tuiExtractValueFromEvent} from './utils/extract-value-from-event';
+import {tuiNotKzRegion} from './utils/not-kz-region';
 
 @Component({
     selector: 'tui-input-phone-international',
@@ -246,13 +247,16 @@ export class TuiInputPhoneInternationalComponent
                 /^(?!880[1-9 ])/.test(value) &&
                 value.length + 1 === this.getMaxAllowedLength(TuiCountryIsoCode.RU);
 
-            return (
+            const matched =
                 ruCodeTest ||
                 (value.startsWith(
                     this.isoToCountryCode(countryIsoCode).replace(CHAR_PLUS, ''),
                 ) &&
-                    value.length + 1 === this.getMaxAllowedLength(countryIsoCode))
-            );
+                    value.length + 1 === this.getMaxAllowedLength(countryIsoCode));
+
+            return matched && countryIsoCode === TuiCountryIsoCode.RU
+                ? tuiNotKzRegion(value)
+                : matched;
         });
     }
 }

--- a/projects/kit/components/input-phone-international/test/input-phone-international.component.spec.ts
+++ b/projects/kit/components/input-phone-international/test/input-phone-international.component.spec.ts
@@ -141,6 +141,24 @@ describe(`InputPhoneInternational`, () => {
             expect(component.countryIsoCode).toBe(TuiCountryIsoCode.RU);
         });
 
+        describe(`should set KZ country code on paste event`, () => {
+            for (const phone of [`+7(600)555-3535`, `+7 7272 588300`]) {
+                it(phone, () => {
+                    const data = new DataTransfer();
+
+                    data.setData(`text/plain`, phone);
+
+                    const pasteEvent = new ClipboardEvent(`paste`, {
+                        clipboardData: data as unknown as DataTransfer,
+                    });
+
+                    component.onPaste(pasteEvent);
+
+                    expect(component.countryIsoCode).toBe(TuiCountryIsoCode.KZ);
+                });
+            }
+        });
+
         it(`should replace code 8 on paste event`, () => {
             const data = new DataTransfer();
 

--- a/projects/kit/components/input-phone-international/utils/not-kz-region.ts
+++ b/projects/kit/components/input-phone-international/utils/not-kz-region.ts
@@ -1,0 +1,5 @@
+export function tuiNotKzRegion(value: string): boolean {
+    const region = Number(value.slice(1, 4));
+
+    return region < 600 || region > 799;
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4193

