### PR TITLE
feat(kit): `InputTime` uses `Maskito` instead of legacy `text-mask`

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/input-time/input-time.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-time/input-time.cy.ts
@@ -1,5 +1,8 @@
 describe(`InputTime`, () => {
-    beforeEach(() => cy.clock(Date.UTC(2021, 10, 10, 15, 30, 0, 0), [`Date`]));
+    beforeEach(() => {
+        cy.viewport(`iphone-8`);
+        cy.clock(Date.UTC(2021, 10, 10, 15, 30, 0, 0), [`Date`]);
+    });
 
     describe(`Examples`, () => {
         beforeEach(() => cy.tuiVisit(`components/input-time`));
@@ -76,6 +79,46 @@ describe(`InputTime`, () => {
                     .clear()
                     .type(`07:55`, {force: true})
                     .should(`have.value`, `08:00`);
+            });
+        });
+
+        describe(`Basic typing from keyboard`, () => {
+            beforeEach(() => {
+                visitBy(`mode=HH:MM`);
+
+                getInput().clear().should(`have.value`, ``);
+            });
+
+            it(`3 => 03`, () => {
+                getInput()
+                    .type(`3`)
+                    .should(`have.value`, `03`)
+                    .should(`have.prop`, `selectionStart`, 2)
+                    .should(`have.prop`, `selectionEnd`, 2);
+            });
+
+            it(`1111 => 11:11`, () => {
+                getInput()
+                    .type(`1111`)
+                    .should(`have.value`, `11:11`)
+                    .should(`have.prop`, `selectionStart`, `11:11`.length)
+                    .should(`have.prop`, `selectionEnd`, `11:11`.length);
+            });
+
+            it(`0130 => 01:30`, () => {
+                getInput()
+                    .type(`0130`)
+                    .should(`have.value`, `01:30`)
+                    .should(`have.prop`, `selectionStart`, `01:30`.length)
+                    .should(`have.prop`, `selectionEnd`, `01:30`.length);
+            });
+
+            it(`99 => 09:09`, () => {
+                getInput()
+                    .type(`99`)
+                    .should(`have.value`, `09:09`)
+                    .should(`have.prop`, `selectionStart`, `09:09`.length)
+                    .should(`have.prop`, `selectionEnd`, `09:09`.length);
             });
         });
 

--- a/projects/kit/components/input-time/input-time.component.ts
+++ b/projects/kit/components/input-time/input-time.component.ts
@@ -10,6 +10,8 @@ import {
     ViewChild,
 } from '@angular/core';
 import {NgControl} from '@angular/forms';
+import {MaskitoOptions} from '@maskito/core';
+import {maskitoTimeOptionsGenerator} from '@maskito/kit';
 import {
     AbstractTuiNullableControl,
     ALWAYS_FALSE_HANDLER,
@@ -38,15 +40,10 @@ import {
     TuiSizeL,
     TuiSizeS,
     TuiTextfieldSizeDirective,
-    TuiTextMaskOptions,
 } from '@taiga-ui/core';
 import {TUI_SELECT_OPTION} from '@taiga-ui/kit/components/select-option';
 import {FIXED_DROPDOWN_CONTROLLER_PROVIDER} from '@taiga-ui/kit/providers';
 import {TUI_TIME_TEXTS} from '@taiga-ui/kit/tokens';
-import {
-    tuiCreateAutoCorrectedTimePipe,
-    tuiCreateTimeMask,
-} from '@taiga-ui/kit/utils/mask';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -148,7 +145,7 @@ export class TuiInputTimeComponent
         return this.textfieldSize.size;
     }
 
-    get textMaskOptions(): TuiTextMaskOptions {
+    get maskOptions(): MaskitoOptions {
         return this.calculateMask(this.mode);
     }
 
@@ -280,12 +277,18 @@ export class TuiInputTimeComponent
     }
 
     @tuiPure
-    private calculateMask(mode: TuiTimeMode): TuiTextMaskOptions {
-        return {
-            mask: tuiCreateTimeMask(mode, this.options.maxValues),
-            pipe: tuiCreateAutoCorrectedTimePipe(mode, this.options.maxValues),
-            guide: false,
-        };
+    private calculateMask(mode: TuiTimeMode): MaskitoOptions {
+        const {HH, MM, SS, MS} = this.options.maxValues;
+
+        return maskitoTimeOptionsGenerator({
+            mode,
+            timeSegmentMaxValues: {
+                hours: HH,
+                minutes: MM,
+                seconds: SS,
+                milliseconds: MS,
+            },
+        });
     }
 
     @tuiPure

--- a/projects/kit/components/input-time/input-time.module.ts
+++ b/projects/kit/components/input-time/input-time.module.ts
@@ -1,5 +1,6 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {MaskitoModule} from '@maskito/angular';
 import {
     TuiDataListModule,
     TuiHostedDropdownModule,
@@ -9,7 +10,7 @@ import {
     TuiWrapperModule,
 } from '@taiga-ui/core';
 import {TuiSelectOptionModule} from '@taiga-ui/kit/components/select-option';
-import {TextMaskModule, TuiValueAccessorModule} from '@taiga-ui/kit/directives';
+import {TuiValueAccessorModule} from '@taiga-ui/kit/directives';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 
 import {TuiInputTimeComponent} from './input-time.component';
@@ -19,7 +20,7 @@ import {TuiNativeTimeComponent} from './native-time/native-time.component';
 @NgModule({
     imports: [
         CommonModule,
-        TextMaskModule,
+        MaskitoModule,
         TuiSelectOptionModule,
         TuiDataListModule,
         TuiWrapperModule,

--- a/projects/kit/components/input-time/input-time.template.html
+++ b/projects/kit/components/input-time/input-time.template.html
@@ -18,7 +18,7 @@
         [focusable]="focusable"
         [disabled]="disabled"
         [readOnly]="readOnly"
-        [textMask]="textMaskOptions"
+        [maskito]="maskOptions"
         [tuiTextfieldIcon]="iconContent"
         [value]="computedValue"
         [postfix]="postfix"

--- a/projects/kit/components/input-time/test/input-time.component.spec.ts
+++ b/projects/kit/components/input-time/test/input-time.component.spec.ts
@@ -241,7 +241,7 @@ describe(`InputTime`, () => {
         });
 
         it(`Input filters items`, () => {
-            inputPO.sendText(`3`);
+            inputPO.sendText(`03`);
 
             expect(pageObject.getAllByAutomationId(`tui-input-time__item`).length).toBe(
                 1,
@@ -249,7 +249,7 @@ describe(`InputTime`, () => {
         });
 
         it(`The value is substituted when selecting an item from the dropdown`, () => {
-            inputPO.sendText(`3`);
+            inputPO.sendText(`03`);
             pageObject.getByAutomationId(`tui-input-time__item`)!.nativeElement.click();
 
             expect(testComponent.control.value.toString().trim()).toBe(
@@ -259,7 +259,7 @@ describe(`InputTime`, () => {
 
         describe(`strict mode`, () => {
             it(`by default it is false, and the entered value is freely exposed in the control`, () => {
-                inputPO.sendText(`1111`);
+                inputPO.sendText(`11:11`);
 
                 expect(testComponent.control.value.toString().trim()).toBe(`11:11`);
             });
@@ -267,7 +267,7 @@ describe(`InputTime`, () => {
             it(`with strict = true, the entered value is not set if it is absent in items`, () => {
                 testComponent.strict = true;
                 fixture.detectChanges();
-                inputPO.sendText(`1111`);
+                inputPO.sendText(`11:11`);
                 fixture.detectChanges();
 
                 expect(testComponent.control.value.toString().trim()).not.toBe(`11:11`);
@@ -276,7 +276,7 @@ describe(`InputTime`, () => {
             it(`with strict = true, the entered value is added if present in items`, () => {
                 testComponent.strict = true;
                 fixture.detectChanges();
-                inputPO.sendText(`0130`);
+                inputPO.sendText(`01:30`);
                 fixture.detectChanges();
 
                 expect(testComponent.control.value.toString().trim()).toBe(`01:30`);
@@ -285,7 +285,7 @@ describe(`InputTime`, () => {
             it(`with strict = true, the entered value is rounded to the nearest in items`, () => {
                 testComponent.strict = true;
                 fixture.detectChanges();
-                inputPO.sendText(`0120`);
+                inputPO.sendText(`01:20`);
                 fixture.detectChanges();
 
                 expect(testComponent.control.value.toString().trim()).toBe(`01:30`);

--- a/projects/kit/utils/mask/create-auto-corrected-time-pipe.ts
+++ b/projects/kit/utils/mask/create-auto-corrected-time-pipe.ts
@@ -4,6 +4,7 @@ import {MAX_TIME_VALUES} from '@taiga-ui/kit/constants';
 import {TuiTimeFormatParts} from '@taiga-ui/kit/types';
 
 /**
+ * @deprecated Use {@link https://tinkoff.github.io/maskito/kit/time Time} from {@link https://github.com/Tinkoff/maskito Maskito} instead
  * Adjusts the entered time by omitting only suitable values for hours and minutes
  * @returns time as a string
  */

--- a/projects/kit/utils/mask/create-time-mask.ts
+++ b/projects/kit/utils/mask/create-time-mask.ts
@@ -17,6 +17,9 @@ function tuiCreateTimePartMask(
     return regExp;
 }
 
+/**
+ * @deprecated Use {@link https://tinkoff.github.io/maskito/kit/time Time} from {@link https://github.com/Tinkoff/maskito Maskito} instead
+ */
 export function tuiCreateTimeMask(
     mode: TuiTimeMode,
     maxValues: Partial<Record<TuiTimeFormatParts, number>> = {},


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Partially solves https://github.com/Tinkoff/taiga-ui/issues/120
