### PR TITLE
feat(core): add `tuiSvgSrcInterceptors` for multiple source processing

### DIFF
--- a/projects/cdk/interfaces/index.ts
+++ b/projects/cdk/interfaces/index.ts
@@ -7,6 +7,7 @@ export * from './control-value-transformer';
 export * from './day-like';
 export * from './focusable-element-accessor';
 export * from './month-like';
+export * from './safe-html';
 export * from './swipe';
 export * from './time-like';
 export * from './year-like';

--- a/projects/cdk/interfaces/safe-html.ts
+++ b/projects/cdk/interfaces/safe-html.ts
@@ -1,0 +1,3 @@
+import {SafeHtml} from '@angular/platform-browser';
+
+export type TuiSafeHtml = SafeHtml | string;

--- a/projects/cdk/utils/svg/svg-linear-gradient-processor.ts
+++ b/projects/cdk/utils/svg/svg-linear-gradient-processor.ts
@@ -1,4 +1,4 @@
-import {SafeHtml} from '@angular/platform-browser';
+import {TuiSafeHtml} from '@taiga-ui/cdk/interfaces';
 import {tuiIsString} from '@taiga-ui/cdk/utils/miscellaneous';
 
 /**
@@ -16,9 +16,9 @@ import {tuiIsString} from '@taiga-ui/cdk/utils/miscellaneous';
  *
  */
 export function tuiSvgLinearGradientProcessor(
-    svg: SafeHtml | string,
+    svg: TuiSafeHtml,
     salt?: number | string,
-): SafeHtml | string {
+): TuiSafeHtml {
     if (tuiIsString(svg)) {
         const uniqueIds = extractLinearGradientIdsFromSvg(svg);
 

--- a/projects/core/components/svg/svg-options.ts
+++ b/projects/core/components/svg/svg-options.ts
@@ -1,8 +1,15 @@
-import {FactoryProvider, inject, InjectionToken, Optional, SkipSelf} from '@angular/core';
-import {SafeHtml} from '@angular/platform-browser';
+import {
+    FactoryProvider,
+    inject,
+    InjectionToken,
+    Optional,
+    Provider,
+    SkipSelf,
+} from '@angular/core';
 import {
     TuiHandler,
     tuiIsString,
+    TuiSafeHtml,
     TuiStringHandler,
     tuiSvgLinearGradientProcessor,
 } from '@taiga-ui/cdk';
@@ -19,8 +26,8 @@ import {TUI_DEPRECATED_ICONS} from './deprecated-icons';
 export interface TuiSvgOptions {
     readonly path: TuiStringHandler<string>;
     readonly deprecated: TuiStringHandler<string>;
-    readonly srcProcessor: TuiHandler<SafeHtml | string, SafeHtml | string>;
-    readonly contentProcessor: TuiHandler<SafeHtml | string, SafeHtml | string>;
+    readonly srcProcessor: TuiHandler<TuiSafeHtml, TuiSafeHtml>;
+    readonly contentProcessor: TuiHandler<TuiSafeHtml, TuiSafeHtml>;
 }
 
 export const TUI_SVG_DEFAULT_OPTIONS: TuiSvgOptions = {
@@ -48,6 +55,20 @@ export const TUI_SVG_OPTIONS = new InjectionToken<TuiSvgOptions>(`[TUI_SVG_OPTIO
         contentProcessor: inject(TUI_SVG_CONTENT_PROCESSOR),
     }),
 });
+
+export const TUI_SVG_SRC_INTERCEPTORS = new InjectionToken<
+    TuiHandler<TuiSafeHtml, TuiSafeHtml>
+>(`[TUI_SVG_SRC_INTERCEPTORS]`);
+
+export function tuiSvgSrcInterceptors(
+    interceptor: TuiHandler<TuiSafeHtml, TuiSafeHtml>,
+): Provider {
+    return {
+        provide: TUI_SVG_SRC_INTERCEPTORS,
+        useValue: interceptor,
+        multi: true,
+    };
+}
 
 export const tuiSvgOptionsProvider: (
     options: Partial<Omit<TuiSvgOptions, 'path'>> & {

--- a/projects/core/components/svg/test/svg-options.component.spec.ts
+++ b/projects/core/components/svg/test/svg-options.component.spec.ts
@@ -1,6 +1,6 @@
 import {Component, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {TUI_VERSION, tuiIsString, TuiStringHandler} from '@taiga-ui/cdk';
+import {TUI_VERSION, tuiIsString, TuiSafeHtml, TuiStringHandler} from '@taiga-ui/cdk';
 import {
     TUI_ICONS_PATH,
     TUI_ICONS_PLACE,
@@ -9,6 +9,7 @@ import {
     TuiSvgComponent,
     TuiSvgModule,
     tuiSvgOptionsProvider,
+    tuiSvgSrcInterceptors,
 } from '@taiga-ui/core';
 import {configureTestSuite} from '@taiga-ui/testing';
 
@@ -259,6 +260,54 @@ describe(`SVG options`, () => {
 
             expect(testComponent?.svgComponent.isInnerHTML).toBe(true);
             expect(testComponent?.svgComponent.src).toBe(`https://google.com/test.svg`);
+        });
+    });
+
+    describe(`multiple source processors`, () => {
+        configureTestSuite(() => {
+            TestBed.configureTestingModule({
+                imports: [TuiSvgModule],
+                declarations: [TestComponent],
+                providers: [
+                    tuiSvgOptionsProvider({path: `assets/default-path-to-icons/`}),
+                    tuiSvgSrcInterceptors((src: TuiSafeHtml) =>
+                        String(src).startsWith(`icons8::`)
+                            ? `assets/icons8/${String(src).replace(`icons8::`, ``)}.svg`
+                            : src,
+                    ),
+                    tuiSvgSrcInterceptors((src: TuiSafeHtml) =>
+                        String(src).startsWith(`tuiIconTds`)
+                            ? `assets/design-tokens/${String(src)}.svg`
+                            : src,
+                    ),
+                ],
+            });
+        });
+
+        it(`tuiIconMyDefault`, () => {
+            testComponent!.icon = `tuiIconMyDefault`;
+            fixture?.detectChanges();
+
+            expect(testComponent?.svgComponent.isInnerHTML).toBe(false);
+            expect(testComponent?.svgComponent.src).toBe(`tuiIconMyDefault`);
+        });
+
+        it(`icons8`, () => {
+            testComponent!.icon = `icons8::android`;
+            fixture?.detectChanges();
+
+            expect(testComponent?.svgComponent.isInnerHTML).toBe(true);
+            expect(testComponent?.svgComponent.src).toBe(`assets/icons8/android.svg`);
+        });
+
+        it(`tuiIconTdsSuperToken`, () => {
+            testComponent!.icon = `tuiIconTdsSuperToken`;
+            fixture?.detectChanges();
+
+            expect(testComponent?.svgComponent.isInnerHTML).toBe(true);
+            expect(testComponent?.svgComponent.src).toBe(
+                `assets/design-tokens/tuiIconTdsSuperToken.svg`,
+            );
         });
     });
 

