### PR TITLE
fix(cdk): `Schematics` add some missed migrations

### DIFF
--- a/projects/cdk/schematics/ng-update/v3/constants/constants.ts
+++ b/projects/cdk/schematics/ng-update/v3/constants/constants.ts
@@ -334,6 +334,26 @@ export const CONSTANTS_TO_REPLACE: ReplacementConst[] = [
     },
     {
         from: {
+            name: `TuiPreviewService`,
+            moduleSpecifier: `@taiga-ui/proprietary-banking`,
+        },
+        to: {
+            name: `TuiPreviewService`,
+            moduleSpecifier: `@taiga-ui/addon-preview`,
+        },
+    },
+    {
+        from: {
+            name: `TuiPreviewModule`,
+            moduleSpecifier: `@taiga-ui/proprietary-banking`,
+        },
+        to: {
+            name: `TuiPreviewModule`,
+            moduleSpecifier: `@taiga-ui/addon-preview`,
+        },
+    },
+    {
+        from: {
             name: `TuiAccountModule`,
             moduleSpecifier: `@taiga-ui/proprietary-core`,
         },

--- a/projects/cdk/schematics/ng-update/v3/constants/templates.ts
+++ b/projects/cdk/schematics/ng-update/v3/constants/templates.ts
@@ -1,43 +1,12 @@
-import {Element} from 'parse5';
-
 import {hasElementAttribute} from '../../../utils/templates/elements';
+import {AttributeToDirective} from '../interfaces/attribute-to-directive';
+import {RemovableInput} from '../interfaces/removable-input';
+import {ReplaceableAttribute} from '../interfaces/replaceable-attribute';
+import {ReplaceableAttributeValue} from '../interfaces/replaceable-attribute-value';
+import {ReplaceableTag} from '../interfaces/replaceable-tag';
 import {TUI_INTERACTIVE_SELECTORS} from './tui-interactive-selectors';
 
-export interface ReplacementAttributes {
-    readonly from: {
-        readonly attrName: string;
-        readonly withTagNames?: string[];
-        readonly withAttrsNames?: string[];
-        readonly filterFn?: (element: Element) => boolean;
-    };
-    readonly to: {
-        readonly attrName: string;
-    };
-}
-
-export interface ReplacementTags {
-    readonly from: string;
-    readonly to: string;
-    readonly addAttributes: string[];
-}
-
-export interface AttributeToDirective {
-    readonly componentSelector: string[] | string;
-    readonly filterFn?: (element: Element) => boolean;
-    readonly inputProperty: string;
-    readonly directive: string;
-    readonly directiveModule: {
-        readonly name: string;
-        readonly moduleSpecifier: string;
-    };
-}
-
-export interface InputToRemove {
-    readonly inputName: string;
-    readonly tags: string[];
-}
-
-export const ATTRS_TO_REPLACE: ReplacementAttributes[] = [
+export const ATTRS_TO_REPLACE: ReplaceableAttribute[] = [
     {
         from: {attrName: `tuiResizableColumn`, withAttrsNames: [`tuiResizableColumn`]},
         to: {attrName: `tuiTh [resizable]="true"`},
@@ -524,7 +493,7 @@ export const ATTRS_TO_REPLACE: ReplacementAttributes[] = [
     },
 ];
 
-export const INPUTS_TO_REMOVE: InputToRemove[] = [
+export const INPUTS_TO_REMOVE: RemovableInput[] = [
     {
         inputName: `iconAlign`,
         tags: [`tui-input`, `tui-primitive-textfield`, `tui-input-tag`],
@@ -535,7 +504,7 @@ export const INPUTS_TO_REMOVE: InputToRemove[] = [
     },
 ];
 
-export const TAGS_TO_REPLACE: ReplacementTags[] = [
+export const TAGS_TO_REPLACE: ReplaceableTag[] = [
     {
         from: `tui-group`,
         to: `div`,
@@ -755,4 +724,31 @@ export const TEMPLATE_COMMENTS = [
         withAttr: `allowSpaces`,
         comment: `Use property [separator] to forbid spaces. See example: https://taiga-ui.dev/components/input-tag#no-spaces-inside-tags`,
     },
+    {
+        tag: `tui-preview-pagination`,
+        withAttr: `lastIndex`,
+        comment: `Use property [length] instead. See example: https://taiga-ui.dev/components/preview`,
+    },
 ] as const;
+
+export const REPLACE_ATTR_VALUE: ReplaceableAttributeValue[] = [
+    {
+        attrName: `tuiHintDirection`,
+        values: [
+            {from: `bottom-middle`, to: `bottom`},
+            {from: `top-middle`, to: `top`},
+        ],
+    },
+    {
+        attrName: `ngProjectAs`,
+        values: [{from: `tuiOverNotifications`, to: `tuiOverAlerts`}],
+    },
+    {
+        attrName: `direction`,
+        withTagNames: [`tui-tooltip`],
+        values: [
+            {from: `bottom-middle`, to: `bottom`},
+            {from: `top-middle`, to: `top`},
+        ],
+    },
+];

--- a/projects/cdk/schematics/ng-update/v3/interfaces/attribute-to-directive.ts
+++ b/projects/cdk/schematics/ng-update/v3/interfaces/attribute-to-directive.ts
@@ -1,0 +1,12 @@
+import {Element} from 'parse5';
+
+export interface AttributeToDirective {
+    readonly componentSelector: string[] | string;
+    readonly filterFn?: (element: Element) => boolean;
+    readonly inputProperty: string;
+    readonly directive: string;
+    readonly directiveModule: {
+        readonly name: string;
+        readonly moduleSpecifier: string;
+    };
+}

--- a/projects/cdk/schematics/ng-update/v3/interfaces/removable-input.ts
+++ b/projects/cdk/schematics/ng-update/v3/interfaces/removable-input.ts
@@ -1,0 +1,4 @@
+export interface RemovableInput {
+    readonly inputName: string;
+    readonly tags: string[];
+}

--- a/projects/cdk/schematics/ng-update/v3/interfaces/replaceable-attribute-value.ts
+++ b/projects/cdk/schematics/ng-update/v3/interfaces/replaceable-attribute-value.ts
@@ -1,0 +1,5 @@
+export interface ReplaceableAttributeValue {
+    readonly attrName: string;
+    readonly values: Array<{readonly from: string; readonly to: string}>;
+    readonly withTagNames?: string[];
+}

--- a/projects/cdk/schematics/ng-update/v3/interfaces/replaceable-attribute.ts
+++ b/projects/cdk/schematics/ng-update/v3/interfaces/replaceable-attribute.ts
@@ -1,0 +1,13 @@
+import {Element} from 'parse5';
+
+export interface ReplaceableAttribute {
+    readonly from: {
+        readonly attrName: string;
+        readonly withTagNames?: string[];
+        readonly withAttrsNames?: string[];
+        readonly filterFn?: (element: Element) => boolean;
+    };
+    readonly to: {
+        readonly attrName: string;
+    };
+}

--- a/projects/cdk/schematics/ng-update/v3/interfaces/replaceable-tag.ts
+++ b/projects/cdk/schematics/ng-update/v3/interfaces/replaceable-tag.ts
@@ -1,0 +1,5 @@
+export interface ReplaceableTag {
+    readonly from: string;
+    readonly to: string;
+    readonly addAttributes: string[];
+}

--- a/projects/cdk/schematics/ng-update/v3/steps/migrate-templates.ts
+++ b/projects/cdk/schematics/ng-update/v3/steps/migrate-templates.ts
@@ -22,6 +22,7 @@ import {
     findElementsByTagName,
     findElementsInTemplateByFn,
     findElementsWithAttribute,
+    findElementsWithAttributeOnTag,
     hasElementAttribute,
 } from '../../../utils/templates/elements';
 import {getComponentTemplates} from '../../../utils/templates/get-component-templates';
@@ -39,6 +40,7 @@ import {
     ATTR_TO_DIRECTIVE,
     ATTRS_TO_REPLACE,
     INPUTS_TO_REMOVE,
+    REPLACE_ATTR_VALUE,
     TAGS_TO_REPLACE,
     TEMPLATE_COMMENTS,
     TRUTHY_BOOLEAN_INPUT_TO_HTML_BINARY_ATTRIBUTE,
@@ -440,19 +442,10 @@ function replaceInputValues({
     const template = getTemplateFromTemplateResource(resource, fileSystem);
     const templateOffset = getTemplateOffset(resource);
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const ATTR_VALUES = [
-        {
-            attrName: `tuiHintDirection`,
-            values: [
-                {from: `bottom-middle`, to: `bottom`},
-                {from: `top-middle`, to: `top`},
-            ],
-        },
-    ] as const;
-
-    ATTR_VALUES.forEach(({attrName, values}) => {
-        const elements = [...findElementsWithAttribute(template, attrName)];
+    REPLACE_ATTR_VALUE.forEach(({attrName, values, withTagNames}) => {
+        const elements = [
+            ...findElementsWithAttributeOnTag(template, attrName, withTagNames),
+        ];
 
         elements.forEach(element => {
             const {name, value} =

--- a/projects/cdk/schematics/ng-update/v3/steps/replace-styles.ts
+++ b/projects/cdk/schematics/ng-update/v3/steps/replace-styles.ts
@@ -15,7 +15,7 @@ export function replaceStyles(): void {
         .forEach(sourceFile => {
             let fullText = sourceFile.getFullText();
 
-            if (fullText.includes(`taiga-ui-local`)) {
+            if (fullText.includes(`taiga-ui`)) {
                 DEPRECATED_BREAKPOINTS.forEach(({from, to}) => {
                     fullText = fullText.replace(
                         new RegExp(`(?<=@media.*)(${from})(?=[\\s,{])`, `g`),
@@ -30,6 +30,7 @@ export function replaceStyles(): void {
                 .replace(`&[data-state='pressed']`, `&[data-state='active']`)
                 .replace(`tui-portal-host`, `tui-dropdown-host`)
                 .replace(`tui-dropdown-box`, `tui-dropdown`)
+                .replace(`--tui-color-link`, `--tui-link`)
                 .replace(/@import '~@taiga-ui/g, `@import '@taiga-ui`)
                 .replace(
                     `@import '@taiga-ui/core/styles/taiga-ui-global';`,

--- a/projects/cdk/schematics/ng-update/v3/tests/schematic-replace-html.spec.ts
+++ b/projects/cdk/schematics/ng-update/v3/tests/schematic-replace-html.spec.ts
@@ -37,6 +37,8 @@ export class TestComponent {}
 `;
 
 const TEMPLATE_BEFORE = `
+<tui-table-bars-host ngProjectAs="tuiOverNotifications"></tui-table-bars-host>
+<tui-tooltip direction="top-middle"></tui-tooltip>
 <tui-svg
     src="tuiIconSettingsLarge"
     class="icon"
@@ -249,6 +251,8 @@ const TEMPLATE_BEFORE = `
 `;
 
 const TEMPLATE_AFTER = `<!-- TODO: (Taiga UI migration) tuiFormatNumber pipe has new API. See https://taiga-ui.dev/pipes/format-number -->
+<tui-table-bars-host ngProjectAs="tuiOverAlerts"></tui-table-bars-host>
+<tui-tooltip direction="top"></tui-tooltip>
 <tui-svg
     src="tuiIconSettingsLarge"
     class="icon"

--- a/projects/cdk/schematics/utils/templates/elements.ts
+++ b/projects/cdk/schematics/utils/templates/elements.ts
@@ -61,6 +61,24 @@ export function findElementsWithAttribute(
 }
 
 /**
+ * Parses a HTML fragment and traverses all AST nodes in order find elements that include the specified attribute and tag name.
+ * @param html
+ * @param attributeName
+ */
+export function findElementsWithAttributeOnTag(
+    html: string,
+    attributeName: string,
+    tagNames: string[] = [],
+): Element[] {
+    return findElementsInTemplateByFn(
+        html,
+        el =>
+            el.attrs?.some(attr => attr.name === attributeName.toLowerCase()) &&
+            (tagNames.includes(el.tagName) || !tagNames.length),
+    );
+}
+
+/**
  * Finds elements with explicit tag names that also contain the specified attribute. Returns the
  * attribute start offset based on the specified HTML.
  */


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

part of #4242 

## What is the new behavior?

`TuiPreviewService`, `TuiPreviewModule`, `tui-preview-pagination[lastIndex]`
breakpoints global
`ngProjectAs="tuiOverNotifications"`
`tui-tooltip[direction]`
`--tui-color-link` to `--tui-link`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
