### PR TITLE
fix(addon-commerce): hide input filler in dark mode

### DIFF
--- a/projects/addon-commerce/components/input-card-grouped/input-card-grouped.style.less
+++ b/projects/addon-commerce/components/input-card-grouped/input-card-grouped.style.less
@@ -117,8 +117,10 @@
         color: var(--tui-text-03-night);
     }
 
-    &_card,
-    :host[data-mode='onDark'] &_card {
+    &&&_card,
+    :host[data-mode='onDark'] &&&_card {
+        // @note: (&&&_) it's increasing css cascade priority
+        /* stylelint-disable selector-max-specificity */
         &:not(.t-input_hidden),
         &:not(.t-input_hidden)::placeholder,
         &:not(.t-input_hidden):-webkit-autofill {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Part of #4752 


https://github.com/Tinkoff/taiga-ui/assets/12021443/db8ef4b6-7c36-4fcd-85c9-f3b70039fdad


