### PR TITLE
deprecate(addon-commerce): use new `TUI_CARD_HOLDER_MASK` instead of deprecated `cardHolderMask`

### DIFF
--- a/projects/addon-commerce/constants/card-holder-mask.ts
+++ b/projects/addon-commerce/constants/card-holder-mask.ts
@@ -1,3 +1,4 @@
+import {MaskitoOptions} from '@maskito/core';
 import {tuiCreateCorrectionMask, TuiTextMaskListHandler} from '@taiga-ui/core';
 
 const ALLOWED_REGEXP = /[A-Z]| /;
@@ -30,14 +31,42 @@ const MAP: Record<string, string> = {
     Я: `Z`,
 };
 
-function toEnglishUppercase(char: string): string | null {
+// TODO: delete in v4.0
+function toEnglishUppercaseLegacy(char: string): string | null {
     const uppercase = char.toUpperCase();
     const result = ALLOWED_REGEXP.test(uppercase) ? uppercase : MAP[uppercase];
 
     return result || null;
 }
 
+function toEnglishUppercase(value: string): string {
+    return value
+        .toUpperCase()
+        .split(``)
+        .map(char => MAP[char] || char)
+        .join(``);
+}
+
+export const TUI_CARD_HOLDER_MASK: MaskitoOptions = {
+    mask: /^[a-z\s]+$/i,
+    preprocessor: ({elementState, data}) => {
+        const {value, selection} = elementState;
+
+        return {
+            elementState: {
+                selection,
+                value: toEnglishUppercase(value),
+            },
+            data: toEnglishUppercase(data),
+        };
+    },
+};
+
+/**
+ * @deprecated Use {@link TUI_CARD_HOLDER_MASK} with {@link https://github.com/Tinkoff/maskito Maskito}
+ * TODO: delete in v4.0
+ */
 export const cardHolderMask: TuiTextMaskListHandler = tuiCreateCorrectionMask(
     ALLOWED_REGEXP,
-    toEnglishUppercase,
+    toEnglishUppercaseLegacy,
 );

--- a/projects/addon-commerce/constants/tests/card-holder-mask.spec.ts
+++ b/projects/addon-commerce/constants/tests/card-holder-mask.spec.ts
@@ -1,3 +1,4 @@
+// cspell:disable
 import {TUI_CARD_HOLDER_MASK} from '@taiga-ui/addon-commerce';
 
 describe(`TUI_CARD_HOLDER_MASK`, () => {

--- a/projects/addon-commerce/constants/tests/card-holder-mask.spec.ts
+++ b/projects/addon-commerce/constants/tests/card-holder-mask.spec.ts
@@ -1,0 +1,42 @@
+import {TUI_CARD_HOLDER_MASK} from '@taiga-ui/addon-commerce';
+
+describe(`TUI_CARD_HOLDER_MASK`, () => {
+    describe(`mask property`, () => {
+        const re = TUI_CARD_HOLDER_MASK.mask as RegExp;
+
+        it(`accepts uppercase latin letters and space`, () => {
+            expect(`NIKITA BARSUKOV`.match(re)).toBeTruthy();
+        });
+
+        it(`rejects cyrillics`, () => {
+            expect(`NIKITA БАРСУКОВ`.match(re)).toBeFalsy();
+        });
+
+        it(`rejects digits`, () => {
+            expect(`NIK1TA 6ARSUKOV`.match(re)).toBeFalsy();
+        });
+    });
+
+    describe(`preprocessor property`, () => {
+        const preprocessor = (value: string): string => {
+            return (
+                TUI_CARD_HOLDER_MASK.preprocessor?.(
+                    {elementState: {value: ``, selection: [0, 0]}, data: value},
+                    `insert`,
+                ).data || ``
+            );
+        };
+
+        it(`keeps latin letters untouched`, () => {
+            expect(preprocessor(`NIKITA BARSUKOV`)).toBe(`NIKITA BARSUKOV`);
+        });
+
+        it(`converts cyrillics to latin`, () => {
+            expect(preprocessor(`ТШЛШЕФ BARЫГЛЩМ`)).toBe(`NIKITA BARSUKOV`);
+        });
+
+        it(`converts lowercase to uppercase`, () => {
+            expect(preprocessor(`тшлшеф bARsukov`)).toBe(`NIKITA BARSUKOV`);
+        });
+    });
+});

--- a/projects/core/utils/mask/create-correction-mask.ts
+++ b/projects/core/utils/mask/create-correction-mask.ts
@@ -8,6 +8,10 @@ import {
 
 const ASSERTION = `Correction function must return single char or null`;
 
+/**
+ * TODO: delete in v4.0
+ * @deprecated Use {@link https://tinkoff.github.io/maskito/core-concepts/processors processors} from {@link https://github.com/Tinkoff/maskito Maskito}
+ */
 export function tuiCreateCorrectionMask(
     allowed: RegExp,
     correctionHandler: TuiTextMaskCorrectionHandler,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

Partially solves https://github.com/Tinkoff/taiga-ui/issues/120
