### PR TITLE
fix(addon-doc): anchor and theme mode buttons get proper size of svg icons

### DIFF
--- a/projects/addon-doc/components/example/example.template.html
+++ b/projects/addon-doc/components/example/example.template.html
@@ -11,7 +11,7 @@
         tuiIconButton
         type="button"
         size="xs"
-        icon="tuiIconLinkLarge"
+        icon="tuiIconLink"
         appearance="icon"
         class="t-link-icon"
         [title]="copy$ | async"

--- a/projects/addon-doc/components/internal/source-code/source-code.template.html
+++ b/projects/addon-doc/components/internal/source-code/source-code.template.html
@@ -2,7 +2,7 @@
     *polymorpheusOutlet="sourceCode as link; context: pathOptions"
     tuiIconButton
     type="button"
-    icon="tuiIconCodeLarge"
+    icon="tuiIconCode"
     appearance="icon"
     target="_blank"
     size="s"

--- a/projects/addon-doc/components/main/main.template.html
+++ b/projects/addon-doc/components/main/main.template.html
@@ -18,7 +18,7 @@
             shape="rounded"
             type="button"
             class="tui-doc-night-mode-switch"
-            [icon]="night.value ? 'tuiIconSunLarge' : 'tuiIconMoonLarge'"
+            [icon]="night.value ? 'tuiIconSun' : 'tuiIconMoon'"
             (click)="night.toggle()"
         ></button>
     </header>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4495

## What is the new behavior?
