### PR TITLE
fix(core): `PrimitiveTextfield` fix input disabled state [ng 15+]

### DIFF
--- a/projects/core/components/primitive-textfield/primitive-textfield.template.html
+++ b/projects/core/components/primitive-textfield/primitive-textfield.template.html
@@ -22,7 +22,7 @@
         tuiMaskAccessor
         automation-id="tui-primitive-textfield__native-input"
         class="t-input"
-        [attr.disabled]="computedDisabled || null"
+        [disabled]="computedDisabled"
         [attr.name]="name"
         [attr.aria-invalid]="computedInvalid"
         [id]="id"

--- a/projects/kit/components/input-slider/input-slider.template.html
+++ b/projects/kit/components/input-slider/input-slider.template.html
@@ -36,7 +36,7 @@
     [max]="computedSteps"
     [segments]="segments"
     [keySteps]="computeKeySteps(keySteps, min, max)"
-    [attr.disabled]="readOnly || computedDisabled || null"
+    [disabled]="readOnly || computedDisabled"
     [ngModel]="value"
     (ngModelChange)="onSliderChange($event)"
     (click)="focusTextInput()"

--- a/projects/kit/components/range/range.template.html
+++ b/projects/kit/components/range/range.template.html
@@ -16,7 +16,7 @@
         [size]="size"
         [keySteps]="computedKeySteps"
         [tuiFocusable]="focusable"
-        [attr.disabled]="computedDisabled || null"
+        [disabled]="computedDisabled"
     />
     <input
         tuiSlider
@@ -31,6 +31,6 @@
         [size]="size"
         [keySteps]="computedKeySteps"
         [tuiFocusable]="focusable"
-        [attr.disabled]="computedDisabled || null"
+        [disabled]="computedDisabled"
     />
 </div>

--- a/projects/kit/components/slider/helpers/slider-key-steps.directive.ts
+++ b/projects/kit/components/slider/helpers/slider-key-steps.directive.ts
@@ -33,6 +33,7 @@ import {TuiSliderComponent} from '../slider.component';
         '[attr.aria-valuenow]': 'safeCurrentValue',
         '[attr.aria-valuemin]': 'min',
         '[attr.aria-valuemax]': 'max',
+        '[disabled]': 'computedDisabled',
     },
 })
 export class TuiSliderKeyStepsDirective

--- a/projects/kit/directives/mask/legacy-mask.ts
+++ b/projects/kit/directives/mask/legacy-mask.ts
@@ -118,11 +118,7 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
     }
 
     setDisabledState(isDisabled: boolean): void {
-        this._renderer.setProperty(
-            this._elementRef.nativeElement,
-            'disabled',
-            isDisabled,
-        );
+        this._renderer.setProperty(this.inputElement, 'disabled', isDisabled);
     }
 
     _handleInput(value: any) {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4536

## What is the new behavior?

there was a [breaking change](https://angular.io/guide/update-to-version-15#setdisabledstate-is-always-called-when-a-controlvalueaccessor-is-attached) in angular 15 

in ng15 we can't use `ngModel` and `[arrt.disabled]` together https://github.com/angular/angular/issues/48737  
