### PR TITLE
docs: add missing closing tag in app-bar docs

### DIFF
--- a/projects/demo/src/modules/components/app-bar/examples/import/insert-template.md
+++ b/projects/demo/src/modules/components/app-bar/examples/import/insert-template.md
@@ -14,5 +14,6 @@
       title="settings"
       tuiSlot="right"
     ></button>
+  </tui-app-bar>
 </header>
 ```


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [x] Documentation content changes

## What is the current behavior?

The example HTML code for tui-app-bar is missing the closing tag for tui-app-bar.

Here's a link to the documentation: https://taiga-ui.dev/navigation/app-bar/Setup

The missing tag is at the end of step 2: 'Add to the template'

## What is the new behavior?

This PR adds the missing closing tag for tui-app-bar in the example code, so that the example code is valid.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
