### PR TITLE
feat(core): add ability to align dropdown to center

### DIFF
--- a/projects/core/directives/dropdown/dropdown-options.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-options.directive.ts
@@ -10,14 +10,14 @@ import {
 } from '@angular/core';
 import {tuiDefaultProp} from '@taiga-ui/cdk';
 import {
+    TuiDropdownAlign,
     TuiDropdownWidth,
-    TuiHorizontalDirection,
     TuiVerticalDirection,
 } from '@taiga-ui/core/types';
 import {tuiOverrideOptions} from '@taiga-ui/core/utils';
 
 export interface TuiDropdownOptions {
-    readonly align: TuiHorizontalDirection;
+    readonly align: TuiDropdownAlign;
     readonly direction: TuiVerticalDirection | null;
     readonly limitWidth: TuiDropdownWidth;
     readonly minHeight: number;

--- a/projects/core/directives/dropdown/dropdown-position-sided.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-position-sided.directive.ts
@@ -46,7 +46,8 @@ export class TuiDropdownPositionSidedDirective extends TuiPositionAccessor {
         const {height, width} = rect;
         const hostRect = this.vertical.accessor?.getClientRect() ?? EMPTY_CLIENT_RECT;
         const viewport = this.viewport.getClientRect();
-        const {align, direction, minHeight, offset} = this.options;
+        const {direction, minHeight, offset} = this.options;
+        const align = this.options.align === 'center' ? 'left' : this.options.align;
         const available = {
             top: hostRect.bottom - viewport.top,
             left: hostRect.left - offset - viewport.left,

--- a/projects/core/directives/dropdown/dropdown-position.directive.ts
+++ b/projects/core/directives/dropdown/dropdown-position.directive.ts
@@ -44,6 +44,10 @@ export class TuiDropdownPositionDirective extends TuiPositionAccessor {
             top: hostRect.top - offset - height,
             bottom: hostRect.bottom + offset,
             right,
+            center:
+                hostRect.left + hostRect.width / 2 + width / 2 < viewport.right - offset
+                    ? hostRect.left + hostRect.width / 2 - width / 2
+                    : right,
             left: hostRect.left + width < viewport.right - offset ? hostRect.left : right,
         } as const;
         const better = available.top > available.bottom ? 'top' : 'bottom';

--- a/projects/core/types/dropdown-align.ts
+++ b/projects/core/types/dropdown-align.ts
@@ -1,0 +1,1 @@
+export type TuiDropdownAlign = 'center' | 'left' | 'right';

--- a/projects/core/types/index.ts
+++ b/projects/core/types/index.ts
@@ -4,6 +4,7 @@ export * from './decimal';
 export * from './decimal-symbol';
 export * from './dialog-size';
 export * from './direction';
+export * from './dropdown-align';
 export * from './dropdown-width';
 export * from './hint-direction';
 export * from './marker-handler';

--- a/projects/demo/src/modules/components/abstract/control.ts
+++ b/projects/demo/src/modules/components/abstract/control.ts
@@ -3,8 +3,8 @@ import {TuiAutofillFieldName, TuiInputMode, TuiInputType} from '@taiga-ui/cdk';
 import {
     TUI_DROPDOWN_DEFAULT_OPTIONS,
     TUI_HINT_DIRECTIONS,
+    TuiDropdownAlign,
     TuiDropdownWidth,
-    TuiHorizontalDirection,
     TuiSizeL,
     TuiSizeS,
     TuiVerticalDirection,
@@ -118,7 +118,11 @@ export abstract class AbstractExampleTuiControl
 
     hintAppearance = this.hintAppearanceVariants[0];
 
-    readonly dropdownAlignVariants: readonly TuiHorizontalDirection[] = [`left`, `right`];
+    readonly dropdownAlignVariants: readonly TuiDropdownAlign[] = [
+        `left`,
+        `right`,
+        `center`,
+    ];
 
     dropdownAlign = TUI_DROPDOWN_DEFAULT_OPTIONS.align;
 

--- a/projects/demo/src/modules/components/abstract/dropdown-documentation/dropdown-documentation.template.html
+++ b/projects/demo/src/modules/components/abstract/dropdown-documentation/dropdown-documentation.template.html
@@ -18,7 +18,7 @@
     <ng-template
         documentationPropertyName="tuiDropdownAlign"
         documentationPropertyMode="input"
-        documentationPropertyType="TuiHorizontalDirection"
+        documentationPropertyType="TuiDropdownAlign"
         [documentationPropertyValues]="documentedComponent.dropdownAlignVariants"
         [(documentationPropertyValue)]="documentedComponent.dropdownAlign"
     >

--- a/projects/demo/src/modules/components/abstract/dropdown.ts
+++ b/projects/demo/src/modules/components/abstract/dropdown.ts
@@ -1,12 +1,16 @@
 import {
     TUI_DROPDOWN_DEFAULT_OPTIONS,
+    TuiDropdownAlign,
     TuiDropdownWidth,
-    TuiHorizontalDirection,
     TuiVerticalDirection,
 } from '@taiga-ui/core';
 
 export abstract class AbstractExampleTuiDropdown {
-    readonly dropdownAlignVariants: readonly TuiHorizontalDirection[] = [`left`, `right`];
+    readonly dropdownAlignVariants: readonly TuiDropdownAlign[] = [
+        `left`,
+        `right`,
+        `center`,
+    ];
 
     readonly dropdownLimitWidthVariants: readonly TuiDropdownWidth[] = [
         `fixed`,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Does not align dropdown to center

Closes # [3704](https://github.com/Tinkoff/taiga-ui/issues/3704)

## What is the new behavior?

Aligns dropdown to center

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
