### PR TITLE
feat(addon-doc): add `tuiTextCode` for escaped brackets in code

### DIFF
--- a/projects/addon-doc/directives/index.ts
+++ b/projects/addon-doc/directives/index.ts
@@ -1,2 +1,4 @@
 export * from './scroll-into-view/scroll-into-view.directive';
 export * from './scroll-into-view/scroll-into-view.module';
+export * from './text-code/text-code.directive';
+export * from './text-code/text-code.module';

--- a/projects/addon-doc/directives/text-code/text-code.directive.ts
+++ b/projects/addon-doc/directives/text-code/text-code.directive.ts
@@ -1,0 +1,10 @@
+import {Directive, HostBinding, Input} from '@angular/core';
+
+@Directive({
+    selector: 'code[tuiText]',
+})
+export class TuiTextCodeDirective {
+    @Input('tuiText')
+    @HostBinding('textContent')
+    code = '';
+}

--- a/projects/addon-doc/directives/text-code/text-code.module.ts
+++ b/projects/addon-doc/directives/text-code/text-code.module.ts
@@ -1,0 +1,9 @@
+import {NgModule} from '@angular/core';
+
+import {TuiTextCodeDirective} from './text-code.directive';
+
+@NgModule({
+    declarations: [TuiTextCodeDirective],
+    exports: [TuiTextCodeDirective],
+})
+export class TuiTextCodeModule {}

--- a/projects/demo/src/modules/components/combo-box/combo-box.module.ts
+++ b/projects/demo/src/modules/components/combo-box/combo-box.module.ts
@@ -3,7 +3,11 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiLetModule} from '@taiga-ui/cdk';
 import {
     TuiButtonModule,
@@ -62,6 +66,7 @@ import {TuiComboBoxExample6} from './examples/6';
         TuiAddonDocModule,
         InheritedDocumentationModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiComboBoxComponent)),
+        TuiTextCodeModule,
     ],
     declarations: [
         ExampleTuiComboBoxComponent,

--- a/projects/demo/src/modules/components/combo-box/combo-box.template.html
+++ b/projects/demo/src/modules/components/combo-box/combo-box.template.html
@@ -197,7 +197,7 @@
                 [(documentationPropertyValue)]="strict"
             >
                 Value must only be an item of suggestions&nbsp;
-                <code>&lt;T&gt;</code>
+                <code tuiText="<T>"></code>
 
                 <p>
                     <strong>
@@ -208,7 +208,7 @@
                         can handle
                         <code>string</code>
                         value, as well as
-                        <code>&lt;T&gt;</code>
+                        <code tuiText="<T>"></code>
                     </strong>
                 </p>
             </ng-template>

--- a/projects/demo/src/modules/components/dialog/dialog.module.ts
+++ b/projects/demo/src/modules/components/dialog/dialog.module.ts
@@ -3,7 +3,11 @@ import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {TuiMoneyModule} from '@taiga-ui/addon-commerce';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiElasticStickyModule} from '@taiga-ui/addon-mobile';
 import {TuiAutoFocusModule, TuiPreventDefaultModule} from '@taiga-ui/cdk';
 import {
@@ -67,6 +71,7 @@ import {PayExampleModalModule} from './examples/9/pay-modal/pay-modal.module';
         TuiInputNumberModule,
         PayExampleModalModule,
         TuiTextfieldControllerModule,
+        TuiTextCodeModule,
     ],
     declarations: [
         ExampleTuiDialogComponent,

--- a/projects/demo/src/modules/components/dialog/dialog.template.html
+++ b/projects/demo/src/modules/components/dialog/dialog.template.html
@@ -228,7 +228,7 @@
                 [(documentationPropertyValue)]="closeable"
             >
                 Show a cross to close dialog. Pass
-                <code>Observable&lt;boolean&gt;</code>
+                <code tuiText="Observable<boolean>"></code>
                 if you want prevent closing, for example, with a prompt.
             </ng-template>
             <ng-template
@@ -237,7 +237,7 @@
                 [(documentationPropertyValue)]="dismissible"
             >
                 Dialog can be canceled with Escape key or with a click outside. Pass
-                <code>Observable&lt;boolean&gt;</code>
+                <code tuiText="Observable<boolean>"></code>
                 if you want prevent closing, for example, with a prompt.
             </ng-template>
             <ng-template
@@ -245,7 +245,8 @@
                 documentationPropertyType="number"
                 [(documentationPropertyValue)]="data"
             >
-                Input data for dialog, type &lt;I&gt;
+                Input data for dialog, type:
+                <code tuiText="<T>"></code>
             </ng-template>
             <ng-template
                 documentationPropertyName="header"
@@ -316,7 +317,7 @@
                     in it. Dialog will provide with this token some useful options:
                     <code>$implicit</code>
                     with
-                    <code>Observer&lt;O&gt;</code>
+                    <code tuiText="Observer<O>"></code>
                     and
                     <code>completeWith</code>
                     hook to call

--- a/projects/demo/src/modules/components/editor/custom-tool/paste-emoji/editor-paste-emoji.component.html
+++ b/projects/demo/src/modules/components/editor/custom-tool/paste-emoji/editor-paste-emoji.component.html
@@ -49,7 +49,7 @@
                 Pass the component as content projection (with
                 <code>ngProjectAs="tools"</code>
                 ) to
-                <code>&lt;tui-editor&gt;</code>
+                <code tuiText="<tui-editor>"></code>
                 .
             </li>
         </ul>

--- a/projects/demo/src/modules/components/editor/custom-tool/paste-emoji/editor-paste-emoji.module.ts
+++ b/projects/demo/src/modules/components/editor/custom-tool/paste-emoji/editor-paste-emoji.module.ts
@@ -2,7 +2,11 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiEditorModule, TuiEditorSocketModule} from '@taiga-ui/addon-editor';
 import {TuiActiveZoneModule} from '@taiga-ui/cdk';
 import {
@@ -31,6 +35,7 @@ import {ExampleTuiSmilesToolModule} from './examples/1/smiles-tool/smiles-tool.m
         ExampleTuiSmilesToolModule,
         TuiEditorSocketModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiEditorPasteEmojiToolComponent)),
