### PR TITLE
fix(addon-editor): focus should trigger only for outside contenteditable area

### DIFF
--- a/projects/addon-editor/components/editor/editor.component.html
+++ b/projects/addon-editor/components/editor/editor.component.html
@@ -37,7 +37,7 @@
         *ngIf="editorLoaded"
         tuiEditorPortal
         class="t-scrollbar"
-        (mousedown.prevent)="nativeFocusableElement?.focus()"
+        (mousedown)="focus($event)"
     >
         <div
             tuiDropdownLimitWidth="auto"

--- a/projects/addon-editor/components/editor/editor.component.ts
+++ b/projects/addon-editor/components/editor/editor.component.ts
@@ -164,6 +164,15 @@ export class TuiEditorComponent
         this.editor?.unsetLink();
     }
 
+    focus(event: MouseEvent): void {
+        if (this.nativeFocusableElement?.contains(event.target as Node | null)) {
+            return;
+        }
+
+        event.preventDefault();
+        this.nativeFocusableElement?.focus();
+    }
+
     override ngOnDestroy(): void {
         this.editor?.destroy();
     }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

@waterplea sorry, but `mousedown` fixed focus, but now it doesn't respond at all
https://taiga-ui.dev/next/editor/API

<img width="300" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/279185ef-b891-46ac-b050-7ff145fb0bd4">


