### PR TITLE
fix(cdk): fix change detection issue in `DialogHost`

### DIFF
--- a/projects/cdk/components/dialog-host/dialog-host.component.ts
+++ b/projects/cdk/components/dialog-host/dialog-host.component.ts
@@ -14,7 +14,7 @@ import {TuiDestroyService} from '@taiga-ui/cdk/services';
 import {TUI_DIALOGS} from '@taiga-ui/cdk/tokens';
 import {TuiDialog} from '@taiga-ui/cdk/types';
 import {combineLatest, Observable, of} from 'rxjs';
-import {debounceTime, map, takeUntil} from 'rxjs/operators';
+import {map, takeUntil} from 'rxjs/operators';
 
 /**
  * Is closing dialog on browser backward navigation enabled
@@ -63,7 +63,6 @@ export class TuiDialogHostComponent<T extends TuiDialog<unknown, unknown>>
         // can happen after view was checked, so calling `detectChanges` instead
         combineLatest(this.dialogsByType)
             .pipe(
-                debounceTime(0),
                 map(arr =>
                     new Array<T>()
                         .concat(...arr)
@@ -73,7 +72,7 @@ export class TuiDialogHostComponent<T extends TuiDialog<unknown, unknown>>
             )
             .subscribe(dialogs => {
                 this.dialogs = dialogs;
-                this.cdr.detectChanges();
+                this.cdr.markForCheck();
             });
     }
 

--- a/projects/cdk/components/dialog-host/dialog-host.component.ts
+++ b/projects/cdk/components/dialog-host/dialog-host.component.ts
@@ -14,7 +14,7 @@ import {TuiDestroyService} from '@taiga-ui/cdk/services';
 import {TUI_DIALOGS} from '@taiga-ui/cdk/tokens';
 import {TuiDialog} from '@taiga-ui/cdk/types';
 import {combineLatest, Observable, of} from 'rxjs';
-import {map, takeUntil} from 'rxjs/operators';
+import {debounceTime, map, takeUntil} from 'rxjs/operators';
 
 /**
  * Is closing dialog on browser backward navigation enabled
@@ -63,6 +63,7 @@ export class TuiDialogHostComponent<T extends TuiDialog<unknown, unknown>>
         // can happen after view was checked, so calling `detectChanges` instead
         combineLatest(this.dialogsByType)
             .pipe(
+                debounceTime(0),
                 map(arr =>
                     new Array<T>()
                         .concat(...arr)

--- a/projects/kit/components/pdf-viewer/test/pdf-viewer.component.spec.ts
+++ b/projects/kit/components/pdf-viewer/test/pdf-viewer.component.spec.ts
@@ -52,12 +52,12 @@ describe(`Pdf Viewer with TUI_PDF_VIEWER_OPTIONS`, () => {
     });
 
     describe(`label`, () => {
-        it(`correctly shows label option data`, () => {
+        it(`correctly shows label option data`, async () => {
             tuiPdfViewerService
                 .open(sanitizer.bypassSecurityTrustResourceUrl(``))
                 .subscribe();
             fixture.detectChanges();
-
+            await fixture.whenStable();
             expect(getLabelElement()!.nativeElement.textContent.trim()).toBe(label);
         });
     });

--- a/projects/kit/components/pdf-viewer/test/pdf-viewer.component.spec.ts
+++ b/projects/kit/components/pdf-viewer/test/pdf-viewer.component.spec.ts
@@ -52,12 +52,12 @@ describe(`Pdf Viewer with TUI_PDF_VIEWER_OPTIONS`, () => {
     });
 
     describe(`label`, () => {
-        it(`correctly shows label option data`, async () => {
+        it(`correctly shows label option data`, () => {
             tuiPdfViewerService
                 .open(sanitizer.bypassSecurityTrustResourceUrl(``))
                 .subscribe();
             fixture.detectChanges();
-            await fixture.whenStable();
+
             expect(getLabelElement()!.nativeElement.textContent.trim()).toBe(label);
         });
     });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

After fixing  [ExpressionChangedAfterItHasBeenCheckedError](https://github.com/Tinkoff/taiga-ui/pull/4533#top) one of internal project ran into another issue - mismatch between dialogs in array and view. Temporarily return markForCheck()

Closes # <!-- link to a relevant issue. -->

## What is the new behavior?

