### PR TITLE
fix(addon-mobile): `PullToRefresh` properly disable when no component was provided

### DIFF
--- a/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.component.ts
+++ b/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.component.ts
@@ -60,14 +60,16 @@ export class TuiPullToRefreshComponent {
         @Inject(TuiPullToRefreshService) readonly pulling$: Observable<number>,
     ) {
         // Ensure scrolling down is impossible while pulling
-        tuiScrollFrom(nativeElement)
-            .pipe(startWith(null), takeUntil(destroy$))
-            .subscribe(() => {
-                if (nativeElement.scrollTop) {
-                    nativeElement.style.touchAction = '';
-                } else {
-                    nativeElement.style.touchAction = 'pan-down';
-                }
-            });
+        if (this.component) {
+            tuiScrollFrom(nativeElement)
+                .pipe(startWith(null), takeUntil(destroy$))
+                .subscribe(() => {
+                    if (nativeElement.scrollTop) {
+                        nativeElement.style.touchAction = '';
+                    } else {
+                        nativeElement.style.touchAction = 'pan-down';
+                    }
+                });
+        }
     }
 }

--- a/projects/core/styles/theme/wrapper/icon.less
+++ b/projects/core/styles/theme/wrapper/icon.less
@@ -2,7 +2,8 @@
 
 /* stylelint-disable order/order */
 /* stylelint-disable selector-max-specificity */
-[tuiWrapper][data-appearance='icon'] {
+// TODO: Remove manual specificity after FM is updated to 3.18+
+[tuiWrapper][data-appearance='icon'][data-appearance='icon'] {
     .transition(opacity);
     color: var(--tui-text-01);
     opacity: 0.5;

--- a/projects/demo/src/modules/app/landing/landing.template.html
+++ b/projects/demo/src/modules/app/landing/landing.template.html
@@ -247,6 +247,7 @@
         appearance="accent"
         routerLink="/getting-started"
         class="browse browse_desktop"
+        [pseudoFocus]="false"
     >
         Browse components
     </a>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes # <!-- link to a relevant issue. -->

## What is the new behavior?
