### PR TITLE
fix(core): change embedded views behavior for `wrapper` in hosted dropdown

### DIFF
--- a/projects/core/components/hosted-dropdown/hosted-dropdown.component.ts
+++ b/projects/core/components/hosted-dropdown/hosted-dropdown.component.ts
@@ -77,7 +77,7 @@ export class TuiHostedDropdownComponent implements TuiFocusableElementAccessor {
     @ContentChild(TuiHostedDropdownConnectorDirective, {read: ElementRef})
     private readonly dropdownHost?: ElementRef<HTMLElement>;
 
-    @ViewChild('wrapper', {read: ElementRef})
+    @ViewChild('wrapper', {read: ElementRef, static: true})
     private readonly wrapper?: ElementRef<HTMLDivElement>;
 
     @ViewChild(TuiDropdownDirective)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4788

<img width="1623" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/1343ad49-ea47-4a26-bd58-3203e9bf4478">


## What is the new behavior?

<img width="729" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/a73750fa-a3cf-4c8d-ac65-696b073f03bd">

