### PR TITLE
chore(demo-integrations): fix cypress tests for `Slider`

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/slider/slider.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/slider/slider.cy.ts
@@ -97,7 +97,7 @@ describe(`Slider`, () => {
 
                 checkSlider(`@slider`, {
                     expectedValue: `0.75`,
-                    expectedFillPercentage: `16.6667%`,
+                    expectedFillPercentage: `17%`,
                 });
 
                 cy.get(`@example`).matchImageSnapshot(
@@ -125,7 +125,7 @@ describe(`Slider`, () => {
 
                 checkSlider(`@slider`, {
                     expectedValue: `1.5`,
-                    expectedFillPercentage: `66.6667%`,
+                    expectedFillPercentage: `67%`,
                 });
 
                 cy.get(`@example`).matchImageSnapshot(
@@ -205,9 +205,15 @@ function checkSlider(
 ): void {
     cy.get(sliderSelector)
         .should(`have.value`, expectedValue)
-        .filter(
-            (_, $el) =>
-                getComputedStyle($el).getPropertyValue(`--tui-slider-fill-percentage`) ===
-                expectedFillPercentage,
-        );
+        .filter((_, $el) => {
+            const actualFillPercentage = Math.round(
+                parseFloat(
+                    getComputedStyle($el).getPropertyValue(
+                        `--tui-slider-fill-percentage`,
+                    ),
+                ),
+            );
+
+            return `${actualFillPercentage}%` === expectedFillPercentage;
+        });
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
See https://github.com/Tinkoff/taiga-ui/actions/runs/4947701579/jobs/8847563984?pr=4427

```
  Slider
    ✓ correctly displays values with float percentage progress (13903ms)
    ✓ correctly sets control value on input change (using TuiSliderKeyStepsDirective) (17823ms)
    ✓ with `min` > 0 (3592ms)
    ✓ with `min` < 0 && `max` > 0  (3250ms)
    programmatically change value
      ngModel
        (Attempt 1 of 2) decrease value by 1 step
        1) decrease value by 1 step
        ✓ increase value by 1 step (3556ms)
        (Attempt 1 of 2) increase value by 2 step
        2) increase value by 2 step
      formController
        ✓ => 0 (4163ms)
        ✓ => 500 (3638ms)
        ✓ => 750 (3605ms)
        ✓ => 1000 (3498ms)
  9 passing (1m)
  2 failing
  1) Slider
       programmatically change value
         ngModel
           decrease value by 1 step:
     AssertionError: Timed out retrying after 4000ms: Expected to find element: `filter`, but never found it. Queried from:
              > <input.ng-untouched.ng-pristine.ng-valid>
      at checkSlider (webpack:///./cypress/tests/kit/slider/slider.cy.ts:208:9)
      at Context.eval (webpack:///./cypress/tests/kit/slider/slider.cy.ts:98:16)

  2) Slider
       programmatically change value
         ngModel
           increase value by 2 step:
     AssertionError: Timed out retrying after 4000ms: Expected to find element: `filter`, but never found it. Queried from:
              > <input.ng-untouched.ng-pristine.ng-valid>
      at checkSlider (webpack:///./cypress/tests/kit/slider/slider.cy.ts:208:9)
      at Context.eval (webpack:///./cypress/tests/kit/slider/slider.cy.ts:126:16)
```