+        TuiTextCodeModule,
     ],
     declarations: [
         TuiEditorPasteEmojiToolExample1,

--- a/projects/demo/src/modules/components/editor/custom-tool/paste-image/editor-paste-image-tool.component.html
+++ b/projects/demo/src/modules/components/editor/custom-tool/paste-image/editor-paste-image-tool.component.html
@@ -49,7 +49,7 @@
                 Pass the component as content projection (with
                 <code>ngProjectAs="tools"</code>
                 ) to
-                <code>&lt;tui-editor&gt;</code>
+                <code tuiText="<tui-editor>"></code>
                 .
             </li>
         </ul>

--- a/projects/demo/src/modules/components/editor/custom-tool/paste-image/editor-paste-image-tool.module.ts
+++ b/projects/demo/src/modules/components/editor/custom-tool/paste-image/editor-paste-image-tool.module.ts
@@ -2,7 +2,11 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiEditorModule, TuiEditorSocketModule} from '@taiga-ui/addon-editor';
 import {TuiActiveZoneModule} from '@taiga-ui/cdk';
 import {
@@ -31,6 +35,7 @@ import {ExampleTuiPasteImageToolModule} from './examples/1/image-tool/image-tool
         ExampleTuiPasteImageToolModule,
         TuiEditorSocketModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiEditorPasteImageToolComponent)),
