### PR TITLE
feat(addon-commerce): `InputExpire` & `InputCVC` use `Maskito` instead of legacy `text-mask`

### DIFF
--- a/projects/addon-commerce/components/input-cvc/input-cvc.component.ts
+++ b/projects/addon-commerce/components/input-cvc/input-cvc.component.ts
@@ -9,6 +9,7 @@ import {
     ViewChild,
 } from '@angular/core';
 import {NgControl} from '@angular/forms';
+import {MaskitoOptions} from '@maskito/core';
 import {TuiCodeCVCLength} from '@taiga-ui/addon-commerce/types';
 import {
     AbstractTuiControl,
@@ -25,7 +26,6 @@ import {
     TUI_TEXTFIELD_LABEL_OUTSIDE,
     TuiPrimitiveTextfieldComponent,
     TuiTextfieldLabelOutsideDirective,
-    TuiTextMaskOptions,
 } from '@taiga-ui/core';
 
 @Component({
@@ -53,17 +53,15 @@ export class TuiInputCVCComponent
     @tuiRequiredSetter()
     set length(length: TuiCodeCVCLength) {
         this.exampleText = '0'.repeat(length);
-        this.textMaskOptions = {
+        this.maskOptions = {
             mask: new Array(length).fill(TUI_DIGIT_REGEXP),
-            guide: false,
         };
     }
 
     exampleText = '000';
 
-    textMaskOptions: TuiTextMaskOptions = {
+    maskOptions: MaskitoOptions = {
         mask: new Array(3).fill(TUI_DIGIT_REGEXP),
-        guide: false,
     };
 
     constructor(
@@ -97,8 +95,6 @@ export class TuiInputCVCComponent
     onFocused(focused: boolean): void {
         this.updateFocused(focused);
     }
-
-    onCopy(): void {}
 
     /** deprecated use 'value' setter */
     onValueChange(value: string): void {

--- a/projects/addon-commerce/components/input-cvc/input-cvc.module.ts
+++ b/projects/addon-commerce/components/input-cvc/input-cvc.module.ts
@@ -1,12 +1,13 @@
 import {NgModule} from '@angular/core';
+import {MaskitoModule} from '@maskito/angular';
 import {TuiPrimitiveTextfieldModule, TuiTextfieldControllerModule} from '@taiga-ui/core';
-import {TextMaskModule, TuiValueAccessorModule} from '@taiga-ui/kit';
+import {TuiValueAccessorModule} from '@taiga-ui/kit';
 
 import {TuiInputCVCComponent} from './input-cvc.component';
 
 @NgModule({
     imports: [
-        TextMaskModule,
+        MaskitoModule,
         TuiPrimitiveTextfieldModule,
         TuiTextfieldControllerModule,
         TuiValueAccessorModule,

--- a/projects/addon-commerce/components/input-cvc/input-cvc.template.html
+++ b/projects/addon-commerce/components/input-cvc/input-cvc.template.html
@@ -4,7 +4,7 @@
     [disabled]="disabled"
     [readOnly]="readOnly"
     [nativeId]="nativeId"
-    [textMask]="textMaskOptions"
+    [maskito]="maskOptions"
     [invalid]="computedInvalid"
     [focusable]="focusable"
     [pseudoHover]="pseudoHover"
@@ -12,7 +12,7 @@
     [pseudoFocus]="pseudoFocus"
     [(value)]="value"
     (focusedChange)="onFocused($event)"
-    (copy.prevent)="onCopy()"
+    (copy.prevent)="(0)"
 >
     <ng-content></ng-content>
     <input

--- a/projects/addon-commerce/components/input-cvc/test/input-cvc.component.spec.ts
+++ b/projects/addon-commerce/components/input-cvc/test/input-cvc.component.spec.ts
@@ -50,10 +50,9 @@ describe(`InputCVC`, () => {
             expect(testComponent.default.exampleText).toBe(`000`);
         });
 
-        it(`textMaskOptions`, () => {
-            expect(testComponent.default.textMaskOptions).toEqual({
+        it(`MaskOptions`, () => {
+            expect(testComponent.default.maskOptions).toEqual({
                 mask: [TUI_DIGIT_REGEXP, TUI_DIGIT_REGEXP, TUI_DIGIT_REGEXP],
-                guide: false,
             });
         });
     });
@@ -63,15 +62,14 @@ describe(`InputCVC`, () => {
             expect(testComponent.custom.exampleText).toBe(`0000`);
         });
 
-        it(`textMaskOptions`, () => {
-            expect(testComponent.custom.textMaskOptions).toEqual({
+        it(`MaskOptions`, () => {
+            expect(testComponent.custom.maskOptions).toEqual({
                 mask: [
                     TUI_DIGIT_REGEXP,
                     TUI_DIGIT_REGEXP,
                     TUI_DIGIT_REGEXP,
                     TUI_DIGIT_REGEXP,
                 ],
-                guide: false,
             });
         });
     });

--- a/projects/addon-commerce/components/input-expire/input-expire.component.ts
+++ b/projects/addon-commerce/components/input-expire/input-expire.component.ts
@@ -9,7 +9,7 @@ import {
     ViewChild,
 } from '@angular/core';
 import {NgControl} from '@angular/forms';
-import {tuiCreateAutoCorrectedExpirePipe} from '@taiga-ui/addon-commerce/utils';
+import {maskitoDateOptionsGenerator} from '@maskito/kit';
 import {
     AbstractTuiControl,
     tuiAsControl,
@@ -18,11 +18,7 @@ import {
     tuiDefaultProp,
     TuiFocusableElementAccessor,
 } from '@taiga-ui/cdk';
-import {
-    TUI_DIGIT_REGEXP,
-    TuiPrimitiveTextfieldComponent,
-    TuiTextMaskOptions,
-} from '@taiga-ui/core';
+import {TuiPrimitiveTextfieldComponent} from '@taiga-ui/core';
 
 @Component({
     selector: 'tui-input-expire',
@@ -45,17 +41,10 @@ export class TuiInputExpireComponent
     @tuiDefaultProp()
     autocompleteEnabled = false;
 
-    readonly textMaskOptions: TuiTextMaskOptions = {
-        mask: [
-            TUI_DIGIT_REGEXP,
-            TUI_DIGIT_REGEXP,
-            '/',
-            TUI_DIGIT_REGEXP,
-            TUI_DIGIT_REGEXP,
-        ],
-        pipe: tuiCreateAutoCorrectedExpirePipe(),
-        guide: false,
-    };
+    readonly maskOptions = maskitoDateOptionsGenerator({
+        mode: 'mm/yy',
+        separator: '/',
+    });
 
     constructor(
         @Optional()
@@ -77,25 +66,6 @@ export class TuiInputExpireComponent
 
     get autocomplete(): TuiAutofillFieldName {
         return this.autocompleteEnabled ? 'cc-exp' : 'off';
-    }
-
-    onValueChange(value: string): void {
-        // @bad TODO: Workaround until mask pipe can replace chars and keep caret position
-        // @bad TODO: Think about a solution without mask at all
-        if (!this.input?.nativeFocusableElement) {
-            return;
-        }
-
-        if (parseInt(value.slice(0, 2), 10) > 12) {
-            value = `12${value.slice(2)}`;
-        }
-
-        if (value.startsWith('00')) {
-            value = `01${value.slice(2)}`;
-        }
-
-        this.input.nativeFocusableElement.value = value;
-        this.value = value;
     }
 
     onFocused(focused: boolean): void {

--- a/projects/addon-commerce/components/input-expire/input-expire.module.ts
+++ b/projects/addon-commerce/components/input-expire/input-expire.module.ts
@@ -1,12 +1,13 @@
 import {NgModule} from '@angular/core';
+import {MaskitoModule} from '@maskito/angular';
 import {TuiPrimitiveTextfieldModule, TuiTextfieldControllerModule} from '@taiga-ui/core';
-import {TextMaskModule, TuiValueAccessorModule} from '@taiga-ui/kit';
+import {TuiValueAccessorModule} from '@taiga-ui/kit';
 
 import {TuiInputExpireComponent} from './input-expire.component';
 
 @NgModule({
     imports: [
-        TextMaskModule,
+        MaskitoModule,
         TuiPrimitiveTextfieldModule,
         TuiTextfieldControllerModule,
         TuiValueAccessorModule,

--- a/projects/addon-commerce/components/input-expire/input-expire.template.html
+++ b/projects/addon-commerce/components/input-expire/input-expire.template.html
@@ -3,14 +3,13 @@
     class="t-input"
     [nativeId]="nativeId"
     [disabled]="disabled"
-    [textMask]="textMaskOptions"
+    [maskito]="maskOptions"
     [readOnly]="readOnly"
     [invalid]="computedInvalid"
     [pseudoHover]="pseudoHover"
     [pseudoActive]="pseudoActive"
     [pseudoFocus]="pseudoFocus"
-    [value]="value"
-    (valueChange)="onValueChange($event)"
+    [(value)]="value"
     (focusedChange)="onFocused($event)"
 >
     <input

--- a/projects/addon-commerce/components/input-expire/test/input-expire.component.spec.ts
+++ b/projects/addon-commerce/components/input-expire/test/input-expire.component.spec.ts
@@ -47,30 +47,4 @@ describe(`InputExpire`, () => {
         expect(testComponent.value).toBe(`12/12`);
         expect(input.value).toBe(`12/12`);
     });
-
-    describe(`Input correction`, () => {
-        it(`replaces 50/08 with 12/08`, () => {
-            input.value = `50/08`;
-            input.dispatchEvent(new Event(`input`, {bubbles: true}));
-
-            expect(testComponent.value).toBe(`05/08`);
-            expect(input.value).toBe(`05/08`);
-        });
-
-        it(`replaces 14/08 with 12/08`, () => {
-            input.value = `14/08`;
-            input.dispatchEvent(new Event(`input`, {bubbles: true}));
-
-            expect(testComponent.value).toBe(`12/08`);
-            expect(input.value).toBe(`12/08`);
-        });
-
-        it(`replaces 00/08 with 01/08`, () => {
-            input.value = `00/08`;
-            input.dispatchEvent(new Event(`input`, {bubbles: true}));
-
-            expect(testComponent.value).toBe(`01/08`);
-            expect(input.value).toBe(`01/08`);
-        });
-    });
 });

--- a/projects/demo-integrations/cypress/tests/addon-commerce/input-expire.cy.ts
+++ b/projects/demo-integrations/cypress/tests/addon-commerce/input-expire.cy.ts
@@ -1,0 +1,49 @@
+describe(`InputExpire`, () => {
+    beforeEach(() => {
+        cy.tuiVisit(`components/input-card/API`);
+        cy.get(`#demo-content tui-input-expire input`)
+            .first()
+            .should(`have.value`, ``)
+            .as(`input`);
+    });
+
+    it(`Empty input => type 5 => 05`, () => {
+        cy.get(`@input`)
+            .type(`05`)
+            .should(`have.value`, `05`)
+            .should(`have.prop`, `selectionStart`, `05`.length)
+            .should(`have.prop`, `selectionEnd`, `05`.length);
+    });
+
+    it(`Empty input => type 14 => (prevent 4) => 1`, () => {
+        cy.get(`@input`)
+            .type(`14`)
+            .should(`have.value`, `1`)
+            .should(`have.prop`, `selectionStart`, 1)
+            .should(`have.prop`, `selectionEnd`, 1);
+    });
+
+    it(`Empty input => type 12 => 12`, () => {
+        cy.get(`@input`)
+            .type(`12`)
+            .should(`have.value`, `12`)
+            .should(`have.prop`, `selectionStart`, `12`.length)
+            .should(`have.prop`, `selectionEnd`, `12`.length);
+    });
+
+    it(`Empty input => Type 00 => 0`, () => {
+        cy.get(`@input`)
+            .type(`00`)
+            .should(`have.value`, `0`)
+            .should(`have.prop`, `selectionStart`, 1)
+            .should(`have.prop`, `selectionEnd`, 1);
+    });
+
+    it(`Empty input => Type 0130 => 01/30`, () => {
+        cy.get(`@input`)
+            .type(`0130`)
+            .should(`have.value`, `01/30`)
+            .should(`have.prop`, `selectionStart`, `01/30`.length)
+            .should(`have.prop`, `selectionEnd`, `01/30`.length);
+    });
+});


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the new behavior?
Partially solves #120

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