--- a/projects/core/tokens/svg-content-processor.ts
+++ b/projects/core/tokens/svg-content-processor.ts
@@ -1,13 +1,10 @@
 import {InjectionToken} from '@angular/core';
-import {SafeHtml} from '@angular/platform-browser';
-import {TuiHandler, tuiSvgLinearGradientProcessor} from '@taiga-ui/cdk';
+import {TuiHandler, TuiSafeHtml, tuiSvgLinearGradientProcessor} from '@taiga-ui/cdk';
 
 /**
  * Transform function the contents of the loaded svg file
  * @deprecated Use {@link TUI_SVG_OPTIONS} instead
  */
 export const TUI_SVG_CONTENT_PROCESSOR = new InjectionToken<
-    TuiHandler<SafeHtml | string, SafeHtml | string>
->(`[TUI_SVG_CONTENT_PROCESSOR]`, {
-    factory: () => tuiSvgLinearGradientProcessor,
-});
+    TuiHandler<TuiSafeHtml, TuiSafeHtml>
+>(`[TUI_SVG_CONTENT_PROCESSOR]`, {factory: () => tuiSvgLinearGradientProcessor});

--- a/projects/core/tokens/svg-src-processor.ts
+++ b/projects/core/tokens/svg-src-processor.ts
@@ -1,6 +1,5 @@
 import {InjectionToken} from '@angular/core';
