### PR TITLE
fix(cdk): `TuiStaticRequestService` should be throw error when response code is not `200`

### DIFF
--- a/projects/cdk/services/static-request.service.ts
+++ b/projects/cdk/services/static-request.service.ts
@@ -33,7 +33,13 @@ export class TuiStaticRequestService {
                   defer(() => from(fetch(url)));
 
         const piped = response$.pipe(
-            switchMap(async res => res.text()),
+            switchMap(async response => {
+                if (response.ok) {
+                    return response.text();
+                }
+
+                throw new Error(`Failed to load ${url} (${response.statusText})`);
+            }),
             shareReplay({bufferSize: 1, refCount: false}),
         );
 

--- a/projects/demo/src/modules/icons/icons.component.ts
+++ b/projects/demo/src/modules/icons/icons.component.ts
@@ -34,6 +34,7 @@ export class IconsComponent {
                 s3,1.3,3,3v0.1c2.3,0.6,4,3,4,5.9v3.8l1.4,4.2h-4.5c-0.4,1.8-2,3-3.9,3c-1.8,0-3.4-1.2-3.9-3H3.6z"/>
         </svg>`,
         assets`/images/ts.svg#ts`,
+        assets`/images/undefined.svg`,
     ];
 
     icon = this.iconVariants[0];

--- a/projects/demo/src/modules/icons/icons.template.html
+++ b/projects/demo/src/modules/icons/icons.template.html
@@ -79,7 +79,10 @@
 
     <ng-template pageTab="Component">
         <div class="b-full-width">
-            <tui-svg [src]="icon"></tui-svg>
+            <tui-svg
+                [src]="icon"
+                (tui-icon-error)="documentationPropertyIconErrorChange.emitEvent($event)"
+            ></tui-svg>
         </div>
 
         <tui-doc-documentation>
@@ -94,6 +97,7 @@
                 size with CSS
             </ng-template>
             <ng-template
+                #documentationPropertyIconErrorChange="documentationProperty"
                 documentationPropertyName="tui-icon-error"
                 documentationPropertyMode="output"
                 documentationPropertyType="CustomEvent<TuiIconError>"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4784

<img width="1545" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/3de6bdbb-5cc6-4c53-8d59-61cecb7d9af2">


## What is the new behavior?

<img width="1452" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/f0c76dc9-d98d-4d19-9025-500b46716dc0">

