### PR TITLE
fix(addon-mobile): `PullToRefresh` properly disable when no component was provided

### DIFF
--- a/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.component.ts
+++ b/projects/addon-mobile/components/pull-to-refresh/pull-to-refresh.component.ts
@@ -4,6 +4,7 @@ import {
     ElementRef,
     Inject,
     Input,
+    NgZone,
     Output,
     Self,
 } from '@angular/core';
@@ -14,6 +15,7 @@ import {
     TuiDestroyService,
     TuiHandler,
     tuiScrollFrom,
+    tuiZonefree,
 } from '@taiga-ui/cdk';
 import {TUI_SCROLL_REF} from '@taiga-ui/core';
 import {PolymorpheusContent} from '@tinkoff/ng-polymorpheus';
@@ -49,6 +51,7 @@ export class TuiPullToRefreshComponent {
     );
 
     constructor(
+        @Inject(NgZone) ngZone: NgZone,
         @Inject(TuiDestroyService) @Self() destroy$: Observable<unknown>,
         @Inject(TUI_SCROLL_REF) {nativeElement}: ElementRef<HTMLElement>,
         @Inject(TUI_IS_IOS) private readonly isIOS: boolean,
@@ -58,14 +61,16 @@ export class TuiPullToRefreshComponent {
         @Inject(TuiPullToRefreshService) readonly pulling$: Observable<number>,
     ) {
         // Ensure scrolling down is impossible while pulling
-        tuiScrollFrom(nativeElement)
-            .pipe(startWith(null), takeUntil(destroy$))
-            .subscribe(() => {
-                if (nativeElement.scrollTop) {
-                    nativeElement.style.touchAction = '';
-                } else {
-                    nativeElement.style.touchAction = 'pan-down';
-                }
-            });
+        if (this.component) {
+            tuiScrollFrom(nativeElement)
+                .pipe(startWith(null), tuiZonefree(ngZone), takeUntil(destroy$))
+                .subscribe(() => {
+                    if (nativeElement.scrollTop) {
+                        nativeElement.style.touchAction = '';
+                    } else {
+                        nativeElement.style.touchAction = 'pan-down';
+                    }
+                });
+        }
     }
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes # <!-- link to a relevant issue. -->

## What is the new behavior?
