### PR TITLE
docs: add documentationPropertyName to "disabled" inputs

### DIFF
--- a/projects/demo/src/modules/components/checkbox-block/checkbox-block.template.html
+++ b/projects/demo/src/modules/components/checkbox-block/checkbox-block.template.html
@@ -89,7 +89,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/checkbox-labeled/checkbox-labeled.template.html
+++ b/projects/demo/src/modules/components/checkbox-labeled/checkbox-labeled.template.html
@@ -82,7 +82,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/checkbox/checkbox.template.html
+++ b/projects/demo/src/modules/components/checkbox/checkbox.template.html
@@ -83,7 +83,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/combo-box/combo-box.template.html
+++ b/projects/demo/src/modules/components/combo-box/combo-box.template.html
@@ -162,7 +162,7 @@
 
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/editor/starter/editor-starter.template.html
+++ b/projects/demo/src/modules/components/editor/starter/editor-starter.template.html
@@ -31,7 +31,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-card-grouped/input-card-grouped.template.html
+++ b/projects/demo/src/modules/components/input-card-grouped/input-card-grouped.template.html
@@ -88,7 +88,7 @@
 
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-card/input-card.template.html
+++ b/projects/demo/src/modules/components/input-card/input-card.template.html
@@ -108,7 +108,7 @@
                 <ng-template tuiAccordionItemContent>
                     <tui-doc-documentation>
                         <ng-template
-                            documentationPropertyName=""
+                            documentationPropertyName="disabled"
                             documentationPropertyType="boolean"
                             [(documentationPropertyValue)]="disabledCard"
                         >
@@ -150,7 +150,7 @@
                 <ng-template tuiAccordionItemContent>
                     <tui-doc-documentation>
                         <ng-template
-                            documentationPropertyName=""
+                            documentationPropertyName="disabled"
                             documentationPropertyType="boolean"
                             [(documentationPropertyValue)]="disabledExpire"
                         >
@@ -176,7 +176,7 @@
                 <ng-template tuiAccordionItemContent>
                     <tui-doc-documentation>
                         <ng-template
-                            documentationPropertyName=""
+                            documentationPropertyName="disabled"
                             documentationPropertyType="boolean"
                             [(documentationPropertyValue)]="disabledCVC"
                         >

--- a/projects/demo/src/modules/components/input-copy/input-copy.template.html
+++ b/projects/demo/src/modules/components/input-copy/input-copy.template.html
@@ -47,7 +47,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-count/input-count.template.html
+++ b/projects/demo/src/modules/components/input-count/input-count.template.html
@@ -103,7 +103,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-date-range/input-date-range.template.html
+++ b/projects/demo/src/modules/components/input-date-range/input-date-range.template.html
@@ -159,7 +159,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-date-time/input-date-time.template.html
+++ b/projects/demo/src/modules/components/input-date-time/input-date-time.template.html
@@ -138,7 +138,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-date/input-date.template.html
+++ b/projects/demo/src/modules/components/input-date/input-date.template.html
@@ -152,7 +152,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-files/input-files.template.html
+++ b/projects/demo/src/modules/components/input-files/input-files.template.html
@@ -126,7 +126,7 @@
         </tui-doc-demo>
         <tui-doc-documentation heading="TuiInputFiles">
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-inline/input-inline.template.html
+++ b/projects/demo/src/modules/components/input-inline/input-inline.template.html
@@ -46,7 +46,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-month-range/input-month-range.template.html
+++ b/projects/demo/src/modules/components/input-month-range/input-month-range.template.html
@@ -67,7 +67,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-month/input-month.template.html
+++ b/projects/demo/src/modules/components/input-month/input-month.template.html
@@ -56,7 +56,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-number/input-number.template.html
+++ b/projects/demo/src/modules/components/input-number/input-number.template.html
@@ -183,7 +183,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-password/input-password.template.html
+++ b/projects/demo/src/modules/components/input-password/input-password.template.html
@@ -52,7 +52,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-phone-international/input-phone-international.template.html
+++ b/projects/demo/src/modules/components/input-phone-international/input-phone-international.template.html
@@ -62,7 +62,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-phone/input-phone.template.html
+++ b/projects/demo/src/modules/components/input-phone/input-phone.template.html
@@ -79,7 +79,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-range/input-range.template.html
+++ b/projects/demo/src/modules/components/input-range/input-range.template.html
@@ -130,7 +130,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-slider/input-slider.template.html
+++ b/projects/demo/src/modules/components/input-slider/input-slider.template.html
@@ -131,7 +131,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-tag/input-tag.template.html
+++ b/projects/demo/src/modules/components/input-tag/input-tag.template.html
@@ -130,7 +130,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-time/input-time.template.html
+++ b/projects/demo/src/modules/components/input-time/input-time.template.html
@@ -99,7 +99,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input-year/input-year.template.html
+++ b/projects/demo/src/modules/components/input-year/input-year.template.html
@@ -59,7 +59,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/input/input.template.html
+++ b/projects/demo/src/modules/components/input/input.template.html
@@ -261,7 +261,7 @@
         </ng-template>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/multi-select/multi-select.template.html
+++ b/projects/demo/src/modules/components/multi-select/multi-select.template.html
@@ -171,7 +171,7 @@
 
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/radio-block/radio-block.template.html
+++ b/projects/demo/src/modules/components/radio-block/radio-block.template.html
@@ -100,7 +100,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/radio-labeled/radio-labeled.template.html
+++ b/projects/demo/src/modules/components/radio-labeled/radio-labeled.template.html
@@ -93,7 +93,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/radio-list/radio-list.template.html
+++ b/projects/demo/src/modules/components/radio-list/radio-list.template.html
@@ -52,7 +52,7 @@
         </ng-template>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/radio/radio.template.html
+++ b/projects/demo/src/modules/components/radio/radio.template.html
@@ -96,7 +96,7 @@
         </button>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/range/range.template.html
+++ b/projects/demo/src/modules/components/range/range.template.html
@@ -69,7 +69,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/rating/rating.template.html
+++ b/projects/demo/src/modules/components/rating/rating.template.html
@@ -52,7 +52,7 @@
                 Component is read only
             </ng-template>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/select/select.template.html
+++ b/projects/demo/src/modules/components/select/select.template.html
@@ -196,7 +196,7 @@
 
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/slider/slider.component.html
+++ b/projects/demo/src/modules/components/slider/slider.component.html
@@ -124,7 +124,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >

--- a/projects/demo/src/modules/components/toggle/toggle.template.html
+++ b/projects/demo/src/modules/components/toggle/toggle.template.html
@@ -38,7 +38,7 @@
         </tui-doc-demo>
         <tui-doc-documentation>
             <ng-template
-                documentationPropertyName=""
+                documentationPropertyName="disabled"
                 documentationPropertyType="boolean"
                 [(documentationPropertyValue)]="disabled"
             >


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [x] Documentation content changes

## What is the current behavior?

Closes #4034

## What is the new behavior?

a `disabled` query param is added to a URL, when an input is toggled