+        TuiTextCodeModule,
     ],
     declarations: [
         TuiEditorPasteImageToolExample1,

--- a/projects/demo/src/modules/components/editor/starter/editor-starter.template.html
+++ b/projects/demo/src/modules/components/editor/starter/editor-starter.template.html
@@ -131,7 +131,7 @@
 
                     <p>
                         It accepts
-                        <code>ReadonlyMap&lt;string, string&gt;</code>
+                        <code tuiText="ReadonlyMap<string, string>"></code>
                         : the
                         <strong>key</strong>
                         is the name of the color (used only for hint and accessibility), the

--- a/projects/demo/src/modules/components/input/examples/10/index.html
+++ b/projects/demo/src/modules/components/input/examples/10/index.html
@@ -59,7 +59,7 @@
 
 <p>
     Another way you can use this combination of html attributes:
-    <code>&lt;input role="presentation" autocomplete="off" /&gt;</code>
+    <code tuiText='<input role="presentation" autocomplete="off" />'></code>
     -
     <a
         tuiLink

--- a/projects/demo/src/modules/components/input/input.module.ts
+++ b/projects/demo/src/modules/components/input/input.module.ts
@@ -3,7 +3,11 @@ import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {TuiInputCardModule, TuiMoneyModule} from '@taiga-ui/addon-commerce';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiTableModule} from '@taiga-ui/addon-table';
 import {TuiLetModule, TuiMapperPipeModule, TuiRepeatTimesModule} from '@taiga-ui/cdk';
 import {
@@ -81,6 +85,7 @@ import {ExampleTuiInputComponent} from './input.component';
         TuiAddonDocModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiInputComponent)),
         TextMaskModule,
+        TuiTextCodeModule,
     ],
     declarations: [
         ExampleTuiInputComponent,

--- a/projects/demo/src/modules/components/input/input.template.html
+++ b/projects/demo/src/modules/components/input/input.template.html
@@ -291,7 +291,7 @@
                 [(documentationPropertyValue)]="placeholder"
             >
                 Placeholder (use external
-                <code>&lt;input tuiTextfield/&gt;</code>
+                <code tuiText="<input tuiTextfield/>"></code>
                 to set it)
             </ng-template>
         </tui-doc-documentation>

--- a/projects/demo/src/modules/components/progress-bar/examples/2/index.html
+++ b/projects/demo/src/modules/components/progress-bar/examples/2/index.html
@@ -1,7 +1,7 @@
 <h6 class="description">Single color</h6>
 <p>
     Use
-    <code>&lt;progress /&gt;</code>
+    <code tuiText="<progress />"></code>
     's CSS-property
     <code>color</code>
     to set solid color of progress indicator.

--- a/projects/demo/src/modules/components/progress-bar/progress-bar.component.html
+++ b/projects/demo/src/modules/components/progress-bar/progress-bar.component.html
@@ -10,13 +10,13 @@
             </dt>
             <dd>
                 – attribute component for native html tag
-                <code>&lt;progress /&gt;</code>
+                <code tuiText="<progress />"></code>
                 .
             </dd>
         </dl>
         <p>
             <strong>Usage:</strong>
-            <code>&lt;progress tuiProgressBar value="40" max="100"&gt;&lt;/progress&gt;</code>
+            <code tuiText='<progress tuiProgressBar value="40" max="100"></progress>'></code>
             .
         </p>
 
@@ -109,7 +109,7 @@
                     value
                 </a>
                 of
-                <code>&lt;progress /&gt;</code>
+                <code tuiText="<progress />"></code>
             </ng-template>
 
             <ng-template
@@ -128,7 +128,7 @@
                     max
                 </a>
                 of
-                <code>&lt;progress /&gt;</code>
+                <code tuiText="<progress />"></code>
             </ng-template>
 
             <ng-template
@@ -151,7 +151,7 @@
                 Color of the progress indicator
                 <p>
                     We recommend set solid color via
-                    <code>&lt;progress /&gt;</code>
+                    <code tuiText="<progress />"></code>
                     's CSS-property
                     <code>color</code>
                     (especially, if you support old not-chromium based Edge)

--- a/projects/demo/src/modules/components/progress-bar/progress-bar.module.ts
+++ b/projects/demo/src/modules/components/progress-bar/progress-bar.module.ts
@@ -1,7 +1,11 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiLinkModule} from '@taiga-ui/core';
 import {TuiProgressModule} from '@taiga-ui/kit';
 
@@ -19,6 +23,7 @@ import {ExampleProgressBarComponent} from './progress-bar.component';
         TuiAddonDocModule,
         TuiProgressModule,
         TuiLinkModule,
