### PR TITLE
chore(demo-integrations): fix cypress tests for `Slider`

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/slider/slider.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/slider/slider.cy.ts
@@ -106,7 +106,7 @@ describe(`Slider`, () => {
 
                 checkSlider(`@slider`, {
                     expectedValue: `0.75`,
-                    expectedFillPercentage: `16.6667%`,
+                    expectedFillPercentage: `17%`,
                 });
 
                 cy.get(`@example`).matchImageSnapshot(
@@ -134,7 +134,7 @@ describe(`Slider`, () => {
 
                 checkSlider(`@slider`, {
                     expectedValue: `1.5`,
-                    expectedFillPercentage: `66.6667%`,
+                    expectedFillPercentage: `67%`,
                 });
 
                 cy.get(`@example`).matchImageSnapshot(
@@ -214,9 +214,15 @@ function checkSlider(
 ): void {
     cy.get(sliderSelector)
         .should(`have.value`, expectedValue)
-        .filter(
-            (_, $el) =>
-                getComputedStyle($el).getPropertyValue(`--tui-slider-fill-percentage`) ===
-                expectedFillPercentage,
-        );
+        .filter((_, $el) => {
+            const actualFillPercentage = Math.round(
+                parseFloat(
+                    getComputedStyle($el).getPropertyValue(
+                        `--tui-slider-fill-percentage`,
+                    ),
+                ),
+            );
+
+            return `${actualFillPercentage}%` === expectedFillPercentage;
+        });
 }


### PR DESCRIPTION
## What is the current behavior?
See jobs of https://github.com/Tinkoff/taiga-ui/pull/4580

```
  2 failing

  1) Slider
       programmatically change value
         ngModel
           decrease value by 1 step:
     AssertionError: Timed out retrying after 30000ms:
     Expected to find element: ``, but never found it.
     Queried from element: <input.ng-untouched.ng-pristine.ng-valid>
      at checkSlider (webpack:///./cypress/tests/kit/slider/slider.cy.ts:217:9)
      at Context.eval (webpack:///./cypress/tests/kit/slider/slider.cy.ts:107:16)

  2) Slider
       programmatically change value
         ngModel
           increase value by 2 step:
     AssertionError: Timed out retrying after 30000ms:
     Expected to find element: ``, but never found it.
     Queried from element: <input.ng-untouched.ng-pristine.ng-valid>
      at checkSlider (webpack:///./cypress/tests/kit/slider/slider.cy.ts:217:9)
      at Context.eval (webpack:///./cypress/tests/kit/slider/slider.cy.ts:135:16)
```

## What is the new behavior?
The same as
* https://github.com/Tinkoff/taiga-ui/pull/4429
