### PR TITLE
fix(core): `PrimitiveTextfield` label should not be visible when filler used and input focused

### DIFF
--- a/projects/core/components/primitive-textfield/primitive-textfield.component.ts
+++ b/projects/core/components/primitive-textfield/primitive-textfield.component.ts
@@ -208,7 +208,10 @@ export class TuiPrimitiveTextfieldComponent
 
     get placeholderVisible(): boolean {
         const hasDecor =
-            this.nativeFocusableElement?.placeholder || this.prefix || this.postfix;
+            this.nativeFocusableElement?.placeholder ||
+            this.prefix ||
+            this.postfix ||
+            this.filler;
         const showDecor = hasDecor && !this.readOnly && this.computedFocused;
 
         return !this.hasValue && !showDecor;

--- a/projects/demo-integrations/cypress/tests/core/primitive-textfield/primitive-textfield.cy.ts
+++ b/projects/demo-integrations/cypress/tests/core/primitive-textfield/primitive-textfield.cy.ts
@@ -25,4 +25,14 @@ describe(`TuiPrimitiveTextfield`, () => {
             .should(`be.visible`)
             .matchImageSnapshot(`02-prefix-postfix`);
     });
+
+    it(`label should not be visible in focused state with filler`, () => {
+        cy.tuiVisit(
+            `components/primitive-textfield/API?filler=&tuiTextfieldFiller=filler&tuiTextfieldLabelOutside=true`,
+        );
+        cy.get(`#demo-content input`)
+            .click()
+            .tuiWaitBeforeScreenshot()
+            .matchImageSnapshot(`03-label-filler`);
+    });
 });


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
<img width="304" alt="Снимок экрана 2023-04-14 в 16 21 37" src="https://user-images.githubusercontent.com/46284632/232055413-2109ee9f-adbe-4705-835f-7592de6c7d6d.png">


## What is the new behavior?
<img width="244" alt="Снимок экрана 2023-04-14 в 16 22 04" src="https://user-images.githubusercontent.com/46284632/232055444-ca98cdf6-f59d-4168-bbbf-163d83a5adef.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