+        TuiTextCodeModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleProgressBarComponent)),
     ],
     declarations: [

--- a/projects/demo/src/modules/components/progress-circle/progress-circle.module.ts
+++ b/projects/demo/src/modules/components/progress-circle/progress-circle.module.ts
@@ -1,7 +1,11 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiProgressModule} from '@taiga-ui/kit';
 
 import {TuiProgressCircleExample1} from './examples/1';
@@ -16,6 +20,7 @@ import {ExampleProgressCircleComponent} from './progress-circle.component';
         TuiAddonDocModule,
         TuiProgressModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleProgressCircleComponent)),
+        TuiTextCodeModule,
     ],
     declarations: [
         ExampleProgressCircleComponent,

--- a/projects/demo/src/modules/components/progress-circle/progress-circle.template.html
+++ b/projects/demo/src/modules/components/progress-circle/progress-circle.template.html
@@ -6,7 +6,7 @@
     <ng-template pageTab>
         <dl>
             <dt>
-                <code>&lt;tui-progress-circle /&gt;</code>
+                <code tuiText="<tui-progress-circle />"></code>
             </dt>
             <dd>
                 is a component to visually represent the completion of a process or operation (as a partially filled

--- a/projects/demo/src/modules/components/progress-segmented/progress-segmented.module.ts
+++ b/projects/demo/src/modules/components/progress-segmented/progress-segmented.module.ts
@@ -2,7 +2,11 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {TuiMoneyModule} from '@taiga-ui/addon-commerce';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiLabelModule} from '@taiga-ui/core';
 import {TuiProgressModule} from '@taiga-ui/kit';
 
@@ -20,6 +24,7 @@ import {ExampleProgressSegmentedComponent} from './progress-segmented.component'
         TuiLabelModule,
         TuiMoneyModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleProgressSegmentedComponent)),
+        TuiTextCodeModule,
     ],
     declarations: [
         ExampleProgressSegmentedComponent,

--- a/projects/demo/src/modules/components/progress-segmented/progress-segmented.template.html
+++ b/projects/demo/src/modules/components/progress-segmented/progress-segmented.template.html
@@ -6,7 +6,7 @@
     <ng-template pageTab>
         <dl>
             <dt>
-                <code>&lt;tui-progress-segmented /&gt;</code>
+                <code tuiText="<tui-progress-segmented />"></code>
             </dt>
             <dd>
                 is a component to visually represent the completion of a process or operation (as a segmented bar). It

--- a/projects/demo/src/modules/components/slider/slider.component.html
+++ b/projects/demo/src/modules/components/slider/slider.component.html
@@ -10,7 +10,7 @@
             </dt>
             <dd>
                 attribute component for native html tag
-                <code>&lt;input type="range" /&gt;</code>
+                <code tuiText='<input type="range" />'></code>
                 to choose a value from a limited range.
             </dd>
         </dl>
@@ -28,7 +28,7 @@
         </p>
         <p>
             <strong>Usage:</strong>
-            <code>&lt;input tuiSlider type="range" min="0" max="100" step="1" /&gt;</code>
+            <code tuiText='<input tuiSlider type="range" min="0" max="100" step="1" />'></code>
             .
         </p>
 
@@ -148,7 +148,7 @@
                     max
                 </a>
                 of
-                <code>&lt;input&nbsp;type="range"&nbsp;/&gt;</code>
+                <code tuiText='<input type="range" />'></code>
             </ng-template>
             <ng-template
                 documentationPropertyName="min"
@@ -166,7 +166,7 @@
                     min
                 </a>
                 of
-                <code>&lt;input&nbsp;type="range"&nbsp;/&gt;</code>
+                <code tuiText='<input type="range" />'></code>
             </ng-template>
             <ng-template
                 documentationPropertyName="step"
@@ -184,7 +184,7 @@
                     step
                 </a>
                 of
-                <code>&lt;input&nbsp;type="range"&nbsp;/&gt;</code>
+                <code tuiText='<input type="range" />'></code>
             </ng-template>
             <ng-template
                 documentationPropertyName="size"

--- a/projects/demo/src/modules/components/slider/slider.module.ts
+++ b/projects/demo/src/modules/components/slider/slider.module.ts
@@ -2,7 +2,11 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {
     TuiButtonModule,
     TuiHintModule,
@@ -33,6 +37,7 @@ import {ExampleTuiSliderComponent} from './slider.component';
         TuiButtonModule,
         TuiHintModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiSliderComponent)),
