### PR TITLE
feat(addon-doc): add new parameter `tabTitles` to `TUI_DOC_EXAMPLE_OPTIONS`

### DIFF
--- a/projects/addon-doc/components/example/example-options.ts
+++ b/projects/addon-doc/components/example/example-options.ts
@@ -1,9 +1,11 @@
 import {InjectionToken, ValueProvider} from '@angular/core';
 import {TUI_EXAMPLE_PRIMARY_FILE_NAME} from '@taiga-ui/addon-doc/interfaces';
 import {TuiBooleanHandler} from '@taiga-ui/cdk';
+import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 
 export interface TuiDocExampleOptions {
     codeEditorVisibilityHandler: TuiBooleanHandler<Record<string, string>>;
+    tabTitles: Map<unknown, PolymorpheusContent>;
 }
 
 export const TUI_DOC_EXAMPLE_DEFAULT_OPTIONS: TuiDocExampleOptions = {
@@ -12,6 +14,7 @@ export const TUI_DOC_EXAMPLE_DEFAULT_OPTIONS: TuiDocExampleOptions = {
             files[TUI_EXAMPLE_PRIMARY_FILE_NAME.TS] &&
                 files[TUI_EXAMPLE_PRIMARY_FILE_NAME.HTML],
         ),
+    tabTitles: new Map(),
 };
 
 /**

--- a/projects/addon-doc/components/example/example.component.ts
+++ b/projects/addon-doc/components/example/example.component.ts
@@ -88,6 +88,10 @@ export class TuiDocExampleComponent {
     readonly visible = (files: Record<string, string>): boolean =>
         Boolean(this.codeEditor && this.options.codeEditorVisibilityHandler(files));
 
+    getTabTitle(fileName: string): PolymorpheusContent {
+        return this.options.tabTitles.get(fileName) || fileName;
+    }
+
     copyExampleLink(): void {
         const hashPosition = this.location.href.indexOf('#');
         const currentUrl =

--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -42,7 +42,9 @@
                         *tuiItem
                         tuiTab
                     >
-                        {{ tab }}
+                        <ng-container *polymorpheusOutlet="getTabTitle(tab) as text">
+                            {{ text }}
+                        </ng-container>
                     </button>
                 </ng-container>
             </tui-tabs-with-more>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?
**angular-logo.component.ts**
```ts
@Component({
    selector: `angular-logo`,
    template: `
        <tui-svg [src]="link"></tui-svg>
    `,
    changeDetection: ChangeDetectionStrategy.OnPush,
})
export class AngularLogoComponent {
    readonly link = `https://taiga-ui.dev/assets/images/angular.svg`;
}

export const ANGULAR_LOGO = new PolymorpheusComponent(AngularLogoComponent);
```

**app.providers.ts**
```ts
tuiDocExampleOptionsProvider({
    tabTitles: new Map<string, PolymorpheusContent>([
        [`index.ts`, TYPESCRIPT_LOGO],
        [`app.component.ts`, ANGULAR_LOGO],
        [`index.tsx`, REACT_LOGO],
    ]),
}),
```

<img width="597" alt="Screenshot 2023-05-03 at 11 38 27" src="https://user-images.githubusercontent.com/35179038/235868858-429e4696-c080-47f2-a4cd-ada7017db91a.png">



## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
