### PR TITLE
fix(kit): prevent overflow first character inside `InputInlineComponent`

### DIFF
--- a/projects/kit/components/input-inline/input-inline.style.less
+++ b/projects/kit/components/input-inline/input-inline.style.less
@@ -16,8 +16,8 @@
 }
 
 .t-placeholder {
-    min-width: 1px;
     display: inline-block;
+    min-width: 1px;
 }
 
 .t-native {

--- a/projects/kit/components/input-inline/input-inline.style.less
+++ b/projects/kit/components/input-inline/input-inline.style.less
@@ -12,12 +12,12 @@
     display: block;
     padding-right: 0.02em; // to prevent caret shaking
     margin-left: 1px; // to prevent hiding characters in safari
-    overflow: hidden;
     white-space: pre;
 }
 
 .t-placeholder {
-    margin-left: -1px;
+    min-width: 1px;
+    display: inline-block;
 }
 
 .t-native {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

<img width="381" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/47309399-ab4a-4cba-b81c-301202bc0021">


## What is the new behavior?

<img width="433" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/c35a2f55-1534-4430-ae93-96f862d533f8">