+        TuiTextCodeModule,
     ],
     declarations: [
         ExampleTuiSliderComponent,

--- a/projects/demo/src/modules/components/text-area/text-area.module.ts
+++ b/projects/demo/src/modules/components/text-area/text-area.module.ts
@@ -2,7 +2,11 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {
     TuiButtonModule,
     TuiErrorModule,
@@ -47,6 +51,7 @@ import {ExampleTuiTextAreaComponent} from './text-area.component';
         TuiErrorModule,
         TuiFieldErrorPipeModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiTextAreaComponent)),
+        TuiTextCodeModule,
     ],
     declarations: [
         ExampleTuiTextAreaComponent,

--- a/projects/demo/src/modules/components/text-area/text-area.template.html
+++ b/projects/demo/src/modules/components/text-area/text-area.template.html
@@ -114,7 +114,7 @@
                 [(documentationPropertyValue)]="maxLength"
             >
                 Use maxLength for highlighting extra characters. If you want to limit the number of characters, add
-                <code>&lt;textarea tuiTextfield&gt;&lt;/textarea&gt;</code>
+                <code tuiText="<textarea tuiTextfield></textarea>"></code>
                 with native maxlength attribute.
             </ng-template>
             <ng-template

--- a/projects/demo/src/modules/decorators/default-prop/default-prop.template.html
+++ b/projects/demo/src/modules/decorators/default-prop/default-prop.template.html
@@ -56,7 +56,7 @@
     <ng-template pageTab>
         <p>
             You can also pass contract function of type
-            <code>TuiBooleanHandler&lt;T&gt;</code>
+            <code tuiText="TuiBooleanHandler<T>"></code>
             with the component instance as
             <code>this</code>
             . If check is unsuccessful, it shows an error message about the problem in console in dev mode.

--- a/projects/demo/src/modules/decorators/required-setter/required-setter.module.ts
+++ b/projects/demo/src/modules/decorators/required-setter/required-setter.module.ts
@@ -2,7 +2,11 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiButtonModule} from '@taiga-ui/core';
 import {TuiInputCountModule} from '@taiga-ui/kit';
 
@@ -16,6 +20,7 @@ import {ExampleTuiRequiredSetterDemoComponent} from './required-setter-demo.comp
         TuiInputCountModule,
         TuiButtonModule,
         TuiAddonDocModule,
