### PR TITLE
fix(kit): prevent min rate star selection

### DIFF
--- a/projects/kit/components/rating/rating.component.ts
+++ b/projects/kit/components/rating/rating.component.ts
@@ -94,7 +94,13 @@ export class TuiRatingComponent
     }
 
     setRateByReverseIndex(index: number): void {
-        this.value = this.max - index;
+        const reversedIndex = this.max - index;
+
+        if (reversedIndex <= this.min) {
+            return;
+        }
+
+        this.value = reversedIndex;
     }
 
     setRate(value: number): void {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4657 

## What is the new behavior?
Do not select a star if the selection value is less than the minimum value