### PR TITLE
feat(core): support cache busting for `tuiIcon...` icons

### DIFF
--- a/projects/core/components/svg/svg.component.ts
+++ b/projects/core/components/svg/svg.component.ts
@@ -20,7 +20,7 @@ import {
     TuiStaticRequestService,
     TuiStringHandler,
 } from '@taiga-ui/cdk';
-import {TUI_ICON_ERROR} from '@taiga-ui/core/constants';
+import {TUI_CACHE_BUSTING_PAYLOAD, TUI_ICON_ERROR} from '@taiga-ui/core/constants';
 import {TuiIconError} from '@taiga-ui/core/interfaces';
 import {TuiSvgService} from '@taiga-ui/core/services';
 import {TUI_SANITIZER} from '@taiga-ui/core/tokens';
@@ -112,7 +112,7 @@ export class TuiSvgComponent {
     }
 
     private get isUse(): boolean {
-        return this.use.includes('.svg#');
+        return this.use.replace(TUI_CACHE_BUSTING_PAYLOAD, '').includes('.svg#');
     }
 
     private get isExternal(): boolean {

--- a/projects/core/constants/cache-basting-payload.ts
+++ b/projects/core/constants/cache-basting-payload.ts
@@ -1,0 +1,3 @@
+import {TUI_VERSION} from '@taiga-ui/cdk';
+
+export const TUI_CACHE_BUSTING_PAYLOAD = `?v=${TUI_VERSION}` as const;

--- a/projects/core/constants/index.ts
+++ b/projects/core/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './cache-basting-payload';
 export * from './decimal-symbols';
 export * from './default-icons-path';
 export * from './default-marker-handler';

--- a/projects/core/pipes/flag/flag.pipe.ts
+++ b/projects/core/pipes/flag/flag.pipe.ts
@@ -1,12 +1,14 @@
 import {Inject, Pipe, PipeTransform} from '@angular/core';
 import {TUI_SVG_OPTIONS, TuiSvgOptions} from '@taiga-ui/core/components/svg';
+import {TUI_CACHE_BUSTING_PAYLOAD} from '@taiga-ui/core/constants';
 import {TuiCountryIsoCode} from '@taiga-ui/i18n';
 
 @Pipe({name: `tuiFlag`})
 export class TuiFlagPipe implements PipeTransform {
     private readonly staticPath = this.svgOptions
         .path(`tuiIcon`)
-        .replace(`tuiIcon.svg#tuiIcon`, ``);
+        .replace(`tuiIcon.svg#tuiIcon`, ``)
+        .replace(`tuiIcon.svg${TUI_CACHE_BUSTING_PAYLOAD}#tuiIcon`, ``);
 
     constructor(@Inject(TUI_SVG_OPTIONS) private readonly svgOptions: TuiSvgOptions) {}
 

--- a/projects/core/utils/miscellaneous/icons-path-factory.ts
+++ b/projects/core/utils/miscellaneous/icons-path-factory.ts
@@ -1,12 +1,12 @@
 import {TuiStringHandler} from '@taiga-ui/cdk';
-import {DEFAULT_ICONS_PATH} from '@taiga-ui/core/constants';
+import {DEFAULT_ICONS_PATH, TUI_CACHE_BUSTING_PAYLOAD} from '@taiga-ui/core/constants';
 
 export function tuiIconsPathFactory(staticPath: string): TuiStringHandler<string> {
     const base = staticPath.endsWith(`/`) ? staticPath : `${staticPath}/`;
 
     return name => {
         if (name.startsWith(`tuiIcon`)) {
-            return `${base}${name}.svg#${name}`;
+            return `${base}${name}.svg${TUI_CACHE_BUSTING_PAYLOAD}#${name}`;
         }
 
         return DEFAULT_ICONS_PATH(name);


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

https://www.keycdn.com/support/what-is-cache-busting

## What is the new behavior?

<img width="540" alt="image" src="https://user-images.githubusercontent.com/12021443/235922945-08e916ae-caf6-49aa-8f4d-2c897d4888ec.png">