-import {SafeHtml} from '@angular/platform-browser';
-import {TuiHandler} from '@taiga-ui/cdk';
+import {TuiHandler, TuiSafeHtml} from '@taiga-ui/cdk';
 import {identity} from 'rxjs';
 
 /**
@@ -8,7 +7,5 @@ import {identity} from 'rxjs';
  * @deprecated Use {@link TUI_SVG_OPTIONS} instead
  */
 export const TUI_SVG_SRC_PROCESSOR = new InjectionToken<
-    TuiHandler<SafeHtml | string, SafeHtml | string>
->(`[TUI_SVG_SRC_PROCESSOR]`, {
-    factory: () => identity,
-});
+    TuiHandler<TuiSafeHtml, TuiSafeHtml>
+>(`[TUI_SVG_SRC_PROCESSOR]`, {factory: () => identity});

--- a/projects/demo/src/modules/components/avatar/avatar.component.ts
+++ b/projects/demo/src/modules/components/avatar/avatar.component.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
-import {SafeHtml} from '@angular/platform-browser';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {RawLoaderContent, TuiDocExample} from '@taiga-ui/addon-doc';
+import {TuiSafeHtml} from '@taiga-ui/cdk';
 import {TuiSizeXXL, TuiSizeXXS} from '@taiga-ui/core';
 
 @Component({
@@ -59,7 +59,7 @@ export class ExampleTuiAvatarComponent {
         'https://taiga-ui.dev/assets/images/test-not-found.png',
     ];
 
-    readonly fallbackVariants: ReadonlyArray<SafeHtml | string> = [
+    readonly fallbackVariants: readonly TuiSafeHtml[] = [
         'tuiIconUserLarge',
         '<svg enable-background="new 0 0 32 32" height="32px" viewBox="0 0 32 32" width="32px"' +
             ' xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="Error_x2C__lost_x2C__no_page_x2C__not_found"><g><g><g><circle cx="7.5" cy="5.5" fill="#263238" r="0.5"/><circle cx="5.5" cy="5.5" fill="#263238" r="0.5"/><circle cx="3.5" cy="5.5" fill="#263238" r="0.5"/><path d="M30.5,8h-29C1.224,8,1,7.776,1,7.5S1.224,7,1.5,7h29C30.776,7,31,7.224,31,7.5S30.776,8,30.5,8z" fill="#263238"/><path d="M29.5,29h-27C1.673,29,1,28.327,1,27.5v-23C1,3.673,1.673,3,2.5,3h27C30.327,3,31,3.673,31,4.5v23      C31,28.327,30.327,29,29.5,29z M2.5,4C2.224,4,2,4.225,2,4.5v23C2,27.775,2.224,28,2.5,28h27c0.276,0,0.5-0.225,0.5-0.5v-23      C30,4.225,29.776,4,29.5,4H2.5z" fill="#263238"/></g></g></g><g><path d="M24.5,24c-0.276,0-0.5-0.224-0.5-0.5V21h-3.5c-0.163,0-0.315-0.079-0.409-0.212s-0.117-0.303-0.062-0.456    l2.5-7C22.6,13.133,22.789,13,23,13h1.5c0.276,0,0.5,0.224,0.5,0.5V20h0.5c0.276,0,0.5,0.224,0.5,0.5S25.776,21,25.5,21H25v2.5    C25,23.776,24.776,24,24.5,24z M21.209,20H24v-6h-0.647L21.209,20z" fill="#263238"/><path d="M10.5,24c-0.276,0-0.5-0.224-0.5-0.5V21H6.5c-0.163,0-0.315-0.079-0.409-0.212s-0.117-0.303-0.062-0.456    l2.5-7C8.6,13.133,8.789,13,9,13h1.5c0.276,0,0.5,0.224,0.5,0.5V20h0.5c0.276,0,0.5,0.224,0.5,0.5S11.776,21,11.5,21H11v2.5    C11,23.776,10.776,24,10.5,24z M7.209,20H10v-6H9.353L7.209,20z" fill="#263238"/><path d="M17.5,24h-3c-0.827,0-1.5-0.673-1.5-1.5v-8c0-0.827,0.673-1.5,1.5-1.5h3c0.827,0,1.5,0.673,1.5,1.5v8    C19,23.327,18.327,24,17.5,24z M14.5,14c-0.276,0-0.5,0.225-0.5,0.5v8c0,0.275,0.224,0.5,0.5,0.5h3c0.276,0,0.5-0.225,0.5-0.5v-8    c0-0.275-0.224-0.5-0.5-0.5H14.5z" fill="#263238"/></g></g></svg>',
@@ -67,7 +67,7 @@ export class ExampleTuiAvatarComponent {
 
     avatarUrl: string | null = null;
 
-    fallback: SafeHtml | string | null = this.fallbackVariants[0];
+    fallback: TuiSafeHtml | null = this.fallbackVariants[0];
 
     text = 'daenerys targaryen';
 

--- a/projects/demo/src/modules/markup/icons/customization/customization-icons.component.ts
+++ b/projects/demo/src/modules/markup/icons/customization/customization-icons.component.ts
@@ -1,5 +1,6 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
-import {TUI_SANITIZER, tuiSvgOptionsProvider} from '@taiga-ui/core';
+import {TuiSafeHtml} from '@taiga-ui/cdk';
+import {TUI_SANITIZER, tuiSvgSrcInterceptors} from '@taiga-ui/core';
 import {NgDompurifySanitizer} from '@tinkoff/ng-dompurify';
 
 @Component({
@@ -15,15 +16,19 @@ import {NgDompurifySanitizer} from '@tinkoff/ng-dompurify';
             provide: TUI_SANITIZER,
             useClass: NgDompurifySanitizer,
         },
-        tuiSvgOptionsProvider({
-            srcProcessor: src => {
-                const myCustomPrefix = 'icons8::';
-
-                return String(src).startsWith(myCustomPrefix)
-                    ? `assets/icons8/${String(src).replace(myCustomPrefix, '')}.svg`
-                    : src;
-            },
-        }),
+        /**
+         * @note:
+         * Be careful, component has its own injector which doesn't inherit providers from parent injector.
+         * https://angular.io/guide/providers#providing-services-in-modules-versus-components
+         *
+         * If you want to keep previous interceptors then best to keep it global,
+         * provide all necessary interceptors at the top level of your app (e.g. AppModule).
+         */
+        tuiSvgSrcInterceptors((src: TuiSafeHtml) =>
+            String(src).startsWith('icons8::')
+                ? `assets/icons8/${String(src).replace('icons8::', '')}.svg`
+                : src,
+        ),
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/projects/kit/components/avatar/avatar.component.ts
+++ b/projects/kit/components/avatar/avatar.component.ts
@@ -5,8 +5,14 @@ import {
     Inject,
     Input,
 } from '@angular/core';
-import {SafeHtml, SafeResourceUrl} from '@angular/platform-browser';
-import {tuiDefaultProp, tuiIsString, tuiPure, tuiRequiredSetter} from '@taiga-ui/cdk';
+import {SafeResourceUrl} from '@angular/platform-browser';
+import {
+    tuiDefaultProp,
+    tuiIsString,
+    tuiPure,
+    tuiRequiredSetter,
+    TuiSafeHtml,
+} from '@taiga-ui/cdk';
 import {tuiSizeBigger, TuiSizeXXL, TuiSizeXXS} from '@taiga-ui/core';
 import {tuiStringHashToHsl} from '@taiga-ui/kit/utils/format';
 
@@ -37,7 +43,7 @@ export class TuiAvatarComponent {
 
     @Input()
     @tuiDefaultProp()
-    fallback: SafeHtml | string | null = null;
+    fallback: TuiSafeHtml | null = null;
 
     @Input()
     @tuiDefaultProp()


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

in proprietary repo

```ts
{
        provide: TUI_SVG_SRC_PROCESSOR,
        useFactory:
            (base: string): TuiStringHandler<string> =>
            src =>
                tuiIsString(src) && src.startsWith(`tuiIconTds`)
                    ? `${base}/${src}.svg`
                    : src,
        deps: [TUI_ICONS_PLACE],
    },
```

the main problem is that your users can overwrite default behavior

## What is the new behavior?

```ts
tuiSvgSrcInterceptors((src: TuiSafeHtml) =>
    String(src).startsWith(`icons8::`)
        ? `assets/icons8/${String(src).replace(`icons8::`, ``)}.svg`
        : src,
),
tuiSvgSrcInterceptors((src: TuiSafeHtml) =>
    String(src).startsWith(`tuiIconTds`)
        ? `assets/design-tokens/${String(src)}.svg`
        : src,
)
// ...
```
