### PR TITLE
fix(demo): added tuiTextfieldLabelOutside for format-number demo slider

### DIFF
--- a/projects/demo/src/modules/pipes/format-number/format-number.template.html
+++ b/projects/demo/src/modules/pipes/format-number/format-number.template.html
@@ -34,6 +34,7 @@
         <tui-input-slider
             tuiTextfieldSize="m"
             class="slider"
+            [tuiTextfieldLabelOutside]="true"
             [max]="10000000"
             [quantum]="0.111"
             [(ngModel)]="value"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Not aligned value on format-number pipe demo slider

## What is the new behavior?
