### PR TITLE
feat(addon-editor): `ColorSelector` uses `Maskito` instead of legacy `text-mask`

### DIFF
--- a/projects/addon-editor/components/color-selector/color-edit/color-edit.component.ts
+++ b/projects/addon-editor/components/color-selector/color-edit/color-edit.component.ts
@@ -5,8 +5,10 @@ import {
     Input,
     Output,
 } from '@angular/core';
+import {MaskitoOptions} from '@maskito/core';
 import {tuiDefaultProp, tuiHexToRgb, tuiRgbToHex} from '@taiga-ui/cdk';
-import {TuiTextMaskOptions} from '@taiga-ui/core';
+
+const HEX_MODE_LENGTH = 6;
 
 @Component({
     selector: 'tui-color-edit',
@@ -22,9 +24,8 @@ export class TuiColorEditComponent {
     @Output()
     readonly colorChange = new EventEmitter<[number, number, number, number]>();
 
-    readonly hexMask: TuiTextMaskOptions = {
-        mask: ({length}) => Array.from({length}, () => /\d|[a-f]|[A-F]/),
-        guide: false,
+    readonly hexMask: MaskitoOptions = {
+        mask: new RegExp(`^[A-F\\d]{0,${HEX_MODE_LENGTH}}$`, 'gi'),
     };
 
     readonly modes = ['HEX', 'RGB'];
@@ -44,7 +45,7 @@ export class TuiColorEditComponent {
     }
 
     onHexChange(hex: string): void {
-        if (hex.length !== 6) {
+        if (hex.length !== HEX_MODE_LENGTH) {
             return;
         }
 

--- a/projects/addon-editor/components/color-selector/color-edit/color-edit.module.ts
+++ b/projects/addon-editor/components/color-selector/color-edit/color-edit.module.ts
@@ -1,6 +1,7 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {MaskitoModule} from '@maskito/angular';
 import {
     TuiDataListModule,
     TuiDropdownModule,
@@ -8,7 +9,6 @@ import {
     TuiTextfieldControllerModule,
 } from '@taiga-ui/core';
 import {
-    TextMaskModule,
     TuiInputCountModule,
     TuiSelectModule,
     TuiValueAccessorModule,
@@ -20,7 +20,7 @@ import {TuiColorEditComponent} from './color-edit.component';
     imports: [
         CommonModule,
         FormsModule,
-        TextMaskModule,
+        MaskitoModule,
         TuiValueAccessorModule,
         TuiSelectModule,
         TuiPrimitiveTextfieldModule,

--- a/projects/addon-editor/components/color-selector/color-edit/color-edit.template.html
+++ b/projects/addon-editor/components/color-selector/color-edit/color-edit.template.html
@@ -23,16 +23,11 @@
     *ngIf="isHex; else rgb"
     tuiValueAccessor
     tuiTextfieldSize="m"
-    [textMask]="hexMask"
+    [maskito]="hexMask"
     [tuiTextfieldLabelOutside]="true"
     [value]="hex"
     (valueChange)="onHexChange($event)"
->
-    <input
-        tuiTextfield
-        maxlength="6"
-    />
-</tui-primitive-textfield>
+></tui-primitive-textfield>
 <ng-template #rgb>
     <tui-input-count
         tuiTextfieldSize="m"

--- a/projects/kit/directives/mask/legacy-mask.ts
+++ b/projects/kit/directives/mask/legacy-mask.ts
@@ -39,8 +39,8 @@ function _isAndroid(): boolean {
 /**
  * @internal
  * @deprecated Use {@link https://github.com/Tinkoff/maskito Maskito}
- * Don't use it! It can be deleted at any time (even in minor releases).
- * Use {@link https://github.com/text-mask/text-mask/tree/master/angular2 angular2-text-mask} instead.
+ * Don't use it!
+ * TODO: delete in v4.0
  */
 @Directive({
     host: {
@@ -166,9 +166,9 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
 
 /**
  * @internal
- * @deprecated
- * Don't use it! It can be deleted at any time (even in minor releases).
- * Use {@link https://github.com/text-mask/text-mask/tree/master/angular2 angular2-text-mask} instead.
+ * @deprecated Use {@link https://github.com/Tinkoff/maskito Maskito}
+ * Don't use it!
+ * TODO: delete in v4.0
  */
 @NgModule({
     declarations: [MaskedInputDirective],


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
Partially solves #120