### PR TITLE
fix(addon-commerce): expired field should be clickable after reset of prefilled value

### DIFF
--- a/projects/addon-commerce/components/input-card-grouped/input-card-grouped.component.ts
+++ b/projects/addon-commerce/components/input-card-grouped/input-card-grouped.component.ts
@@ -346,6 +346,7 @@ export class TuiInputCardGroupedComponent
     }
 
     clear(): void {
+        this.expireInert = false;
         this.value = null;
         this.focusCard();
     }

--- a/projects/demo-integrations/cypress/tests/addon-commerce/input-card-grouped.cy.ts
+++ b/projects/demo-integrations/cypress/tests/addon-commerce/input-card-grouped.cy.ts
@@ -187,4 +187,31 @@ describe(`InputCardGrouped`, () => {
                 .matchImageSnapshot(`17-default-prefilled-state-input-card`);
         });
     });
+
+    it(`expired field should be clickable after reset of prefilled value`, () => {
+        cy.tuiVisit(`components/input-card-grouped#custom-labels`);
+
+        cy.get(`tui-doc-example[heading="Custom labels"]`)
+            .tuiScrollIntoView()
+            .as(`wrapper`);
+
+        cy.get(`@wrapper`).find(`tui-input-card-grouped`).as(`input-card-grouped`);
+
+        cy.get(`@input-card-grouped`)
+            .findByAutomationId(`tui-input-card-grouped__expire`)
+            .should(`have.css`, `pointer-events`, `none`);
+
+        cy.get(`@input-card-grouped`)
+            .find(`[src="tuiIconCloseLarge"]`)
+            .click({force: true});
+
+        cy.get(`@input-card-grouped`)
+            .findByAutomationId(`tui-input-card-grouped__card`)
+            .type(`5586200071492158`);
+
+        cy.get(`@input-card-grouped`)
+            .findByAutomationId(`tui-input-card-grouped__expire`)
+            .should(`have.css`, `pointer-events`, `auto`)
+            .type(`12/25`);
+    });
 });

--- a/projects/demo/src/modules/components/input-card-grouped/examples/5/index.ts
+++ b/projects/demo/src/modules/components/input-card-grouped/examples/5/index.ts
@@ -21,8 +21,7 @@ import {of} from 'rxjs';
 })
 export class TuiInputCardGroupedExample5 {
     readonly control = new FormControl({
-        card: '22222222222222222',
-        expire: '02/22',
-        cvc: '222',
+        card: '558620******2158',
+        expire: '12/25',
     });
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4398
