### PR TITLE
ci: cannot run Jest tests via IDE Webstorm

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,7 @@ process.env.TZ = `Europe/Moscow`;
 process.env.FORCE_COLOR = `true`;
 process.env.TS_JEST_DISABLE_VER_CHECKER = `true`;
 
-const {compilerOptions} = require(resolve(`./tsconfig.json`));
+const {compilerOptions} = require(resolve(__dirname, `tsconfig.json`));
 const maxParallel = require(`os`).cpus().length / 2;
 
 module.exports = {
@@ -26,7 +26,7 @@ module.exports = {
      */
     globals: {
         'ts-jest': {
-            tsconfig: resolve(`./tsconfig.spec.json`),
+            tsconfig: resolve(__dirname, `tsconfig.spec.json`),
             isolatedModules: true,
         },
     },


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Run any Jest test-file via Webstorm GUI:
<img height="500" alt="Screenshot 2023-05-17 at 10 44 01" src="https://github.com/Tinkoff/taiga-ui/assets/35179038/c5e95420-0751-4aec-a8cd-af3dd2035fbd">

It throws
```
Error: Jest: Failed to parse the TypeScript config file /Users/n.barsukov/WebstormProjects/taiga-ui/jest.config.ts
Error: Cannot find module '/Users/n.barsukov/WebstormProjects/taiga-ui/projects/kit/tsconfig.json'
```

## What is the new behavior?
No error
