### PR TITLE
fix: hosts of portals can throw `ExpressionChangedAfterItHasBeenCheckedError`

### DIFF
--- a/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.component.ts
+++ b/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.component.ts
@@ -9,9 +9,10 @@ import {
 import {TUI_WINDOW_HEIGHT, TuiDestroyService} from '@taiga-ui/cdk';
 import {TUI_ANIMATION_OPTIONS, tuiFadeIn, tuiSlideInTop} from '@taiga-ui/core';
 import {Observable} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+
 import {TuiSheet} from '../../sheet';
 import {TuiSheetService} from '../../sheet.service';
-import {takeUntil} from 'rxjs/operators';
 
 @Component({
     selector: 'tui-sheets-host',
@@ -21,7 +22,7 @@ import {takeUntil} from 'rxjs/operators';
     animations: [tuiSlideInTop, tuiFadeIn],
 })
 export class TuiSheetsHostComponent {
-    public sheets: readonly TuiSheet<any>[] = [];
+    sheets: ReadonlyArray<TuiSheet<any>> = [];
 
     constructor(
         @Inject(TUI_ANIMATION_OPTIONS) readonly options: AnimationOptions,

--- a/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.component.ts
+++ b/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.component.ts
@@ -1,11 +1,17 @@
 import {AnimationOptions} from '@angular/animations';
-import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
-import {TUI_WINDOW_HEIGHT} from '@taiga-ui/cdk';
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    Inject,
+    Self,
+} from '@angular/core';
+import {TUI_WINDOW_HEIGHT, TuiDestroyService} from '@taiga-ui/cdk';
 import {TUI_ANIMATION_OPTIONS, tuiFadeIn, tuiSlideInTop} from '@taiga-ui/core';
 import {Observable} from 'rxjs';
-
 import {TuiSheet} from '../../sheet';
 import {TuiSheetService} from '../../sheet.service';
+import {takeUntil} from 'rxjs/operators';
 
 @Component({
     selector: 'tui-sheets-host',
@@ -15,11 +21,22 @@ import {TuiSheetService} from '../../sheet.service';
     animations: [tuiSlideInTop, tuiFadeIn],
 })
 export class TuiSheetsHostComponent {
+    public sheets: readonly TuiSheet<any>[] = [];
+
     constructor(
         @Inject(TUI_ANIMATION_OPTIONS) readonly options: AnimationOptions,
-        @Inject(TuiSheetService) readonly service: TuiSheetService,
+        @Inject(TuiSheetService) service: TuiSheetService,
         @Inject(TUI_WINDOW_HEIGHT) readonly height$: Observable<number>,
-    ) {}
+        @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
+    ) {
+        // Due to this view being parallel to app content, `markForCheck` from `async` pipe
+        // can happen after view was checked, so calling `detectChanges` instead
+        service.sheets$.pipe(takeUntil(destroy$)).subscribe(sheets => {
+            this.sheets = sheets;
+            cdr.detectChanges();
+        });
+    }
 
     close({closeable, $implicit}: TuiSheet<unknown>): void {
         if (closeable) {

--- a/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.component.ts
+++ b/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.component.ts
@@ -19,6 +19,7 @@ import {TuiSheetService} from '../../sheet.service';
     templateUrl: './sheets-host.template.html',
     styleUrls: ['./sheets-host.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [TuiDestroyService],
     animations: [tuiSlideInTop, tuiFadeIn],
 })
 export class TuiSheetsHostComponent {

--- a/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.component.ts
+++ b/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.component.ts
@@ -4,6 +4,7 @@ import {
     ChangeDetectorRef,
     Component,
     Inject,
+    OnInit,
     Self,
 } from '@angular/core';
 import {TUI_WINDOW_HEIGHT, TuiDestroyService} from '@taiga-ui/cdk';
@@ -22,21 +23,23 @@ import {TuiSheetService} from '../../sheet.service';
     providers: [TuiDestroyService],
     animations: [tuiSlideInTop, tuiFadeIn],
 })
-export class TuiSheetsHostComponent {
+export class TuiSheetsHostComponent implements OnInit {
     sheets: ReadonlyArray<TuiSheet<any>> = [];
 
     constructor(
         @Inject(TUI_ANIMATION_OPTIONS) readonly options: AnimationOptions,
-        @Inject(TuiSheetService) service: TuiSheetService,
+        @Inject(TuiSheetService) private readonly service: TuiSheetService,
         @Inject(TUI_WINDOW_HEIGHT) readonly height$: Observable<number>,
-        @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
-        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
-    ) {
+        @Self() @Inject(TuiDestroyService) private readonly destroy$: Observable<void>,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
+    ) {}
+
+    ngOnInit(): void {
         // Due to this view being parallel to app content, `markForCheck` from `async` pipe
         // can happen after view was checked, so calling `detectChanges` instead
-        service.sheets$.pipe(takeUntil(destroy$)).subscribe(sheets => {
+        this.service.sheets$.pipe(takeUntil(this.destroy$)).subscribe(sheets => {
             this.sheets = sheets;
-            cdr.detectChanges();
+            this.cdr.detectChanges();
         });
     }
 

--- a/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.template.html
+++ b/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.template.html
@@ -1,27 +1,25 @@
-<ng-container *ngIf="sheets.length > 0">
-    <div
-        *ngFor="let item of sheets"
-        #wrapper="tuiSheetWrapper"
-        class="t-wrapper"
-        [@tuiSlideInTop]="options"
-        [@tuiFadeIn]="options"
-        [tuiSheetWrapper]="item.offset"
-        [class.t-wrapper_closeable]="item.closeable"
-        [class.t-wrapper_overlay]="item.overlay || (wrapper.overlay$ | async)"
-        [class.t-wrapper_visible]="wrapper.visible$ | async"
-        [style.height.px]="wrapper.height$ | async"
-        (click.self)="close(item)"
-    >
-        <tui-sheet
-            tuiScrollRef
-            tuiOverscroll="all"
-            [style.height.px]="((height$ | async) || 0) - item.offset"
-            [item]="item"
-            (close)="close(item)"
-        ></tui-sheet>
-    </div>
-    <div
-        class="t-overlay"
-        (click)="close(sheets[0])"
-    ></div>
-</ng-container>
+<div
+    *ngFor="let item of sheets"
+    #wrapper="tuiSheetWrapper"
+    class="t-wrapper"
+    [@tuiSlideInTop]="options"
+    [@tuiFadeIn]="options"
+    [tuiSheetWrapper]="item.offset"
+    [class.t-wrapper_closeable]="item.closeable"
+    [class.t-wrapper_overlay]="item.overlay || (wrapper.overlay$ | async)"
+    [class.t-wrapper_visible]="wrapper.visible$ | async"
+    [style.height.px]="wrapper.height$ | async"
+    (click.self)="close(item)"
+>
+    <tui-sheet
+        tuiScrollRef
+        tuiOverscroll="all"
+        [style.height.px]="((height$ | async) || 0) - item.offset"
+        [item]="item"
+        (close)="close(item)"
+    ></tui-sheet>
+</div>
+<div
+    class="t-overlay"
+    (click)="close(sheets[0])"
+></div>

--- a/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.template.html
+++ b/projects/addon-mobile/components/sheet/components/sheets-host/sheets-host.template.html
@@ -1,6 +1,6 @@
-<ng-container *ngIf="service.sheets$ | async as items">
+<ng-container *ngIf="sheets.length > 0">
     <div
-        *ngFor="let item of items"
+        *ngFor="let item of sheets"
         #wrapper="tuiSheetWrapper"
         class="t-wrapper"
         [@tuiSlideInTop]="options"
@@ -22,6 +22,6 @@
     </div>
     <div
         class="t-overlay"
-        (click)="close(items[0])"
+        (click)="close(sheets[0])"
     ></div>
 </ng-container>

--- a/projects/cdk/components/alert-host/alert-host.component.ts
+++ b/projects/cdk/components/alert-host/alert-host.component.ts
@@ -9,7 +9,7 @@ import {
     ViewEncapsulation,
 } from '@angular/core';
 import {TUI_PARENT_ANIMATION} from '@taiga-ui/cdk/constants';
-import {TuiDestroyService} from '@taiga-ui/cdk/services/destroy.service';
+import {TuiDestroyService} from '@taiga-ui/cdk/services';
 import {TUI_ALERTS} from '@taiga-ui/cdk/tokens';
 import {TuiDialog, TuiMapper} from '@taiga-ui/cdk/types';
 import {POLYMORPHEUS_CONTEXT} from '@tinkoff/ng-polymorpheus';

--- a/projects/cdk/components/alert-host/alert-host.component.ts
+++ b/projects/cdk/components/alert-host/alert-host.component.ts
@@ -27,7 +27,7 @@ import {takeUntil} from 'rxjs/operators';
     encapsulation: ViewEncapsulation.None,
 })
 export class TuiAlertHostComponent<T extends TuiDialog<unknown, unknown>> {
-    public alerts: readonly (readonly T[])[] = [];
+    alerts: ReadonlyArray<readonly T[]> = [];
 
     constructor(
         @Inject(TUI_ALERTS) allAlerts: Array<Observable<readonly T[]>>,

--- a/projects/cdk/components/alert-host/alert-host.component.ts
+++ b/projects/cdk/components/alert-host/alert-host.component.ts
@@ -23,6 +23,7 @@ import {takeUntil} from 'rxjs/operators';
     // So that we do not force OnPush on custom alerts
     // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
     changeDetection: ChangeDetectionStrategy.Default,
+    providers: [TuiDestroyService],
     animations: [TUI_PARENT_ANIMATION],
     encapsulation: ViewEncapsulation.None,
 })

--- a/projects/cdk/components/alert-host/alert-host.component.ts
+++ b/projects/cdk/components/alert-host/alert-host.component.ts
@@ -5,6 +5,7 @@ import {
     Inject,
     INJECTOR,
     Injector,
+    OnInit,
     Self,
     ViewEncapsulation,
 } from '@angular/core';
@@ -27,22 +28,26 @@ import {takeUntil} from 'rxjs/operators';
     animations: [TUI_PARENT_ANIMATION],
     encapsulation: ViewEncapsulation.None,
 })
-export class TuiAlertHostComponent<T extends TuiDialog<unknown, unknown>> {
+export class TuiAlertHostComponent<T extends TuiDialog<unknown, unknown>>
+    implements OnInit
+{
     alerts: ReadonlyArray<readonly T[]> = [];
 
     constructor(
-        @Inject(TUI_ALERTS) allAlerts: Array<Observable<readonly T[]>>,
+        @Inject(TUI_ALERTS) private readonly allAlerts: Array<Observable<readonly T[]>>,
         @Inject(INJECTOR) private readonly injector: Injector,
-        @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
-        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
-    ) {
+        @Self() @Inject(TuiDestroyService) private readonly destroy$: Observable<void>,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
+    ) {}
+
+    ngOnInit(): void {
         // Due to this view being parallel to app content, `markForCheck` from `async` pipe
         // can happen after view was checked, so calling `detectChanges` instead
-        combineLatest(allAlerts)
-            .pipe(takeUntil(destroy$))
+        combineLatest(this.allAlerts)
+            .pipe(takeUntil(this.destroy$))
             .subscribe(alerts => {
                 this.alerts = alerts;
-                cdr.detectChanges();
+                this.cdr.detectChanges();
             });
     }
 

--- a/projects/cdk/components/alert-host/alert-host.component.ts
+++ b/projects/cdk/components/alert-host/alert-host.component.ts
@@ -1,16 +1,20 @@
 import {
     ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     Inject,
     INJECTOR,
     Injector,
+    Self,
     ViewEncapsulation,
 } from '@angular/core';
 import {TUI_PARENT_ANIMATION} from '@taiga-ui/cdk/constants';
+import {TuiDestroyService} from '@taiga-ui/cdk/services/destroy.service';
 import {TUI_ALERTS} from '@taiga-ui/cdk/tokens';
 import {TuiDialog, TuiMapper} from '@taiga-ui/cdk/types';
 import {POLYMORPHEUS_CONTEXT} from '@tinkoff/ng-polymorpheus';
-import {Observable} from 'rxjs';
+import {combineLatest, Observable} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 
 @Component({
     selector: 'tui-alert-host',
@@ -23,10 +27,23 @@ import {Observable} from 'rxjs';
     encapsulation: ViewEncapsulation.None,
 })
 export class TuiAlertHostComponent<T extends TuiDialog<unknown, unknown>> {
+    public alerts: readonly (readonly T[])[] = [];
+
     constructor(
-        @Inject(TUI_ALERTS) readonly alerts: Array<Observable<readonly T[]>>,
+        @Inject(TUI_ALERTS) allAlerts: Array<Observable<readonly T[]>>,
         @Inject(INJECTOR) private readonly injector: Injector,
-    ) {}
+        @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
+        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
+    ) {
+        // Due to this view being parallel to app content, `markForCheck` from `async` pipe
+        // can happen after view was checked, so calling `detectChanges` instead
+        combineLatest(allAlerts)
+            .pipe(takeUntil(destroy$))
+            .subscribe(alerts => {
+                this.alerts = alerts;
+                cdr.detectChanges();
+            });
+    }
 
     readonly mapper: TuiMapper<unknown, Injector> = useValue =>
         Injector.create({

--- a/projects/cdk/components/alert-host/alert-host.template.html
+++ b/projects/cdk/components/alert-host/alert-host.template.html
@@ -1,10 +1,10 @@
 <div
-    *ngFor="let alert$ of alerts"
+    *ngFor="let alert of alerts"
     class="t-wrapper"
     @tuiParentAnimation
 >
     <ng-container
-        *ngFor="let item of alert$ | async"
+        *ngFor="let item of alert"
         [ngComponentOutlet]="item.component.component"
         [ngComponentOutletInjector]="item | tuiMapper : mapper"
     ></ng-container>

--- a/projects/cdk/components/dialog-host/dialog-host.component.ts
+++ b/projects/cdk/components/dialog-host/dialog-host.component.ts
@@ -15,15 +15,13 @@ import {TuiDialog} from '@taiga-ui/cdk/types';
 import {combineLatest, Observable, of} from 'rxjs';
 import {map, takeUntil} from 'rxjs/operators';
 
-const defaultClosesOnBack = false;
-
 /**
  * Is closing dialog on browser backward navigation enabled
  */
 export const TUI_DIALOG_CLOSES_ON_BACK = new InjectionToken<Observable<boolean>>(
     '[TUI_DIALOG_CLOSES_ON_BACK]',
     {
-        factory: () => of(defaultClosesOnBack),
+        factory: () => of(false),
     },
 );
 
@@ -43,12 +41,11 @@ const isFakeHistoryState = (
     animations: [TUI_PARENT_ANIMATION],
 })
 export class TuiDialogHostComponent<T extends TuiDialog<unknown, unknown>> {
-    public dialogs: readonly T[] = [];
-    public isDialogClosesOnBack = defaultClosesOnBack;
+    dialogs: readonly T[] = [];
 
     constructor(
         @Inject(TUI_DIALOG_CLOSES_ON_BACK)
-        isDialogClosesOnBack$: Observable<boolean>,
+        readonly isDialogClosesOnBack$: Observable<boolean>,
         @Inject(TUI_DIALOGS)
         dialogsByType: Array<Observable<readonly T[]>>,
         @Inject(HISTORY) private readonly historyRef: History,
@@ -69,13 +66,6 @@ export class TuiDialogHostComponent<T extends TuiDialog<unknown, unknown>> {
             )
             .subscribe(dialogs => {
                 this.dialogs = dialogs;
-                cdr.detectChanges();
-            });
-
-        isDialogClosesOnBack$
-            .pipe(takeUntil(destroy$))
-            .subscribe(isDialogClosesOnBack => {
-                this.isDialogClosesOnBack = isDialogClosesOnBack;
                 cdr.detectChanges();
             });
     }

--- a/projects/cdk/components/dialog-host/dialog-host.component.ts
+++ b/projects/cdk/components/dialog-host/dialog-host.component.ts
@@ -38,6 +38,7 @@ const isFakeHistoryState = (
     // So that we do not force OnPush on custom dialogs
     // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
     changeDetection: ChangeDetectionStrategy.Default,
+    providers: [TuiDestroyService],
     animations: [TUI_PARENT_ANIMATION],
 })
 export class TuiDialogHostComponent<T extends TuiDialog<unknown, unknown>> {

--- a/projects/cdk/components/dialog-host/dialog-host.component.ts
+++ b/projects/cdk/components/dialog-host/dialog-host.component.ts
@@ -9,7 +9,7 @@ import {
 import {Title} from '@angular/platform-browser';
 import {HISTORY} from '@ng-web-apis/common';
 import {TUI_PARENT_ANIMATION} from '@taiga-ui/cdk/constants';
-import {TuiDestroyService} from '@taiga-ui/cdk/services/destroy.service';
+import {TuiDestroyService} from '@taiga-ui/cdk/services';
 import {TUI_DIALOGS} from '@taiga-ui/cdk/tokens';
 import {TuiDialog} from '@taiga-ui/cdk/types';
 import {combineLatest, Observable, of} from 'rxjs';

--- a/projects/cdk/components/dialog-host/dialog-host.component.ts
+++ b/projects/cdk/components/dialog-host/dialog-host.component.ts
@@ -60,7 +60,11 @@ export class TuiDialogHostComponent<T extends TuiDialog<unknown, unknown>> {
         // can happen after view was checked, so calling `detectChanges` instead
         combineLatest(dialogsByType)
             .pipe(
-                map(arr => arr.flat().sort((a, b) => a.createdAt - b.createdAt)),
+                map(arr =>
+                    new Array<T>()
+                        .concat(...arr)
+                        .sort((a, b) => a.createdAt - b.createdAt),
+                ),
                 takeUntil(destroy$),
             )
             .subscribe(dialogs => {

--- a/projects/cdk/components/dialog-host/dialog-host.template.html
+++ b/projects/cdk/components/dialog-host/dialog-host.template.html
@@ -1,22 +1,19 @@
-<ng-container *ngIf="dialogs$ | async as dialogs">
-    <section
-        *ngFor="let item of dialogs"
-        tuiFocusTrap
-        tuiScrollRef
-        tuiOverscroll="all"
-        role="dialog"
-        aria-modal="true"
-        class="t-dialog"
-        @tuiParentAnimation
-        [attr.aria-labelledby]="item.id"
-    >
-        <ng-container *polymorpheusOutlet="item.component; context: item"></ng-container>
-    </section>
-    <div
-        *tuiLet="isDialogClosesOnBack$ | async as isDialogClosesOnBack"
-        class="t-overlay"
-        [class.t-overlay_visible]="dialogs.length"
-        (window:popstate)="closeLast(dialogs, !!isDialogClosesOnBack)"
-        (transitionend)="onDialog($event, !!dialogs.length, !!isDialogClosesOnBack)"
-    ></div>
-</ng-container>
+<section
+    *ngFor="let item of dialogs"
+    tuiFocusTrap
+    tuiScrollRef
+    tuiOverscroll="all"
+    role="dialog"
+    aria-modal="true"
+    class="t-dialog"
+    @tuiParentAnimation
+    [attr.aria-labelledby]="item.id"
+>
+    <ng-container *polymorpheusOutlet="item.component; context: item"></ng-container>
+</section>
+<div
+    class="t-overlay"
+    [class.t-overlay_visible]="dialogs.length"
+    (window:popstate)="closeLast(dialogs, !!isDialogClosesOnBack)"
+    (transitionend)="onDialog($event, !!dialogs.length, !!isDialogClosesOnBack)"
+></div>

--- a/projects/cdk/components/dialog-host/dialog-host.template.html
+++ b/projects/cdk/components/dialog-host/dialog-host.template.html
@@ -12,6 +12,7 @@
     <ng-container *polymorpheusOutlet="item.component; context: item"></ng-container>
 </section>
 <div
+    *tuiLet="isDialogClosesOnBack$ | async as isDialogClosesOnBack"
     class="t-overlay"
     [class.t-overlay_visible]="dialogs.length"
     (window:popstate)="closeLast(dialogs, !!isDialogClosesOnBack)"

--- a/projects/core/components/hints-host/hints-host.component.ts
+++ b/projects/core/components/hints-host/hints-host.component.ts
@@ -24,7 +24,7 @@ import {takeUntil} from 'rxjs/operators';
     },
 })
 export class TuiHintsHostComponent {
-    public hints: readonly TuiPortalItem[] = [];
+    hints: readonly TuiPortalItem[] = [];
 
     constructor(
         @Inject(TuiHintService) hints$: Observable<readonly TuiPortalItem[]>,

--- a/projects/core/components/hints-host/hints-host.component.ts
+++ b/projects/core/components/hints-host/hints-host.component.ts
@@ -18,6 +18,7 @@ import {takeUntil} from 'rxjs/operators';
     // So that we do not force OnPush on custom hints
     // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
     changeDetection: ChangeDetectionStrategy.Default,
+    providers: [TuiDestroyService],
     animations: [TUI_PARENT_ANIMATION],
     host: {
         'aria-live': 'polite',

--- a/projects/core/components/hints-host/hints-host.component.ts
+++ b/projects/core/components/hints-host/hints-host.component.ts
@@ -3,6 +3,7 @@ import {
     ChangeDetectorRef,
     Component,
     Inject,
+    OnInit,
     Self,
 } from '@angular/core';
 import {TUI_PARENT_ANIMATION, TuiDestroyService} from '@taiga-ui/cdk';
@@ -24,19 +25,22 @@ import {takeUntil} from 'rxjs/operators';
         'aria-live': 'polite',
     },
 })
-export class TuiHintsHostComponent {
+export class TuiHintsHostComponent implements OnInit {
     hints: readonly TuiPortalItem[] = [];
 
     constructor(
-        @Inject(TuiHintService) hints$: Observable<readonly TuiPortalItem[]>,
-        @Self() @Inject(TuiDestroyService) destroy$: Observable<void>,
-        @Inject(ChangeDetectorRef) cdr: ChangeDetectorRef,
-    ) {
+        @Inject(TuiHintService)
+        private readonly hints$: Observable<readonly TuiPortalItem[]>,
+        @Self() @Inject(TuiDestroyService) private readonly destroy$: Observable<void>,
+        @Inject(ChangeDetectorRef) private readonly cdr: ChangeDetectorRef,
+    ) {}
+
+    ngOnInit(): void {
         // Due to this view being parallel to app content, `markForCheck` from `async` pipe
         // can happen after view was checked, so calling `detectChanges` instead
-        hints$.pipe(takeUntil(destroy$)).subscribe(hints => {
+        this.hints$.pipe(takeUntil(this.destroy$)).subscribe(hints => {
             this.hints = hints;
-            cdr.detectChanges();
+            this.cdr.detectChanges();
         });
     }
 }

--- a/projects/core/components/hints-host/hints-host.template.html
+++ b/projects/core/components/hints-host/hints-host.template.html
@@ -1,5 +1,5 @@
 <div
-    *ngFor="let hint of hints$ | async"
+    *ngFor="let hint of hints"
     role="tooltip"
     @tuiParentAnimation
     [tuiActiveZoneParent]="hint.activeZone || null"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4473

## What is the new behavior?
