### PR TITLE
Revert "feat(cdk): adding support ECMA Decorators for `@tuiPure`

### DIFF
--- a/projects/cdk/decorators/pure.ts
+++ b/projects/cdk/decorators/pure.ts
@@ -1,56 +1,5 @@
 import {TuiPureException} from '@taiga-ui/cdk/exceptions';
 
-/** TODO Delete after updating typescript to version 5 and when backward compatibility will not be required */
-interface ClassGetterDecoratorContext {
-    kind: 'getter';
-    name: string;
-}
-
-/** TODO Delete after updating typescript to version 5 and when backward compatibility will not be required */
-interface ClassMethodDecoratorContext {
-    kind: 'method';
-    name: string;
-}
-
-function decorateMethod(
-    originalMethod: (...args: unknown[]) => unknown,
-): (this: object, ...args: unknown[]) => unknown {
-    let previousArgs: readonly unknown[] = [];
-    let originalFnWasCalledLeastAtOnce = false;
-    let pureValue: unknown;
-
-    return function tuiPureMethodPatched(this: object, ...args: unknown[]): unknown {
-        const isPure =
-            originalFnWasCalledLeastAtOnce &&
-            previousArgs.length === args.length &&
-            args.every((arg, index) => arg === previousArgs[index]);
-
-        if (isPure) {
-            return pureValue;
-        }
-
-        previousArgs = args;
-        pureValue = originalMethod.apply(this, args);
-        originalFnWasCalledLeastAtOnce = true;
-
-        return pureValue;
-    };
-}
-
-function decorateGetter(
-    originalGetter: () => unknown,
-    propertyKey: string | symbol,
-    enumerable: boolean = true,
-): (this: object) => unknown {
-    return function tuiPureGetterPatched(this: object): unknown {
-        const value = originalGetter.call(this);
-
-        Object.defineProperty(this, propertyKey, {enumerable, value});
-
-        return value;
-    };
-}
-
 /**
  * Implements lazy initialization for getter or memoization of a function call similar to pure {@link: Pipe}.
  * Replaces getter with its calculated value upon first call or keeps track of last call arguments and returned
@@ -58,58 +7,24 @@ function decorateGetter(
  *
  * @throws error if used not on getter or function
  *
- * CAUTION: they must be pure.
+ * CAUTION: `this` is not available inside such functions/getters, they must be pure.
  */
 export function tuiPure<T>(
-    target: object,
+    _target: Record<string, any>,
     propertyKey: string,
     {get, enumerable, value}: TypedPropertyDescriptor<T>,
-): TypedPropertyDescriptor<T>;
-
-/**
- * Implements lazy initialization for getter or memoization of a function call similar to pure {@link: Pipe}.
- * Replaces getter with its calculated value upon first call or keeps track of last call arguments and returned
- * value for function, skipping calculation when arguments are strictly the same.
- *
- * CAUTION: they must be pure.
- */
-export function tuiPure<A extends unknown[], R>(
-    target: (...args: A) => R,
-    context: ClassGetterDecoratorContext | ClassMethodDecoratorContext,
-): (...args: A) => R;
-
-export function tuiPure(
-    target: object | ((...args: unknown[]) => unknown),
-    propertyKeyOrContext:
-        | ClassGetterDecoratorContext
-        | ClassMethodDecoratorContext
-        | string,
-    descriptor?: TypedPropertyDescriptor<(...args: unknown[]) => unknown>,
-): TypedPropertyDescriptor<unknown> | ((...args: unknown[]) => unknown) {
-    if (typeof target === `function`) {
-        const context = propertyKeyOrContext as
-            | ClassGetterDecoratorContext
-            | ClassMethodDecoratorContext;
-
-        if (context.kind === `getter`) {
-            return decorateGetter(target as () => unknown, context.name);
-        }
-
-        if (context.kind === `method`) {
-            return decorateMethod(target as (...args: unknown[]) => unknown);
-        }
-
-        throw new TuiPureException();
-    }
-
-    const {get, enumerable, value} = descriptor!;
-    const propertyKey = propertyKeyOrContext as string;
-
+): TypedPropertyDescriptor<T> {
     if (get) {
         return {
             configurable: true,
             enumerable,
-            get: decorateGetter(get, propertyKey, enumerable),
+            get(): T {
+                const value = get.call(this);
+
+                Object.defineProperty(this, propertyKey, {enumerable, value});
+
+                return value;
+            },
         };
     }
 
@@ -117,9 +32,39 @@ export function tuiPure(
         throw new TuiPureException();
     }
 
+    const original = value;
+
     return {
         configurable: true,
         enumerable,
-        value: decorateMethod(value),
+        get(): T {
+            let previousArgs: readonly unknown[] = [];
+            let originalFnWasCalledLeastAtOnce = false;
+            let pureValue: unknown;
+
+            const patched = (...args: unknown[]): unknown => {
+                const isPure =
+                    originalFnWasCalledLeastAtOnce &&
+                    previousArgs.length === args.length &&
+                    args.every((arg, index) => arg === previousArgs[index]);
+
+                if (isPure) {
+                    return pureValue;
+                }
+
+                previousArgs = args;
+                pureValue = original.apply(this, args);
+                originalFnWasCalledLeastAtOnce = true;
+
+                return pureValue;
+            };
+
+            Object.defineProperty(this, propertyKey, {
+                configurable: true,
+                value: patched,
+            });
+
+            return patched as unknown as T;
+        },
     };
 }

--- a/projects/cdk/decorators/test/pure.spec.ts
+++ b/projects/cdk/decorators/test/pure.spec.ts
@@ -1,7 +1,5 @@
 import {tuiPure} from '@taiga-ui/cdk';
 
-/** TODO this tests does not cover typescript@^5 and experimentalDecorators: false */
-
 describe(`tuiPure`, () => {
     it(`calls getter only once and then sets result as a value property on the object`, () => {
         let count = 0;


### PR DESCRIPTION
This reverts commit a0b275c6980779a8bb86b756bb422d08afbf9923.


@sviat9440 Please, check that page

https://taiga-ui.dev/next/components/input-time
<img width="1569" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/707e5ac6-933c-4c38-95e5-eba75a6ae55e">

