### PR TITLE
feat(core): svg source interceptor should accept svg global options

### DIFF
--- a/projects/core/components/svg/svg.component.ts
+++ b/projects/core/components/svg/svg.component.ts
@@ -14,7 +14,6 @@ import {WINDOW} from '@ng-web-apis/common';
 import {
     tuiAssert,
     tuiGetDocumentOrShadowRoot,
-    TuiHandler,
     tuiIsString,
     tuiPure,
     tuiRequiredSetter,
@@ -30,7 +29,12 @@ import {tuiIsPresumedHTMLString} from '@taiga-ui/core/utils/miscellaneous';
 import {Observable, of, ReplaySubject} from 'rxjs';
 import {catchError, map, startWith, switchMap} from 'rxjs/operators';
 
-import {TUI_SVG_OPTIONS, TUI_SVG_SRC_INTERCEPTORS, TuiSvgOptions} from './svg-options';
+import {
+    TUI_SVG_OPTIONS,
+    TUI_SVG_SRC_INTERCEPTORS,
+    TuiSvgInterceptorHandler,
+    TuiSvgOptions,
+} from './svg-options';
 
 const UNDEFINED_NAMED_ICON = 'Attempted to use undefined named icon';
 const MISSING_EXTERNAL_ICON = 'External icon is missing on the given URL';
@@ -55,9 +59,7 @@ export class TuiSvgComponent {
         @Inject(TUI_SVG_OPTIONS) private readonly options: TuiSvgOptions,
         @Optional()
         @Inject(TUI_SVG_SRC_INTERCEPTORS)
-        private readonly srcInterceptors: Array<
-            TuiHandler<TuiSafeHtml, TuiSafeHtml>
-        > | null,
+        private readonly srcInterceptors: readonly TuiSvgInterceptorHandler[] | null,
         @Optional()
         @Inject(TUI_SANITIZER)
         private readonly tuiSanitizer: Sanitizer | null,
@@ -89,7 +91,7 @@ export class TuiSvgComponent {
         ngDevMode && tuiAssert.assert(!deprecated, deprecated);
 
         this.icon = (this.srcInterceptors ?? []).reduce(
-            (newSrc: TuiSafeHtml, interceptor) => interceptor(newSrc),
+            (newSrc, interceptor) => interceptor(newSrc, this.options),
             this.options.srcProcessor(src),
         );
 

--- a/projects/core/tokens/icon-place.ts
+++ b/projects/core/tokens/icon-place.ts
@@ -1,5 +1,7 @@
 import {InjectionToken} from '@angular/core';
 
+export const TUI_DEFAULT_ICONS_PLACE = `assets/taiga-ui/icons` as const;
+
 /**
  * Path to icons
  * @deprecated Use {@link TUI_SVG_OPTIONS} instead
@@ -7,6 +9,6 @@ import {InjectionToken} from '@angular/core';
 export const TUI_ICONS_PLACE: InjectionToken<string> = new InjectionToken<string>(
     `[TUI_ICONS_PLACE]`,
     {
-        factory: () => `assets/taiga-ui/icons`,
+        factory: () => TUI_DEFAULT_ICONS_PLACE,
     },
 );


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

<img width="669" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/dafdf566-9c06-402e-8b60-da85c877ab56">


## What is the new behavior?

<img width="767" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/f3328f92-861c-48e1-b915-96fd09c08bbf">
