### PR TITLE
refactor(cdk): `TuiStaticRequestService` use `fetch` instead of `XMLHttpRequest`

### DIFF
--- a/projects/cdk/services/static-request.service.ts
+++ b/projects/cdk/services/static-request.service.ts
@@ -1,6 +1,7 @@
-import {Inject, Injectable} from '@angular/core';
+import {isPlatformServer} from '@angular/common';
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {WINDOW} from '@ng-web-apis/common';
-import {from, Observable} from 'rxjs';
+import {defer, from, Observable} from 'rxjs';
 import {fromFetch} from 'rxjs/fetch';
 import {shareReplay, switchMap} from 'rxjs/operators';
 
@@ -10,7 +11,10 @@ import {shareReplay, switchMap} from 'rxjs/operators';
 export class TuiStaticRequestService {
     private readonly cache = new Map<string, Observable<string>>();
 
-    constructor(@Inject(WINDOW) private readonly win: Window) {}
+    constructor(
+        @Inject(WINDOW) private readonly win: Window,
+        @Inject(PLATFORM_ID) private readonly platformId: Record<string, unknown>,
+    ) {}
 
     request(url: string): Observable<string> {
         const cache = this.cache.get(url);
@@ -20,13 +24,13 @@ export class TuiStaticRequestService {
         }
 
         const response$ =
-            `AbortController` in this.win
+            `AbortController` in this.win || isPlatformServer(this.platformId)
                 ? fromFetch(url)
                 : /**
                    * Fallback for Firefox 55 and 56
                    * TODO: drop after browser support bump
                    */
-                  from(fetch(url));
+                  defer(() => from(fetch(url)));
 
         const piped = response$.pipe(
             switchMap(async res => res.text()),

--- a/projects/cdk/services/static-request.service.ts
+++ b/projects/cdk/services/static-request.service.ts
@@ -1,12 +1,16 @@
-import {Injectable} from '@angular/core';
-import {Observable, Observer} from 'rxjs';
-import {shareReplay} from 'rxjs/operators';
+import {Inject, Injectable} from '@angular/core';
+import {WINDOW} from '@ng-web-apis/common';
+import {from, Observable} from 'rxjs';
+import {fromFetch} from 'rxjs/fetch';
+import {shareReplay, switchMap} from 'rxjs/operators';
 
 @Injectable({
     providedIn: `root`,
 })
 export class TuiStaticRequestService {
     private readonly cache = new Map<string, Observable<string>>();
+
+    constructor(@Inject(WINDOW) private readonly win: Window) {}
 
     request(url: string): Observable<string> {
         const cache = this.cache.get(url);
@@ -15,30 +19,19 @@ export class TuiStaticRequestService {
             return cache;
         }
 
-        const observable = new Observable((observer: Observer<string>) => {
-            const xhr = new XMLHttpRequest();
+        const response$ =
+            `AbortController` in this.win
+                ? fromFetch(url)
+                : /**
+                   * Fallback for Firefox 55 and 56
+                   * TODO: drop after browser support bump
+                   */
+                  from(fetch(url));
 
-            xhr.onreadystatechange = () => {
-                if (xhr.readyState === 4) {
-                    const response = xhr.responseType ? xhr.response : xhr.responseText;
-
-                    if (xhr.status === 200) {
-                        observer.next(response);
-                        observer.complete();
-                    } else {
-                        observer.error(response);
-                    }
-                }
-            };
-
-            xhr.open(`GET`, url);
-            xhr.send();
-
-            return () => {
-                xhr.abort();
-            };
-        });
-        const piped = observable.pipe(shareReplay({bufferSize: 1, refCount: false}));
+        const piped = response$.pipe(
+            switchMap(async res => res.text()),
+            shareReplay({bufferSize: 1, refCount: false}),
+        );
 
         this.cache.set(url, piped);
 

--- a/projects/cdk/services/test/static-request.service.spec.ts
+++ b/projects/cdk/services/test/static-request.service.spec.ts
@@ -12,7 +12,7 @@ xdescribe(`TuiStaticRequest service`, () => {
     let service: TuiStaticRequestService;
 
     beforeEach(() => {
-        service = new TuiStaticRequestService();
+        service = new TuiStaticRequestService({} as any);
         // @ts-ignore
         jasmine.Ajax.install();
     });

--- a/projects/cdk/services/test/static-request.service.spec.ts
+++ b/projects/cdk/services/test/static-request.service.spec.ts
@@ -12,7 +12,7 @@ xdescribe(`TuiStaticRequest service`, () => {
     let service: TuiStaticRequestService;
 
     beforeEach(() => {
-        service = new TuiStaticRequestService({} as any);
+        service = new TuiStaticRequestService({} as any, {} as any);
         // @ts-ignore
         jasmine.Ajax.install();
     });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Replace legacy `XMLHttpRequest` with modern `fetch`.

See https://caniuse.com/fetch

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
