### PR TITLE
feat(addon-editor): support `translate/spellcheck` option in editor DI

### DIFF
--- a/projects/addon-editor/components/editor/editor.component.html
+++ b/projects/addon-editor/components/editor/editor.component.html
@@ -1,5 +1,5 @@
 <div
-    *tuiLet="editorLoaded$ | async as editorLoaded"
+    *ngIf="editorLoaded$ | async as editorLoaded"
     tuiWrapper
     appearance="textfield"
     class="t-wrapper"
@@ -47,7 +47,6 @@
         >
             <tui-editor-socket
                 tuiTiptapEditor
-                spellcheck="false"
                 class="tui-editor-socket"
                 [value]="value"
                 [editable]="interactive"

--- a/projects/addon-editor/components/editor/editor.component.ts
+++ b/projects/addon-editor/components/editor/editor.component.ts
@@ -26,7 +26,9 @@ import {TuiEditorAttachedFile} from '@taiga-ui/addon-editor/interfaces';
 import {
     TIPTAP_EDITOR,
     TUI_EDITOR_CONTENT_PROCESSOR,
+    TUI_EDITOR_OPTIONS,
     TUI_EDITOR_VALUE_TRANSFORMER,
+    TuiEditorOptions,
 } from '@taiga-ui/addon-editor/tokens';
 import {tuiIsSafeLinkRange} from '@taiga-ui/addon-editor/utils';
 import {
@@ -43,6 +45,7 @@ import {
 import {TUI_ANIMATIONS_DEFAULT_DURATION} from '@taiga-ui/core';
 import {Editor} from '@tiptap/core';
 import {Observable} from 'rxjs';
+import {delay, takeUntil} from 'rxjs/operators';
 
 import {TUI_EDITOR_PROVIDERS} from './editor.providers';
 
@@ -95,8 +98,13 @@ export class TuiEditorComponent
         @Optional()
         @Inject(TUI_EDITOR_VALUE_TRANSFORMER)
         transformer: AbstractTuiValueTransformer<string> | null,
+        @Inject(TUI_EDITOR_OPTIONS) private readonly options: TuiEditorOptions,
     ) {
         super(control, cdr, transformer);
+
+        this.editorLoaded$
+            .pipe(delay(0), takeUntil(this.destroy$))
+            .subscribe(() => this.patchContentEditableElement());
     }
 
     get nativeFocusableElement(): HTMLDivElement | null {
@@ -217,6 +225,14 @@ export class TuiEditorComponent
         return (
             this.focusNode?.nodeName === 'A' &&
             ['IMG', 'TUI-IMAGE-EDITOR'].includes(this.focusNode?.childNodes[0]?.nodeName)
+        );
+    }
+
+    private patchContentEditableElement(): void {
+        this.nativeFocusableElement?.setAttribute('translate', this.options.translate);
+        this.nativeFocusableElement?.setAttribute(
+            'spellcheck',
+            String(this.options.spellcheck),
         );
     }
 }

--- a/projects/addon-editor/components/editor/editor.module.ts
+++ b/projects/addon-editor/components/editor/editor.module.ts
@@ -4,7 +4,7 @@ import {TuiEditLinkModule} from '@taiga-ui/addon-editor/components/edit-link';
 import {TuiEditorSocketModule} from '@taiga-ui/addon-editor/components/editor-socket';
 import {TuiToolbarModule} from '@taiga-ui/addon-editor/components/toolbar';
 import {TuiTiptapEditorModule} from '@taiga-ui/addon-editor/directives';
-import {TuiActiveZoneModule, TuiItemDirective, TuiLetModule} from '@taiga-ui/cdk';
+import {TuiActiveZoneModule, TuiItemDirective} from '@taiga-ui/cdk';
 import {TuiDropdownModule, TuiScrollbarModule, TuiWrapperModule} from '@taiga-ui/core';
 
 import {TuiEditorComponent} from './editor.component';
@@ -27,7 +27,6 @@ import {TuiEditorPortalHostComponent} from './portal/editor-portal-host.componen
         TuiDropdownModule,
         TuiTiptapEditorModule,
         TuiEditorSocketModule,
-        TuiLetModule,
     ],
     exports: [TuiEditorComponent, TuiItemDirective],
 })

--- a/projects/addon-editor/tokens/editor-options.ts
+++ b/projects/addon-editor/tokens/editor-options.ts
@@ -8,6 +8,8 @@ import {
 } from '@taiga-ui/addon-editor/constants';
 
 export interface TuiEditorOptions {
+    readonly translate: 'no' | 'yes';
+    readonly spellcheck: boolean;
     readonly blankColor: string;
     readonly colors: ReadonlyMap<string, string>;
     readonly fontOptions: typeof tuiDefaultFontOptionsHandler;
@@ -15,6 +17,8 @@ export interface TuiEditorOptions {
 }
 
 export const TUI_EDITOR_DEFAULT_OPTIONS: TuiEditorOptions = {
+    translate: `no`,
+    spellcheck: false,
     colors: defaultEditorColors,
     blankColor: EDITOR_BLANK_COLOR,
     linkOptions: TUI_DEFAULT_LINK_OPTIONS,

--- a/projects/demo/src/modules/components/editor/starter/editor-starter.template.html
+++ b/projects/demo/src/modules/components/editor/starter/editor-starter.template.html
@@ -167,6 +167,20 @@
                     <code>fontOptions</code>
                 </dt>
                 <dd class="tui-space_bottom-5">You can customize your own list of font sizes in editor.</dd>
+
+                <dt>
+                    <code>translate</code>
+                </dt>
+                <dd class="tui-space_bottom-5">
+                    Although not all browsers recognize this attribute, it is respected by automatic translation systems
+                    such as Google Translate, and may also be respected by tools used by human translators. As such it's
+                    important that web authors use this attribute to mark content that should not be translated..
+                </dd>
+
+                <dt>
+                    <code>spellcheck</code>
+                </dt>
+                <dd class="tui-space_bottom-5">Defines whether the editor may be checked for spelling errors.</dd>
             </dl>
         </tui-doc-documentation>
     </ng-template>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes


## What is the current behavior?

Closes #4687

<img width="916" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/2dda1b60-db07-48df-bdb7-fbf11cf0e218">


## What is the new behavior?

<img width="490" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/b150f78c-e93a-46b2-863e-db37db65b28b">
