### PR TITLE
docs(demo): add overflownChange output event

### DIFF
--- a/projects/demo/src/modules/components/line-clamp/line-clamp.template.html
+++ b/projects/demo/src/modules/components/line-clamp/line-clamp.template.html
@@ -90,6 +90,17 @@
             >
                 Number of visible lines
             </ng-template>
+            <ng-template
+                documentationPropertyName="overflownChange"
+                documentationPropertyMode="output"
+                documentationPropertyType="boolean"
+            >
+                Emits
+                <code>true</code>
+                if there's extra content which isn't visible otherwise
+                <code>false</code>
+                when all content is visible.
+            </ng-template>
         </tui-doc-documentation>
         <tui-doc-documentation heading="CSS customization">
             <ng-template


### PR DESCRIPTION
this commit add missing "overflownChange" output in API of line-clamp

fixes #3857

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [x] Documentation content changes

## What is the current behavior?

API is missing overflownChange property in line-clamp.

Closes #3857

## What is the new behavior?

API wont be missing overflownChange property in line-clamp.
