### PR TITLE
fix(addon-editor): use `paragraph` type for correct detect empty

### DIFF
--- a/projects/addon-editor/directives/tiptap-editor/utils/is-empty-paragraph.ts
+++ b/projects/addon-editor/directives/tiptap-editor/utils/is-empty-paragraph.ts
@@ -1,5 +1,10 @@
 import {JSONContent} from '@tiptap/core';
 
 export function tuiIsEmptyParagraph(json?: JSONContent[]): boolean {
-    return Array.isArray(json) && json.length === 1 && !json[0].hasOwnProperty(`content`);
+    return (
+        Array.isArray(json) &&
+        json.length === 1 &&
+        json[0].type === `paragraph` &&
+        !json[0].hasOwnProperty(`content`)
+    );
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #3941

## What is the new behavior?

<img width="747" alt="image" src="https://user-images.githubusercontent.com/12021443/232508311-1d3ca615-60de-410f-9878-b68d68ddbbe6.png">
