### PR TITLE
docs: add custom content example to line-clamp

### DIFF
--- a/projects/demo/src/modules/components/line-clamp/examples/5/index.html
+++ b/projects/demo/src/modules/components/line-clamp/examples/5/index.html
@@ -1,0 +1,27 @@
+<p>1. Display only the first line, in a popup display remaining lines.</p>
+
+<tui-island class="island">
+    <tui-line-clamp
+        [content]="userAdditionalInfo"
+        [linesLimit]="1"
+    ></tui-line-clamp>
+</tui-island>
+
+<p>2. Do not use `tui-line-clamp`, use `text-overflow: ellipsis` instead.</p>
+
+<tui-island class="island">
+    <p
+        class="email"
+        [tuiHint]="userAdditionalInfo"
+    >
+        {{ user.email }}
+    </p>
+</tui-island>
+
+<ng-template #userAdditionalInfo>
+    <span>{{ user.email }}</span>
+
+    <p>User ID: {{ user.id }}</p>
+    <p>First Name: {{ user.firstName }}</p>
+    <p>Last Name: {{ user.lastName }}</p>
+</ng-template>

--- a/projects/demo/src/modules/components/line-clamp/examples/5/index.less
+++ b/projects/demo/src/modules/components/line-clamp/examples/5/index.less
@@ -1,0 +1,12 @@
+.island {
+    width: 20rem;
+    margin-bottom: 1rem;
+    box-sizing: border-box;
+}
+
+.email {
+    margin: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/projects/demo/src/modules/components/line-clamp/examples/5/index.ts
+++ b/projects/demo/src/modules/components/line-clamp/examples/5/index.ts
@@ -1,0 +1,26 @@
+import {Component} from '@angular/core';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+
+interface User {
+    id: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+}
+
+@Component({
+    selector: 'tui-line-clamp-example-5',
+    templateUrl: './index.html',
+    styleUrls: ['./index.less'],
+    changeDetection,
+    encapsulation,
+})
+export class TuiLineClampExample5 {
+    readonly user: User = {
+        id: '5a006cb3-2b69-4b23',
+        email: 'extremely.long.information@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+    };
+}

--- a/projects/demo/src/modules/components/line-clamp/line-clamp.component.ts
+++ b/projects/demo/src/modules/components/line-clamp/line-clamp.component.ts
@@ -40,4 +40,10 @@ export class ExampleTuiLineClampComponent {
         HTML: import('./examples/4/index.html?raw'),
         LESS: import('./examples/4/index.less?raw'),
     };
+
+    readonly example5: TuiDocExample = {
+        TypeScript: import('./examples/5/index.ts?raw'),
+        HTML: import('./examples/5/index.html?raw'),
+        LESS: import('./examples/5/index.less?raw'),
+    };
 }

--- a/projects/demo/src/modules/components/line-clamp/line-clamp.module.ts
+++ b/projects/demo/src/modules/components/line-clamp/line-clamp.module.ts
@@ -6,6 +6,7 @@ import {TuiActiveZoneModule} from '@taiga-ui/cdk';
 import {
     TuiButtonModule,
     TuiDataListModule,
+    TuiHintModule,
     TuiHostedDropdownModule,
     TuiLinkModule,
     TuiNotificationModule,
@@ -21,6 +22,7 @@ import {TuiLineClampExample1} from './examples/1';
 import {TuiLineClampExample2} from './examples/2';
 import {TuiLineClampExample3} from './examples/3';
 import {TuiLineClampExample4} from './examples/4';
+import {TuiLineClampExample5} from './examples/5';
 import {ExampleTuiLineClampComponent} from './line-clamp.component';
 
 @NgModule({
@@ -38,6 +40,7 @@ import {ExampleTuiLineClampComponent} from './line-clamp.component';
         TuiActiveZoneModule,
         TuiDataListModule,
         TuiSvgModule,
+        TuiHintModule,
     ],
     declarations: [
         ExampleTuiLineClampComponent,
@@ -45,6 +48,7 @@ import {ExampleTuiLineClampComponent} from './line-clamp.component';
         TuiLineClampExample2,
         TuiLineClampExample3,
         TuiLineClampExample4,
+        TuiLineClampExample5,
     ],
     exports: [ExampleTuiLineClampComponent],
 })

--- a/projects/demo/src/modules/components/line-clamp/line-clamp.template.html
+++ b/projects/demo/src/modules/components/line-clamp/line-clamp.template.html
@@ -37,6 +37,14 @@
         >
             <tui-line-clamp-example-4></tui-line-clamp-example-4>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="custom-content-workaround"
+            heading="Custom content workaround"
+            [content]="example5"
+        >
+            <tui-line-clamp-example-5></tui-line-clamp-example-5>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [x] Documentation content changes

## What is the current behavior?

Closes #4392

## What is the new behavior?

Added a few examples of how to show custom content in `tui-line-clamp` 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
