### PR TITLE
feat(kit): `InputDateRange` uses `Maskito` instead of legacy `text-mask`

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/input-date-range/input-date-range.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/input-date-range/input-date-range.cy.ts
@@ -1,4 +1,9 @@
+/* eslint-disable no-irregular-whitespace */
 describe(`InputDateRange`, () => {
+    beforeEach(() => {
+        cy.viewport(650, 500);
+    });
+
     describe(`API`, () => {
         for (const size of [`s`, `m`, `l`]) {
             it(`correct filler display for size ${size.toUpperCase()}`, () => {
@@ -30,6 +35,56 @@ describe(`InputDateRange`, () => {
 
             getInput().click();
             matchImageSnapshot(`input-date-range-minimum-month`);
+        });
+
+        describe(`prevents changes if you enter an invalid date`, () => {
+            it(`day > 31`, () => {
+                cy.tuiVisit(`components/input-date-range/API`);
+
+                getInput()
+                    .type(`32`)
+                    .should(`have.value`, `3`)
+                    .should(`have.prop`, `selectionStart`, 1)
+                    .should(`have.prop`, `selectionEnd`, 1)
+                    .type(`1`)
+                    .should(`have.value`, `31`)
+                    .should(`have.prop`, `selectionStart`, 2)
+                    .should(`have.prop`, `selectionEnd`, 2);
+            });
+
+            it(`month > 12`, () => {
+                cy.tuiVisit(`components/input-date-range/API`);
+
+                getInput()
+                    .type(`2913`)
+                    .should(`have.value`, `29.1`)
+                    .should(`have.prop`, `selectionStart`, `29.1`.length)
+                    .should(`have.prop`, `selectionEnd`, `29.1`.length)
+                    .type(`0`)
+                    .should(`have.value`, `29.10`)
+                    .should(`have.prop`, `selectionStart`, `29.10`.length)
+                    .should(`have.prop`, `selectionEnd`, `29.10`.length);
+            });
+        });
+
+        it(`pads date range if it is less than [minLength]`, () => {
+            cy.tuiVisit(`components/input-date-range/API?minLength$=0`); // minLength = {day: 3}
+
+            getInput()
+                .type(`21052023-22052023`)
+                .should(`have.value`, `21.05.2023 – 23.05.2023`)
+                .should(`have.prop`, `selectionStart`, `21.05.2023 – 23.05.2023`.length)
+                .should(`have.prop`, `selectionEnd`, `21.05.2023 – 23.05.2023`.length);
+        });
+
+        it(`cuts date range if it is more than [maxLength]`, () => {
+            cy.tuiVisit(`components/input-date-range/API?maxLength$=0`); // maxLength = {day: 5}
+
+            getInput()
+                .type(`20052023-29052023`)
+                .should(`have.value`, `20.05.2023 – 24.05.2023`)
+                .should(`have.prop`, `selectionStart`, `20.05.2023 – 24.05.2023`.length)
+                .should(`have.prop`, `selectionEnd`, `20.05.2023 – 24.05.2023`.length);
         });
 
         function visitBy(size: string): void {

--- a/projects/kit/components/input-date-range/input-date-range.component.ts
+++ b/projects/kit/components/input-date-range/input-date-range.component.ts
@@ -314,13 +314,10 @@ export class TuiInputDateRangeComponent
             this.onOpenChange(true);
         }
 
-        if (value.length !== DATE_RANGE_FILLER_LENGTH) {
-            this.value = null;
-
-            return;
-        }
-
-        this.value = TuiDayRange.normalizeParse(value, this.dateFormat);
+        this.value =
+            value.length === DATE_RANGE_FILLER_LENGTH
+                ? TuiDayRange.normalizeParse(value, this.dateFormat)
+                : null;
     }
 
     onRangeChange(range: TuiDayRange | null): void {

--- a/projects/kit/components/input-date-range/input-date-range.component.ts
+++ b/projects/kit/components/input-date-range/input-date-range.component.ts
@@ -12,6 +12,8 @@ import {
     ViewChild,
 } from '@angular/core';
 import {NgControl} from '@angular/forms';
+import {MASKITO_DEFAULT_OPTIONS, MaskitoOptions} from '@maskito/core';
+import {maskitoDateRangeOptionsGenerator} from '@maskito/kit';
 import {
     AbstractTuiNullableControl,
     AbstractTuiValueTransformer,
@@ -36,6 +38,7 @@ import {
     TuiMapper,
     TuiMonth,
     tuiNullableSame,
+    tuiPure,
 } from '@taiga-ui/cdk';
 import {
     TUI_DEFAULT_MARKER_HANDLER,
@@ -46,11 +49,13 @@ import {
     TuiSizeL,
     TuiSizeS,
     TuiTextfieldSizeDirective,
-    TuiTextMaskOptions,
     TuiWithOptionalMinMax,
 } from '@taiga-ui/core';
 import {TuiDayRangePeriod} from '@taiga-ui/kit/classes';
-import {EMPTY_MASK, MAX_DAY_RANGE_LENGTH_MAPPER} from '@taiga-ui/kit/constants';
+import {
+    MAX_DAY_RANGE_LENGTH_MAPPER,
+    TUI_DATE_MODE_MASKITO_ADAPTER,
+} from '@taiga-ui/kit/constants';
 import {
     TUI_DATE_RANGE_VALUE_TRANSFORMER,
     TUI_DATE_TEXTS,
@@ -59,10 +64,6 @@ import {
     tuiDateStreamWithTransformer,
     TuiInputDateOptions,
 } from '@taiga-ui/kit/tokens';
-import {
-    tuiCreateAutoCorrectedDateRangePipe,
-    tuiCreateDateRangeMask,
-} from '@taiga-ui/kit/utils/mask';
 import {PolymorpheusComponent, PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
 import {Observable} from 'rxjs';
 import {map, takeUntil} from 'rxjs/operators';
@@ -84,12 +85,6 @@ export class TuiInputDateRangeComponent
 {
     @ViewChild(TuiPrimitiveTextfieldComponent)
     private readonly textfield?: TuiPrimitiveTextfieldComponent;
-
-    private readonly textMaskOptions: TuiTextMaskOptions = {
-        mask: tuiCreateDateRangeMask(this.dateFormat, this.dateSeparator),
-        pipe: tuiCreateAutoCorrectedDateRangePipe(this),
-        guide: false,
-    };
 
     @Input()
     @tuiDefaultProp()
@@ -185,8 +180,17 @@ export class TuiInputDateRangeComponent
             : '';
     }
 
-    get computedMask(): TuiTextMaskOptions {
-        return this.activePeriod ? EMPTY_MASK : this.textMaskOptions;
+    get computedMask(): MaskitoOptions {
+        return this.activePeriod
+            ? MASKITO_DEFAULT_OPTIONS
+            : this.calculateMask(
+                  this.dateFormat,
+                  this.dateSeparator,
+                  this.min,
+                  this.max,
+                  this.minLength || {},
+                  this.maxLength || {},
+              );
     }
 
     get activePeriod(): TuiDayRangePeriod | null {
@@ -316,12 +320,7 @@ export class TuiInputDateRangeComponent
             return;
         }
 
-        const parsedValue = TuiDayRange.normalizeParse(value, this.dateFormat);
-
-        this.value =
-            !this.minLength && !this.maxLength
-                ? parsedValue
-                : this.clampValue(parsedValue);
+        this.value = TuiDayRange.normalizeParse(value, this.dateFormat);
     }
 
     onRangeChange(range: TuiDayRange | null): void {
@@ -379,6 +378,25 @@ export class TuiInputDateRangeComponent
         return tuiNullableSame(oldValue, newValue, (a, b) => a.daySame(b));
     }
 
+    @tuiPure
+    private calculateMask(
+        dateFormat: TuiDateMode,
+        separator: string,
+        min: TuiDay,
+        max: TuiDay,
+        minLength: TuiDayLike,
+        maxLength: TuiDayLike,
+    ): MaskitoOptions {
+        return maskitoDateRangeOptionsGenerator({
+            separator,
+            mode: TUI_DATE_MODE_MASKITO_ADAPTER[dateFormat],
+            min: min.toLocalNativeDate(),
+            max: max.toLocalNativeDate(),
+            minLength,
+            maxLength,
+        });
+    }
+
     private get itemSelected(): boolean {
         return this.items.findIndex(item => String(item) === this.nativeValue) !== -1;
     }
@@ -391,24 +409,6 @@ export class TuiInputDateRangeComponent
         if (this.nativeFocusableElement) {
             this.nativeFocusableElement.focus({preventScroll});
         }
-    }
-
-    private clampValue(value: TuiDayRange): TuiDayRange {
-        const clampedBottom =
-            this.minLength && value.from.append(this.minLength).dayAfter(value.to)
-                ? new TuiDayRange(
-                      value.from,
-                      value.from.append(this.minLength).append({day: -1}),
-                  )
-                : value;
-
-        const availableMax = this.maxLength
-            ? clampedBottom.from.append(this.maxLength).append({day: -1})
-            : this.max;
-
-        return clampedBottom.to.dayAfter(availableMax)
-            ? new TuiDayRange(clampedBottom.from, availableMax)
-            : clampedBottom;
     }
 
     private getDateRangeFiller(dateFiller: string): string {

--- a/projects/kit/components/input-date-range/input-date-range.module.ts
+++ b/projects/kit/components/input-date-range/input-date-range.module.ts
@@ -1,5 +1,6 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {MaskitoModule} from '@maskito/angular';
 import {TuiActiveZoneModule, TuiLetModule} from '@taiga-ui/cdk';
 import {
     TuiHostedDropdownModule,
@@ -10,7 +11,7 @@ import {
     TuiWrapperModule,
 } from '@taiga-ui/core';
 import {TuiCalendarRangeModule} from '@taiga-ui/kit/components/calendar-range';
-import {TextMaskModule, TuiValueAccessorModule} from '@taiga-ui/kit/directives';
+import {TuiValueAccessorModule} from '@taiga-ui/kit/directives';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 
 import {TuiInputDateRangeComponent} from './input-date-range.component';
@@ -19,7 +20,7 @@ import {TuiInputDateRangeDirective} from './input-date-range.directive';
 @NgModule({
     imports: [
         CommonModule,
-        TextMaskModule,
+        MaskitoModule,
         TuiActiveZoneModule,
         TuiLetModule,
         PolymorpheusModule,

--- a/projects/kit/components/input-date-range/input-date-range.template.html
+++ b/projects/kit/components/input-date-range/input-date-range.template.html
@@ -20,7 +20,7 @@
         [nativeId]="nativeId"
         [readOnly]="readOnly"
         [disabled]="computedDisabled"
-        [textMask]="computedMask"
+        [maskito]="computedMask"
         [value]="computedValue"
         (valueChange)="onValueChange($event)"
     >

--- a/projects/kit/components/input-date-range/test/input-date-range.component.spec.ts
+++ b/projects/kit/components/input-date-range/test/input-date-range.component.spec.ts
@@ -141,12 +141,6 @@ describe(`InputDateRangeComponent`, () => {
                 fixture.detectChanges();
             });
 
-            it(`If you enter an invalid date, the value is adjusted`, () => {
-                inputPO.sendText(`32.12.2012`);
-
-                expect(inputPO.value).toBe(`31.12.2012`);
-            });
-
             it(`When entering the first date, the control value is null`, () => {
                 inputPO.sendText(`31.12.2012`);
 
@@ -199,12 +193,6 @@ describe(`InputDateRangeComponent`, () => {
             expect(inputPO.value).toBe(`12/01/2021 – 02/14/2022`);
         });
 
-        it(`corrects date of month > 12 or day > 31`, () => {
-            inputPO.sendTextAndBlur(`9999200099992010`);
-
-            expect(inputPO.value).toBe(`12/31/2000 – 12/31/2010`);
-        });
-
         it(`correctly sets stringify selected range via calendar`, async () => {
             inputPO.sendTextAndBlur(`12/01/2021-02/14/2022`);
 
@@ -241,12 +229,6 @@ describe(`InputDateRangeComponent`, () => {
         it(`accepts dd.mm.yyyy format`, () => {
             inputPO.sendTextAndBlur(`2021120120220214`);
             expect(inputPO.value).toBe(`2021-12-01 – 2022-02-14`);
-        });
-
-        it(`corrects date of month > 12 or day > 31`, () => {
-            inputPO.sendTextAndBlur(`2000999920109999`);
-
-            expect(inputPO.value).toBe(`2000-12-31 – 2010-12-31`);
         });
 
         it(`correctly sets stringify selected range via calendar`, () => {

--- a/projects/kit/utils/mask/create-auto-corrected-date-range-pipe.ts
+++ b/projects/kit/utils/mask/create-auto-corrected-date-range-pipe.ts
@@ -49,6 +49,8 @@ function processRawValue(value: string, config: TuiAutoCorrectedDatePipeConfigs)
 }
 
 /**
+ * @deprecated Use {@link https://tinkoff.github.io/maskito/kit/date-range DateRange} from {@link https://github.com/Tinkoff/maskito Maskito} instead
+ * TODO: delete in v4.0
  * Normalizes date in formatted string
  *
  * Normalizes when:

--- a/projects/kit/utils/mask/create-date-range-mask.ts
+++ b/projects/kit/utils/mask/create-date-range-mask.ts
@@ -3,6 +3,10 @@ import {TuiTextMaskList} from '@taiga-ui/core';
 
 import {tuiCreateDateMask} from './create-date-mask';
 
+/**
+ * @deprecated Use {@link https://tinkoff.github.io/maskito/kit/date-range DateRange} from {@link https://github.com/Tinkoff/maskito Maskito} instead
+ * TODO: delete in v4.0
+ */
 export function tuiCreateDateRangeMask(
     dateMode: TuiDateMode,
     dateSeparator: string,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the new behavior?
Partially solves https://github.com/Tinkoff/taiga-ui/issues/120