+        TuiTextCodeModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiRequiredSetterComponent)),
     ],
     declarations: [

--- a/projects/demo/src/modules/decorators/required-setter/required-setter.template.html
+++ b/projects/demo/src/modules/decorators/required-setter/required-setter.template.html
@@ -37,7 +37,7 @@
     <ng-template pageTab>
         <p>
             You can also pass contract function of type
-            <code>TuiBooleanHandler&lt;T&gt;</code>
+            <code tuiText="TuiBooleanHandler<T>"></code>
             with the component instance as
             <code>this</code>
             . If check is unsuccessful, it shows an error message about the problem in console in dev mode.

--- a/projects/demo/src/modules/markup/spaces/examples/1/index.html
+++ b/projects/demo/src/modules/markup/spaces/examples/1/index.html
@@ -1,6 +1,6 @@
 <h2 class="title">
     Margin top
-    <code>tui-space_top-&lt;value&gt;</code>
+    <code tuiText="tui-space_top-<value>"></code>
 </h2>
 <div class="row">
     <div class="example tui-space_top-1 tui-space_right-2">
@@ -21,7 +21,7 @@
 </div>
 <h2 class="title">
     Margin bottom
-    <code>tui-space_bottom-&lt;value&gt;</code>
+    <code tuiText="tui-space_bottom-<value>"></code>
 </h2>
 <div class="row row_align-items_bottom">
     <div class="example tui-space_bottom-1 tui-space_right-2">
@@ -42,7 +42,7 @@
 </div>
 <h2 class="title">
     Margin right
-    <code>tui-space_right-&lt;value&gt;</code>
+    <code tuiText="tui-space_right-<value>"></code>
 </h2>
 <div class="row">
     <div class="example tui-space_right-1">
@@ -64,7 +64,7 @@
 </div>
 <h2 class="title">
     Margin left
-    <code>tui-space_left-&lt;value&gt;</code>
+    <code tuiText="tui-space_left-<value>"></code>
 </h2>
 <div class="row">
     <div class="example"></div>
@@ -86,9 +86,9 @@
 </div>
 <h2 class="title">
     Vertical and horizontal margins
-    <code>tui-space_vertical-&lt;value&gt;</code>
+    <code tuiText="tui-space_vertical-<value>"></code>
     and
-    <code>tui-space_horizontal-&lt;value&gt;</code>
+    <code tuiText="tui-space_horizontal-<value>"></code>
 </h2>
 <div class="row">
     <div class="example tui-space_vertical-4">

--- a/projects/demo/src/modules/markup/spaces/examples/2/index.html
+++ b/projects/demo/src/modules/markup/spaces/examples/2/index.html
@@ -1,6 +1,6 @@
 <h2 class="title">
     Margin top
-    <code>.tui-space(top, &lt;value&gt;);</code>
+    <code tuiText=".tui-space(top, <value>);"></code>
 </h2>
 <div class="row">
     <div class="example example_top-1">
@@ -21,7 +21,7 @@
 </div>
 <h2 class="title">
     Margin bottom
-    <code>.tui-space(bottom, &lt;value&gt;);</code>
+    <code tuiText=".tui-space(bottom, <value>);"></code>
 </h2>
 <div class="row row_align-items_bottom">
     <div class="example example_bottom-1">
@@ -42,7 +42,7 @@
 </div>
 <h2 class="title">
     Margin right
-    <code>.tui-space(right, &lt;value&gt;);</code>
+    <code tuiText=".tui-space(right, <value>);"></code>
 </h2>
 <div class="row">
     <div class="example example_right-1">
@@ -64,7 +64,7 @@
 </div>
 <h2 class="title">
     Margin left
-    <code>.tui-space(left, &lt;value&gt;);</code>
+    <code tuiText=".tui-space(left, <value>);"></code>
 </h2>
 <div class="row">
     <div class="example"></div>
@@ -86,9 +86,9 @@
 </div>
 <h2 class="title">
     Vertical and horizontal margins
-    <code>.tui-space(vertical, &lt;value&gt;);</code>
+    <code tuiText=".tui-space(vertical, <value>);"></code>
     and
-    <code>.tui-space(horizontal, &lt;value&gt;);</code>
+    <code tuiText=".tui-space(horizontal, <value>);"></code>
 </h2>
 <div class="row">
     <div class="example example_vertical">

--- a/projects/demo/src/modules/markup/spaces/spaces.module.ts
+++ b/projects/demo/src/modules/markup/spaces/spaces.module.ts
@@ -6,6 +6,7 @@ import {
     TuiAddonDocModule,
     TuiDocCopyModule,
     tuiGenerateRoutes,
+    TuiTextCodeModule,
 } from '@taiga-ui/addon-doc';
 
 import {StylesInfoModule} from '../../app/styles-info/styles-info.module';
@@ -20,6 +21,7 @@ import {SpacesComponent} from './spaces.component';
         StylesInfoModule,
         TuiDocCopyModule,
         TuiAddonDocModule,
+        TuiTextCodeModule,
         RouterModule.forChild(tuiGenerateRoutes(SpacesComponent)),
     ],
     declarations: [SpacesComponent, TuiSpacingExample1, TuiSpacingExample2],

--- a/projects/demo/src/modules/markup/spaces/spaces.template.html
+++ b/projects/demo/src/modules/markup/spaces/spaces.template.html
@@ -8,7 +8,7 @@
 
         <div class="tui-space_bottom-3">
             You can build a class with direction and value between 0 and 15 (
-            <code>tui-space_&lt;direction&gt;-&lt;value&gt;</code>
+            <code tuiText="tui-space_<direction>-<value>"></code>
             ).
         </div>
 
