### PR TITLE
feat(kit): `InputDate` uses `Maskito` instead of legacy `text-mask`

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/input-date/input-date.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-date/input-date.cy.ts
@@ -105,6 +105,32 @@ describe(`InputDate`, () => {
                 .tuiScrollIntoView();
         }
     });
+
+    describe(`Cypress component testing`, () => {
+        it(`If there is min and an initial value and an initial value less than min - keep the initial value`, () => {
+            cy.tuiVisit(`cypress`);
+
+            const id = `#input-date-initialization`;
+
+            cy.get(`${id} input`).first().should(`be.visible`).as(`input`);
+
+            cy.get(`@input`)
+                .should(`have.value`, `17.05.2023`)
+                .focus()
+                .should(`have.value`, `17.05.2023`)
+                .blur()
+                .should(`have.value`, `17.05.2023`)
+                .focus()
+                .should(`have.value`, `17.05.2023`);
+
+            cy.get(id).contains(`Minimum value 18.05.2023`);
+
+            cy.get(`@input`)
+                .clear()
+                .type(`17.05.2023`)
+                .should(`have.value`, `18.05.2023`);
+        });
+    });
 });
 
 function matchImageSnapshot(name: string): void {

--- a/projects/demo-integrations/cypress/tests/kit/input-date/input-date.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-date/input-date.cy.ts
@@ -1,4 +1,8 @@
 describe(`InputDate`, () => {
+    beforeEach(() => {
+        cy.viewport(400, 500);
+    });
+
     describe(`Examples`, () => {
         for (const size of [`s`, `m`, `l`]) {
             it(`correct filler display for size ${size.toUpperCase()}`, () => {
@@ -58,6 +62,40 @@ describe(`InputDate`, () => {
 
             getInput().click();
             matchImageSnapshot(`input-date-minimum-month`);
+        });
+
+        describe(`Invalid date cases`, () => {
+            it(`does not accept day >31`, () => {
+                cy.tuiVisit(`components/input-date/API`);
+
+                getInput()
+                    .type(`35`)
+                    .should(`have.value`, `3`)
+                    .should(`have.prop`, `selectionStart`, 1)
+                    .should(`have.prop`, `selectionEnd`, 1);
+            });
+
+            it(`does not accept month >12`, () => {
+                cy.tuiVisit(`components/input-date/API`);
+
+                getInput()
+                    .type(`1715`)
+                    .should(`have.value`, `17.1`)
+                    .should(`have.prop`, `selectionStart`, `17.1`.length)
+                    .should(`have.prop`, `selectionEnd`, `17.1`.length);
+            });
+
+            it(`Type 999999 => 09.09.9999`, () => {
+                cy.tuiVisit(`components/input-date/API`);
+
+                getInput()
+                    .type(`999999`)
+                    .should(`have.value`, `09.09.9999`)
+                    .should(`have.prop`, `selectionStart`, `09.09.9999`.length)
+                    .should(`have.prop`, `selectionEnd`, `09.09.9999`.length);
+
+                matchImageSnapshot(`input-date-type-999999`);
+            });
         });
 
         function getInput(): Cypress.Chainable<JQuery> {

--- a/projects/demo/src/modules/app/app.routes.ts
+++ b/projects/demo/src/modules/app/app.routes.ts
@@ -1935,6 +1935,14 @@ export const ROUTES: Routes = [
         },
     },
     {
+        path: `cypress`,
+        loadChildren: async () =>
+            import(`../cypress/cypress.module`).then(m => m.CypressDocPageModule),
+        data: {
+            title: `Cypress tests 🤫`,
+        },
+    },
+    {
         path: `**`,
         redirectTo: ``,
     },

--- a/projects/demo/src/modules/cypress/cypress.component.ts
+++ b/projects/demo/src/modules/cypress/cypress.component.ts
@@ -1,0 +1,8 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+
+@Component({
+    selector: 'cypress-doc-page',
+    templateUrl: './cypress.template.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CypressDocPageComponent {}

--- a/projects/demo/src/modules/cypress/cypress.module.ts
+++ b/projects/demo/src/modules/cypress/cypress.module.ts
@@ -1,0 +1,25 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {RouterModule} from '@angular/router';
+import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {TuiNotificationModule} from '@taiga-ui/core';
+import {TuiInputDateModule} from '@taiga-ui/kit';
+
+import {CypressDocPageComponent} from './cypress.component';
+import {TestDocExample1} from './examples/1-input-date-initialization';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        FormsModule,
+        ReactiveFormsModule,
+        TuiAddonDocModule,
+        TuiNotificationModule,
+        TuiInputDateModule,
+        RouterModule.forChild(tuiGenerateRoutes(CypressDocPageComponent)),
+    ],
+    declarations: [CypressDocPageComponent, TestDocExample1],
+    exports: [CypressDocPageComponent],
+})
+export class CypressDocPageModule {}

--- a/projects/demo/src/modules/cypress/cypress.template.html
+++ b/projects/demo/src/modules/cypress/cypress.template.html
@@ -1,0 +1,13 @@
+<tui-doc-page header="Cypress">
+    <tui-notification
+        status="warning"
+        class="tui-space_bottom-6"
+    >
+        TODO: replace this page with Cypress Component Testing after Angular update (13+)
+    </tui-notification>
+
+    <test-doc-example-1
+        id="input-date-initialization"
+        class="tui-space_bottom-6"
+    ></test-doc-example-1>
+</tui-doc-page>

--- a/projects/demo/src/modules/cypress/examples/1-input-date-initialization/index.html
+++ b/projects/demo/src/modules/cypress/examples/1-input-date-initialization/index.html
@@ -1,0 +1,6 @@
+<tui-input-date
+    [formControl]="control"
+    [min]="min"
+>
+    Minimum value {{ min.toString() }}
+</tui-input-date>

--- a/projects/demo/src/modules/cypress/examples/1-input-date-initialization/index.ts
+++ b/projects/demo/src/modules/cypress/examples/1-input-date-initialization/index.ts
@@ -1,0 +1,13 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormControl} from '@angular/forms';
+import {TuiDay} from '@taiga-ui/cdk';
+
+@Component({
+    selector: 'test-doc-example-1',
+    templateUrl: './index.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TestDocExample1 {
+    readonly control = new FormControl(new TuiDay(2023, 4, 17));
+    readonly min = new TuiDay(2023, 4, 18);
+}

--- a/projects/kit/components/input-date/input-date.module.ts
+++ b/projects/kit/components/input-date/input-date.module.ts
@@ -1,5 +1,6 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {MaskitoModule} from '@maskito/angular';
 import {TuiLetModule, TuiPreventDefaultModule} from '@taiga-ui/cdk';
 import {
     TuiCalendarModule,
@@ -11,7 +12,7 @@ import {
     TuiTextfieldControllerModule,
     TuiWrapperModule,
 } from '@taiga-ui/core';
-import {TextMaskModule, TuiValueAccessorModule} from '@taiga-ui/kit/directives';
+import {TuiValueAccessorModule} from '@taiga-ui/kit/directives';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 
 import {TuiInputDateComponent} from './input-date.component';
@@ -21,7 +22,7 @@ import {TuiNativeDateDirective} from './native-date/native-date.component';
 @NgModule({
     imports: [
         CommonModule,
-        TextMaskModule,
+        MaskitoModule,
         PolymorpheusModule,
         TuiWrapperModule,
         TuiPreventDefaultModule,

--- a/projects/kit/components/input-date/input-date.template.html
+++ b/projects/kit/components/input-date/input-date.template.html
@@ -19,7 +19,7 @@
         [readOnly]="readOnly"
         [focusable]="computedFocusable"
         [disabled]="computedDisabled"
-        [textMask]="computedMask"
+        [maskito]="computedMask"
         [value]="computedValue"
         (valueChange)="onValueChange($event)"
         (focusedChange)="onFocused($event)"

--- a/projects/kit/components/input-date/test/input-date.component.spec.ts
+++ b/projects/kit/components/input-date/test/input-date.component.spec.ts
@@ -112,19 +112,6 @@ describe(`InputDate (base cases when TUI_DATE_FORMAT = DMY)`, () => {
         await initializeEnvironment();
     });
 
-    // TODO: investigate if it is really required
-    xit(`If there is min and an initial value and an initial value less than min - keep the initial value`, async () => {
-        testComponent.min = new TuiDay(2018, 3, 11);
-        fixture.detectChanges();
-
-        await fixture.whenStable();
-
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        expect(inputPO.value).toBe(`01.03.2017`);
-    });
-
     it(`sets valid day if date selected via calendar`, async () => {
         mouseDownOnTextfield();
 

--- a/projects/kit/components/input-date/test/input-date.component.spec.ts
+++ b/projects/kit/components/input-date/test/input-date.component.spec.ts
@@ -112,7 +112,8 @@ describe(`InputDate (base cases when TUI_DATE_FORMAT = DMY)`, () => {
         await initializeEnvironment();
     });
 
-    it(`If there is min and an initial value and an initial value less than min - keep the initial value`, async () => {
+    // TODO: investigate if it is really required
+    xit(`If there is min and an initial value and an initial value less than min - keep the initial value`, async () => {
         testComponent.min = new TuiDay(2018, 3, 11);
         fixture.detectChanges();
 
@@ -143,12 +144,6 @@ describe(`InputDate (base cases when TUI_DATE_FORMAT = DMY)`, () => {
             inputPO.sendText(`01.03.2017`);
 
             expect(inputPO.value).toBe(`01.03.2017`);
-        });
-
-        it(`If you enter an invalid date, the value is adjusted`, () => {
-            inputPO.sendText(`32.12.2012`);
-
-            expect(inputPO.value).toBe(`31.12.2012`);
         });
 
         it(`When entering an incomplete date, leaves it in the field`, () => {
@@ -227,17 +222,6 @@ describe(`InputDate + TUI_DATE_FORMAT = YMD integration`, () => {
         expect(typedDay.year).toBe(2021);
     });
 
-    it(`does not accept dd.mm.yyyy`, () => {
-        inputPO.sendText(`23.12.2021`);
-
-        const typedDay = testComponent.control.value;
-
-        expect(inputPO.value).toBe(`2312.12.21`);
-        expect(typedDay.day).toBe(21);
-        expect(typedDay.month).toBe(11);
-        expect(typedDay.year).toBe(2312);
-    });
-
     it(`does not accept mm.dd.yyyy (and set min day if it is less min day)`, () => {
         inputPO.sendText(`12.23.2021`);
 
@@ -283,17 +267,6 @@ describe(`InputDate + TUI_DATE_FORMAT = MDY integration`, () => {
 
         expect(inputPO.value).toBe(`12.23.2021`);
         expect(typedDay.day).toBe(23);
-        expect(typedDay.month).toBe(11);
-        expect(typedDay.year).toBe(2021);
-    });
-
-    it(`does not accept dd.mm.yyyy`, () => {
-        inputPO.sendText(`23.12.2021`);
-
-        const typedDay = testComponent.control.value;
-
-        expect(inputPO.value).toBe(`12.12.2021`);
-        expect(typedDay.day).toBe(12);
         expect(typedDay.month).toBe(11);
         expect(typedDay.year).toBe(2021);
     });

--- a/projects/kit/constants/date-mode-maskito-adapter.ts
+++ b/projects/kit/constants/date-mode-maskito-adapter.ts
@@ -1,0 +1,8 @@
+import {MaskitoDateMode} from '@maskito/kit';
+import {TuiDateMode} from '@taiga-ui/cdk';
+
+export const TUI_DATE_MODE_MASKITO_ADAPTER: Record<TuiDateMode, MaskitoDateMode> = {
+    DMY: `dd/mm/yyyy`,
+    MDY: `mm/dd/yyyy`,
+    YMD: `yyyy/mm/dd`,
+};

--- a/projects/kit/constants/index.ts
+++ b/projects/kit/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './date-mode-maskito-adapter';
 export * from './date-time-separator';
 export * from './empty-mask';
 export * from './group-class-names';

--- a/projects/kit/utils/mask/create-auto-corrected-date-pipe.ts
+++ b/projects/kit/utils/mask/create-auto-corrected-date-pipe.ts
@@ -1,12 +1,18 @@
 import {DATE_FILLER_LENGTH, TuiDateMode, TuiDay} from '@taiga-ui/cdk';
 import {TuiTextMaskPipeHandler, TuiWithOptionalMinMaxWithValue} from '@taiga-ui/core';
 
+/**
+ * @deprecated Use {@link https://tinkoff.github.io/maskito/kit/date Date} from {@link https://github.com/Tinkoff/maskito Maskito} instead
+ */
 export interface TuiAutoCorrectedDatePipeConfigs
     extends TuiWithOptionalMinMaxWithValue<TuiDay | null, TuiDay> {
     dateFormat: TuiDateMode;
     dateSeparator: string;
 }
 
+/**
+ * @deprecated Use {@link https://tinkoff.github.io/maskito/kit/date Date} from {@link https://github.com/Tinkoff/maskito Maskito} instead
+ */
 export function tuiNormalizeDateValue(
     dateValue: string,
     {value, min, max, dateFormat, dateSeparator}: TuiAutoCorrectedDatePipeConfigs,
@@ -18,6 +24,9 @@ export function tuiNormalizeDateValue(
               .toString(dateFormat, dateSeparator);
 }
 
+/**
+ * @deprecated Use {@link https://tinkoff.github.io/maskito/kit/date Date} from {@link https://github.com/Tinkoff/maskito Maskito} instead
+ */
 export function tuiCreateAutoCorrectedDatePipe(
     config: TuiAutoCorrectedDatePipeConfigs,
 ): TuiTextMaskPipeHandler {

--- a/projects/kit/utils/mask/create-date-mask.ts
+++ b/projects/kit/utils/mask/create-date-mask.ts
@@ -4,6 +4,9 @@ import {TUI_DIGIT_REGEXP, TuiTextMaskList} from '@taiga-ui/core';
 const TWO_DIGITS = new Array(2).fill(TUI_DIGIT_REGEXP);
 const FOUR_DIGITS = new Array(4).fill(TUI_DIGIT_REGEXP);
 
+/**
+ * @deprecated Use {@link https://tinkoff.github.io/maskito/kit/date Date} from {@link https://github.com/Tinkoff/maskito Maskito} instead
+ */
 export function tuiCreateDateMask(mode: TuiDateMode, separator: string): TuiTextMaskList {
     ngDevMode &&
         tuiAssert.assert(


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
Partially solves https://github.com/Tinkoff/taiga-ui/issues/120
