### PR TITLE
fix(kit): `InputDateRange` freezes UI if `[minLength]`/`[maxLength]` are ommited

### DIFF
--- a/projects/kit/components/input-date-range/input-date-range.component.ts
+++ b/projects/kit/components/input-date-range/input-date-range.component.ts
@@ -188,8 +188,8 @@ export class TuiInputDateRangeComponent
                   this.dateSeparator,
                   this.min,
                   this.max,
-                  this.minLength || {},
-                  this.maxLength || {},
+                  this.minLength,
+                  this.maxLength,
               );
     }
 
@@ -381,16 +381,16 @@ export class TuiInputDateRangeComponent
         separator: string,
         min: TuiDay,
         max: TuiDay,
-        minLength: TuiDayLike,
-        maxLength: TuiDayLike,
+        minLength: TuiDayLike | null,
+        maxLength: TuiDayLike | null,
     ): MaskitoOptions {
         return maskitoDateRangeOptionsGenerator({
             separator,
             mode: TUI_DATE_MODE_MASKITO_ADAPTER[dateFormat],
             min: min.toLocalNativeDate(),
             max: max.toLocalNativeDate(),
-            minLength,
-            maxLength,
+            minLength: minLength || {},
+            maxLength: maxLength || {},
         });
     }
 

--- a/projects/kit/components/input-date-range/test/input-date-range.component.spec.ts
+++ b/projects/kit/components/input-date-range/test/input-date-range.component.spec.ts
@@ -174,8 +174,7 @@ describe(`InputDateRangeComponent`, () => {
         });
     });
 
-    // TODO: CPU 100% in maskitoDateRangeOptionsGenerator
-    xdescribe(`InputDateRangeComponent + TUI_DATE_FORMAT="MDY" + TUI_DATE_SEPARATOR="/"`, () => {
+    describe(`InputDateRangeComponent + TUI_DATE_FORMAT="MDY" + TUI_DATE_SEPARATOR="/"`, () => {
         configureTestSuite(() => {
             TestBed.configureTestingModule({
                 ...defaultTestingModuleMeta,
@@ -214,8 +213,7 @@ describe(`InputDateRangeComponent`, () => {
         });
     });
 
-    // TODO: CPU 100% in maskitoDateRangeOptionsGenerator
-    xdescribe(`InputDateRangeComponent + TUI_DATE_FORMAT="YMD" + TUI_DATE_SEPARATOR="-"`, () => {
+    describe(`InputDateRangeComponent + TUI_DATE_FORMAT="YMD" + TUI_DATE_SEPARATOR="-"`, () => {
         configureTestSuite(() => {
             TestBed.configureTestingModule({
                 ...defaultTestingModuleMeta,
@@ -254,7 +252,7 @@ describe(`InputDateRangeComponent`, () => {
         });
     });
 
-    xdescribe(`InputDateRangeComponent + TUI_DATE_RANGE_VALUE_TRANSFORMER`, () => {
+    describe(`InputDateRangeComponent + TUI_DATE_RANGE_VALUE_TRANSFORMER`, () => {
         class TestDateTransformer extends AbstractTuiValueTransformer<
             TuiDay | null,
             Date | null


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4642