@@ -25,7 +25,7 @@
 
         <p>
             Mixin also gets a direction and a value (
-            <code>.tui-space(&lt;direction&gt;, &lt;value&gt;);</code>
+            <code tuiText=".tui-space(<direction>, <value>);"></code>
             ).
         </p>
 

--- a/projects/demo/src/modules/services/alerts/alerts.module.ts
+++ b/projects/demo/src/modules/services/alerts/alerts.module.ts
@@ -3,7 +3,11 @@ import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {TuiMoneyModule} from '@taiga-ui/addon-commerce';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiButtonModule, TuiLinkModule, TuiModeModule} from '@taiga-ui/core';
 import {TuiInputModule, TuiRadioListModule} from '@taiga-ui/kit';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
@@ -36,6 +40,7 @@ import {CustomLabelModule} from './examples/5/custom-label/custom-label.module';
         FormsModule,
         TuiAddonDocModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiAlertsComponent)),
+        TuiTextCodeModule,
     ],
     declarations: [
         ExampleTuiAlertsComponent,

--- a/projects/demo/src/modules/services/alerts/alerts.template.html
+++ b/projects/demo/src/modules/services/alerts/alerts.template.html
@@ -126,7 +126,8 @@
                 documentationPropertyType="number"
                 [(documentationPropertyValue)]="data"
             >
-                Input data of notification, type &lt;I&gt;
+                Input data of notification, type:
+                <code tuiText="<I>"></code>
             </ng-template>
             <ng-template
                 documentationPropertyName="autoClose"
@@ -198,7 +199,7 @@
                     You can also customize notification logic with a component. Use
                     <code>POLYMORPHEUS_CONTEXT</code>
                     into the component to get context input data and to output results. It has the following interface:
-                    <code>TuiDialog&lt;TuiAlertOptions&lt;I&gt;, O&gt;</code>
+                    <code tuiText="TuiDialog<TuiAlertOptions<I>, O>"></code>
                     , where
                     <code>O</code>
                     is output data type and

--- a/projects/demo/src/modules/services/scroll/scroll.module.ts
+++ b/projects/demo/src/modules/services/scroll/scroll.module.ts
@@ -2,7 +2,11 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
-import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {
+    TuiAddonDocModule,
+    tuiGenerateRoutes,
+    TuiTextCodeModule,
+} from '@taiga-ui/addon-doc';
 import {TuiElementModule, TuiScrollService} from '@taiga-ui/cdk';
 import {TuiButtonModule, TuiScrollbarModule} from '@taiga-ui/core';
 import {TuiInputCountModule} from '@taiga-ui/kit';
@@ -20,6 +24,7 @@ import {ExampleTuiScrollComponent} from './scroll.component';
         TuiScrollbarModule,
         TuiAddonDocModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleTuiScrollComponent)),
+        TuiTextCodeModule,
     ],
     declarations: [ExampleTuiScrollComponent, TuiScrollExample1],
     exports: [ExampleTuiScrollComponent],

--- a/projects/demo/src/modules/services/scroll/scroll.template.html
+++ b/projects/demo/src/modules/services/scroll/scroll.template.html
@@ -19,7 +19,7 @@
         <p class="b-full-width">
             Method
             <strong>
-                <code>scroll$: Observable&lt;[number, number]&gt;</code>
+                <code tuiText="scroll$: Observable<[number, number]>"></code>
             </strong>
             <em>
                 (emits a tuple tuple

--- a/projects/demo/src/modules/services/svg/svg.template.html
+++ b/projects/demo/src/modules/services/svg/svg.template.html
@@ -21,7 +21,7 @@
                 <p>
                     <strong>
                         Warning, name of the icon must not start with "
-                        <code>&lt;</code>
+                        <code tuiText="<"></code>
                         "
                     </strong>
                 </p>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

`<code>TuiDialog&lt;TuiAlertOptions&lt;I&gt;, O&gt;</code>`

## What is the new behavior?

easy to write

`<code tuiTextCode="TuiDialog<TuiAlertOptions<I>, O>"></code>`