### PR TITLE
fix(addon-editor): class constructor `NodeView` cannot be invoked without `new`

### DIFF
--- a/projects/addon-editor/extensions/tiptap-node-view/node-view-render.ts
+++ b/projects/addon-editor/extensions/tiptap-node-view/node-view-render.ts
@@ -7,6 +7,7 @@ import {
     NodeViewProps,
     NodeViewRenderer,
     NodeViewRendererOptions,
+    NodeViewRendererProps,
 } from '@tiptap/core';
 import type {Node as ProseMirrorNode} from 'prosemirror-model';
 import type {Decoration} from 'prosemirror-view';
@@ -29,7 +30,7 @@ export class TuiNodeViewNgComponent implements NodeViewProps {
     deleteNode!: NodeViewProps['deleteNode'];
 }
 
-interface TuiNodeViewRendererOptions extends NodeViewRendererOptions {
+export interface TuiNodeViewRendererOptions extends NodeViewRendererOptions {
     update?: (node: ProseMirrorNode, decorations: Decoration[]) => boolean;
     injector: Injector;
 }
@@ -43,7 +44,7 @@ interface TuiNodeViewRendererOptions extends NodeViewRendererOptions {
  * It was copied from
  * {@link https://github.com/sibiraj-s/ngx-tiptap/blob/master/projects/ngx-tiptap/src/lib/NodeViewRenderer.ts ngx-tiptap}
  */
-class TuiNodeView extends NodeView<
+export class TuiNodeView extends NodeView<
     Type<TuiNodeViewNgComponent>,
     Editor,
     TuiNodeViewRendererOptions
@@ -149,10 +150,10 @@ class TuiNodeView extends NodeView<
     }
 }
 
-export const TuiNodeViewRenderer =
-    (
-        component: Type<TuiNodeViewNgComponent>,
-        options: Partial<TuiNodeViewRendererOptions>,
-    ): NodeViewRenderer =>
-    props =>
-        new TuiNodeView(component, props, options);
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function TuiNodeViewRenderer(
+    component: Type<TuiNodeViewNgComponent>,
+    options: Partial<TuiNodeViewRendererOptions>,
+): NodeViewRenderer {
+    return (props: NodeViewRendererProps) => new TuiNodeView(component, props, options);
+}

--- a/projects/cdk/tokens/index.ts
+++ b/projects/cdk/tokens/index.ts
@@ -11,6 +11,7 @@ export * from './is-cypress';
 export * from './is-firefox';
 export * from './is-ios';
 export * from './is-mobile';
+export * from './is-stackblitz';
 export * from './is-webkit';
 export * from './range';
 export * from './removed-element';

--- a/projects/cdk/tokens/is-stackblitz.ts
+++ b/projects/cdk/tokens/is-stackblitz.ts
@@ -1,0 +1,6 @@
+import {inject, InjectionToken} from '@angular/core';
+import {WINDOW} from '@ng-web-apis/common';
+
+export const TUI_IS_STACKBLITZ = new InjectionToken<boolean>(`[TUI_IS_STACKBLITZ]`, {
+    factory: () => inject(WINDOW).location.host.endsWith(`stackblitz.io`),
+});

--- a/projects/demo/src/environments/environment.prod.ts
+++ b/projects/demo/src/environments/environment.prod.ts
@@ -1,14 +1,4 @@
 export const environment = {
     production: true,
     ym: 87890624,
-    imgbb: {
-        host: `https://api.imgbb.com`,
-        apiKey: `3c1615980dcf693b282c4b0fb608b28a`,
-        expiration: 300, // 5min lifetime
-    },
-    fileIO: {
-        host: `https://file.io/`,
-        autoDelete: `true`,
-        expires: `1d`,
-    },
 };

--- a/projects/demo/src/modules/app/stackblitz/project-files/configs.md
+++ b/projects/demo/src/modules/app/stackblitz/project-files/configs.md
@@ -69,7 +69,7 @@
     "module": "es2020",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es5",
     "typeRoots": ["node_modules/@types"],
     "lib": ["esnext", "dom"]
   },

--- a/projects/demo/src/modules/app/stackblitz/utils.ts
+++ b/projects/demo/src/modules/app/stackblitz/utils.ts
@@ -153,6 +153,7 @@ import {
 } from '@taiga-ui/addon-tablebars';
 
 import {ScrollingModule} from '@angular/cdk/scrolling';
+import {HttpClientModule} from '@angular/common/http';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
@@ -163,6 +164,7 @@ ${additionalModulesImports}
 export const ALL_TAIGA_UI_MODULES = [
     BrowserModule,
     BrowserAnimationsModule,
+    HttpClientModule,
     FormsModule,
     ReactiveFormsModule,
     ScrollingModule,

--- a/projects/demo/src/modules/components/editor/images/preview/editor-preview-images.component.ts
+++ b/projects/demo/src/modules/components/editor/images/preview/editor-preview-images.component.ts
@@ -20,17 +20,17 @@ export class ExampleTuiEditorResizableImagesComponent {
     readonly example1: TuiDocExample = {
         TypeScript: import('./examples/1/index.ts?raw'),
         HTML: import('./examples/1/index.html?raw'),
+        'image-preview/image-preview.template.html': import(
+            './examples/1/image-preview/image-preview.template.html?raw'
+        ),
+        'image-preview/image-preview.style.less': import(
+            './examples/1/image-preview/image-preview.style.less?raw'
+        ),
         'image-preview/image-preview.component.ts': import(
             './examples/1/image-preview/image-preview.component.ts?raw'
         ),
         'image-preview/image-preview.module.ts': import(
             './examples/1/image-preview/image-preview.module.ts?raw'
-        ),
-        'image-preview/image-preview.style.less': import(
-            './examples/1/image-preview/image-preview.style.less?raw'
-        ),
-        'image-preview.template.html': import(
-            './examples/1/image-preview/image-preview.template.html?raw'
         ),
     };
 }

--- a/projects/demo/src/modules/components/editor/images/preview/examples/1/index.ts
+++ b/projects/demo/src/modules/components/editor/images/preview/examples/1/index.ts
@@ -1,9 +1,9 @@
-import {Component, Injector} from '@angular/core';
+import {Component, Inject, Injector} from '@angular/core';
 import {FormControl} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
 import {TUI_EDITOR_EXTENSIONS, TuiEditorTool} from '@taiga-ui/addon-editor';
-import {TuiDestroyService} from '@taiga-ui/cdk';
+import {TUI_IS_STACKBLITZ, TuiDestroyService} from '@taiga-ui/cdk';
 
 @Component({
     selector: 'tui-editor-preview-images-example-1',
@@ -28,13 +28,15 @@ import {TuiDestroyService} from '@taiga-ui/cdk';
     encapsulation,
 })
 export class TuiEditorPreviewImagesExample1 {
+    private readonly relativePath = this.isStackblitz ? 'https://taiga-ui.dev/' : '';
+
     readonly builtInTools = [TuiEditorTool.Undo, TuiEditorTool.Img];
 
     control = new FormControl('');
 
-    constructor() {
+    constructor(@Inject(TUI_IS_STACKBLITZ) private readonly isStackblitz: boolean) {
         this.control.patchValue(
-            '<p>Small image</p><img data-type="image-editor" src="assets/images/lumberjack.png" width="300"><p>Big image</p><img data-type="image-editor" src="assets/images/big-wallpaper.jpg" width="500">',
+            `<p>Small image</p><img data-type="image-editor" src="${this.relativePath}assets/images/lumberjack.png" width="300"><p>Big image</p><img data-type="image-editor" src="${this.relativePath}assets/images/big-wallpaper.jpg" width="500">`,
         );
     }
 }

--- a/projects/demo/src/modules/components/editor/images/resizable/examples/1/index.ts
+++ b/projects/demo/src/modules/components/editor/images/resizable/examples/1/index.ts
@@ -8,7 +8,7 @@ import {
     TUI_IMAGE_LOADER,
     TuiEditorTool,
 } from '@taiga-ui/addon-editor';
-import {TuiDestroyService, TuiHandler} from '@taiga-ui/cdk';
+import {TUI_IS_STACKBLITZ, TuiDestroyService, TuiHandler} from '@taiga-ui/cdk';
 import {Observable} from 'rxjs';
 import {switchMap, takeUntil} from 'rxjs/operators';
 
@@ -35,10 +35,12 @@ import {switchMap, takeUntil} from 'rxjs/operators';
     encapsulation,
 })
 export class TuiEditorResizableEditorExample1 {
+    private readonly relativePath = this.isStackblitz ? 'https://taiga-ui.dev/' : '';
+
     readonly builtInTools = [TuiEditorTool.Undo, TuiEditorTool.Img];
 
     base64Image$ = this.http
-        .get('assets/images/lumberjack.png', {responseType: 'blob'})
+        .get(`${this.relativePath}assets/images/lumberjack.png`, {responseType: 'blob'})
         .pipe(switchMap(file => this.imageLoader(file)));
 
     control = new FormControl('');
@@ -48,6 +50,7 @@ export class TuiEditorResizableEditorExample1 {
         private readonly imageLoader: TuiHandler<Blob, Observable<string>>,
         @Inject(HttpClient) private readonly http: HttpClient,
         @Self() @Inject(TuiDestroyService) destroy$: TuiDestroyService,
+        @Inject(TUI_IS_STACKBLITZ) private readonly isStackblitz: boolean,
     ) {
         this.base64Image$.pipe(takeUntil(destroy$)).subscribe(src => {
             this.control.patchValue(

--- a/projects/demo/src/modules/components/editor/images/upload/editor-upload-images.component.ts
+++ b/projects/demo/src/modules/components/editor/images/upload/editor-upload-images.component.ts
@@ -20,7 +20,7 @@ export class ExampleTuiEditorUploadingImagesComponent {
     readonly example1: TuiDocExample = {
         TypeScript: import('./examples/1/index.ts?raw'),
         HTML: import('./examples/1/index.html?raw'),
-        './image-loader.ts': import('./examples/1/image-loader.ts?raw'),
-        './imgbb.service.ts': import('./examples/1/imgbb.service.ts?raw'),
+        'image-loader.ts': import('./examples/1/image-loader.ts?raw'),
+        'imgbb.service.ts': import('./examples/1/imgbb.service.ts?raw'),
     };
 }

--- a/projects/demo/src/modules/components/editor/images/upload/examples/1/imgbb.service.ts
+++ b/projects/demo/src/modules/components/editor/images/upload/examples/1/imgbb.service.ts
@@ -2,7 +2,16 @@ import {Injectable} from '@angular/core';
 import {BehaviorSubject, from, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
-import {environment} from '../../../../../../../environments/environment';
+/**
+ * @description:
+ * You can get your credentials for testing API on:
+ * https://api.imgbb.com/
+ */
+const imgbb = {
+    host: `https://api.imgbb.com`,
+    apiKey: `3c1615980dcf693b282c4b0fb608b28a`,
+    expiration: 300, // 5min lifetime
+};
 
 interface ImgbbResponse {
     data: {
@@ -38,14 +47,15 @@ export class ImgbbService {
     }
 
     save(base64: string): Observable<string> {
-        const {host, apiKey, expiration} = environment.imgbb;
-
         return from(
-            fetch(`${host}/1/upload?key=${apiKey}&expiration=${expiration}`, {
-                method: `POST`,
-                body: ImgbbService.createBody(base64),
-                headers: {'Content-Type': `application/x-www-form-urlencoded`},
-            }).then(async (response: Response) => response.json()),
+            fetch(
+                `${imgbb.host}/1/upload?key=${imgbb.apiKey}&expiration=${imgbb.expiration}`,
+                {
+                    method: `POST`,
+                    body: ImgbbService.createBody(base64),
+                    headers: {'Content-Type': `application/x-www-form-urlencoded`},
+                },
+            ).then(async (response: Response) => response.json()),
         ).pipe(map((response: ImgbbResponse) => response.data.url));
     }
 }

--- a/projects/demo/src/modules/components/editor/images/upload/examples/1/index.ts
+++ b/projects/demo/src/modules/components/editor/images/upload/examples/1/index.ts
@@ -11,7 +11,7 @@ import {
     TuiEditorComponent,
     TuiEditorTool,
 } from '@taiga-ui/addon-editor';
-import {TuiDestroyService, TuiValidationError} from '@taiga-ui/cdk';
+import {TUI_IS_STACKBLITZ, TuiDestroyService, TuiValidationError} from '@taiga-ui/cdk';
 
 import {imageLoader} from './image-loader';
 import {ImgbbService} from './imgbb.service';
@@ -56,7 +56,9 @@ import {ImgbbService} from './imgbb.service';
 })
 export class TuiEditorUploadingImagesExample1 {
     @ViewChild(TuiEditorComponent, {static: true})
-    private readonly editor!: TuiEditorComponent;
+    private readonly editor?: TuiEditorComponent;
+
+    private readonly relativePath = this.isStackblitz ? 'https://taiga-ui.dev/' : '';
 
     readonly builtInTools = [TuiEditorTool.Undo, TuiEditorTool.Img];
 
@@ -65,17 +67,19 @@ export class TuiEditorUploadingImagesExample1 {
     constructor(
         @Inject(DOCUMENT) readonly doc: Document,
         @Inject(ImgbbService) readonly imgbbService: ImgbbService,
+        @Inject(TUI_IS_STACKBLITZ) private readonly isStackblitz: boolean,
     ) {
         this.control.patchValue(
-            '<img data-type="image-editor" src="/assets/images/lumberjack.png" width="300">' +
-                '<p>Try to drag right border of image!</p>' +
-                '<p>To change min/max size of image use token <code>TUI_IMAGE_EDITOR_OPTIONS</code>.</p>' +
-                '<img src="data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUwIDUwIiB3aWR0aD0iNTAiIGhlaWdodD0iNTAiPjxzdHlsZT4uYXtmaWxsOiNkZDAwMzF9LmJ7ZmlsbDojYzMwMDJmfS5je2ZpbGw6I2ZmZn08L3N0eWxlPjxwYXRoIGNsYXNzPSJhIiBkPSJtNDMuNiAxMi42bC0yLjggMjQuNy0xNS44IDguNy0xNS44LTguNy0yLjgtMjQuNyAxOC42LTYuNnoiLz48cGF0aCBjbGFzcz0iYiIgZD0ibTI1IDZsMTguNiA2LjYtMi44IDI0LjctMTUuOCA4Ljd2LTE1LjMtMjAuMy00LjR6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGFzcz0iYyIgZD0ibTM2LjYgMzYuNWgtNC4zbC0yLjQtNS44aC05LjlsLTIuMyA1LjhoLTQuM2wxMS42LTI2LjF6bS0xMS42LTE3LjZsLTMuNCA4LjJoNi44eiIvPjwvc3ZnPg==" />',
+            `
+                <img data-type="image-editor" src="${this.relativePath}assets/images/lumberjack.png" width="300">
+                <p>Try to drag right border of image!</p>
+                <p>To change min/max size of image use token <code>TUI_IMAGE_EDITOR_OPTIONS</code>.</p>
+                <img src="data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUwIDUwIiB3aWR0aD0iNTAiIGhlaWdodD0iNTAiPjxzdHlsZT4uYXtmaWxsOiNkZDAwMzF9LmJ7ZmlsbDojYzMwMDJmfS5je2ZpbGw6I2ZmZn08L3N0eWxlPjxwYXRoIGNsYXNzPSJhIiBkPSJtNDMuNiAxMi42bC0yLjggMjQuNy0xNS44IDguNy0xNS44LTguNy0yLjgtMjQuNyAxOC42LTYuNnoiLz48cGF0aCBjbGFzcz0iYiIgZD0ibTI1IDZsMTguNiA2LjYtMi44IDI0LjctMTUuOCA4Ljd2LTE1LjMtMjAuMy00LjR6Ii8+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGFzcz0iYyIgZD0ibTM2LjYgMzYuNWgtNC4zbC0yLjQtNS44aC05LjlsLTIuMyA1LjhoLTQuM2wxMS42LTI2LjF6bS0xMS42LTE3LjZsLTMuNCA4LjJoNi44eiIvPjwvc3ZnPg==" />`,
         );
     }
 
     readonly validator = ({value}: AbstractControl): ValidationErrors | null =>
-        this.editor.focused ||
+        this.editor?.focused ||
         this.imgbbService.isLoading ||
         !this.doc.hasFocus() || // possible that file dialog is open
         value.length

--- a/projects/demo/src/modules/components/editor/upload-files/examples/1/filesio.service.ts
+++ b/projects/demo/src/modules/components/editor/upload-files/examples/1/filesio.service.ts
@@ -3,7 +3,17 @@ import {TuiEditorAttachedFile} from '@taiga-ui/addon-editor';
 import {BehaviorSubject, from, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
-import {environment} from '../../../../../../environments/environment';
+/**
+ * @description:
+ * You can get your credentials for testing API
+ * by free file.io account:
+ * https://www.file.io/plans
+ */
+const fileIO = {
+    host: `https://file.io/`,
+    autoDelete: `true`,
+    expires: `1d`,
+};
 
 @Injectable({
     providedIn: `root`,
@@ -12,15 +22,14 @@ export class FileIoService {
     readonly loading$ = new BehaviorSubject(false);
 
     upload(file: File): Observable<TuiEditorAttachedFile> {
-        const {host, expires, autoDelete} = environment.fileIO;
         const body = new FormData();
 
         body.append(`file`, file, file.name);
-        body.append(`expires`, expires);
-        body.append(`autoDelete`, autoDelete);
+        body.append(`expires`, fileIO.expires);
+        body.append(`autoDelete`, fileIO.autoDelete);
 
         return from(
-            fetch(host, {
+            fetch(fileIO.host, {
                 method: `POST`,
                 body,
             }).then(async (response: Response) => response.json()),


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?

Closes #3815


<img width="586" alt="image" src="https://user-images.githubusercontent.com/12021443/235505004-e4d73bcf-751a-4cbc-80ae-b9450d7d49c1.png">
