### PR TITLE
docs: add documentation about tuiMarkControlAsTouchedAndValidate

### DIFF
--- a/projects/demo/src/modules/pipes/field-error/examples/1/index.html
+++ b/projects/demo/src/modules/pipes/field-error/examples/1/index.html
@@ -36,8 +36,16 @@
     </label>
 
     <p>
-        If you need to show validation message as early as a user started to type something, subscribe on form value
-        changes and call markAsTouched on control on first value change
+        If you want to show a validation message as soon as a user starts typing, subscribe on form value changes and
+        call markAsTouched on control on first value change. You can also use
+        <a
+            tuiLink
+            routerLink="/utils/miscellaneous"
+            fragment="mark-control-as-touched-and-validate"
+            href="/utils/miscellaneous#mark-control-as-touched-and-validate"
+        >
+            <code>tuiMarkControlAsTouchedAndValidate</code>
+        </a>
     </p>
 
     <p>

--- a/projects/demo/src/modules/pipes/field-error/examples/1/index.ts
+++ b/projects/demo/src/modules/pipes/field-error/examples/1/index.ts
@@ -2,6 +2,7 @@ import {Component} from '@angular/core';
 import {AbstractControl, FormControl, FormGroup, Validators} from '@angular/forms';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {encapsulation} from '@demo/emulate/encapsulation';
+import {distinctUntilChanged} from 'rxjs/operators';
 
 const latinChars = /^[a-zA-Z]+$/;
 
@@ -47,7 +48,7 @@ export class TuiFieldErrorPipeExample1 {
     );
 
     constructor() {
-        this.testValue1.valueChanges.subscribe(() => {
+        this.testValue1.valueChanges.pipe(distinctUntilChanged()).subscribe(() => {
             this.testValue1.markAsTouched();
         });
     }

--- a/projects/demo/src/modules/utils/miscellaneous/examples/6/index.html
+++ b/projects/demo/src/modules/utils/miscellaneous/examples/6/index.html
@@ -1,0 +1,42 @@
+<form
+    class="b-form"
+    [formGroup]="userDetailsForm"
+>
+    <p>
+        <tui-input formControlName="name">Name</tui-input>
+
+        <tui-error
+            formControlName="name"
+            [error]="[] | tuiFieldError | async"
+        ></tui-error>
+    </p>
+
+    <div formGroupName="address">
+        <p>
+            <tui-input formControlName="street">Street</tui-input>
+
+            <tui-error
+                formControlName="street"
+                [error]="[] | tuiFieldError | async"
+            ></tui-error>
+        </p>
+
+        <p>
+            <tui-input formControlName="zipCode">Zip code</tui-input>
+
+            <tui-error
+                formControlName="zipCode"
+                [error]="[] | tuiFieldError | async"
+            ></tui-error>
+        </p>
+
+        <p>
+            <tui-input formControlName="city">City</tui-input>
+
+            <tui-error
+                formControlName="city"
+                [error]="[] | tuiFieldError | async"
+            ></tui-error>
+        </p>
+    </div>
+</form>

--- a/projects/demo/src/modules/utils/miscellaneous/examples/6/index.ts
+++ b/projects/demo/src/modules/utils/miscellaneous/examples/6/index.ts
@@ -1,0 +1,26 @@
+import {Component, OnInit} from '@angular/core';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
+import {changeDetection} from '@demo/emulate/change-detection';
+import {encapsulation} from '@demo/emulate/encapsulation';
+import {tuiMarkControlAsTouchedAndValidate} from '@taiga-ui/cdk';
+
+@Component({
+    selector: 'tui-miscellaneous-example-6',
+    templateUrl: './index.html',
+    changeDetection,
+    encapsulation,
+})
+export class TuiMiscellaneousExample6 implements OnInit {
+    userDetailsForm = new FormGroup({
+        name: new FormControl('', Validators.required),
+        address: new FormGroup({
+            street: new FormControl('', Validators.required),
+            city: new FormControl('', Validators.required),
+            zipCode: new FormControl('', Validators.required),
+        }),
+    });
+
+    ngOnInit(): void {
+        tuiMarkControlAsTouchedAndValidate(this.userDetailsForm);
+    }
+}

--- a/projects/demo/src/modules/utils/miscellaneous/miscellaneous.component.ts
+++ b/projects/demo/src/modules/utils/miscellaneous/miscellaneous.component.ts
@@ -31,4 +31,9 @@ export class ExampleMiscellaneousComponent {
         HTML: import('./examples/5/index.html?raw'),
         LESS: import('./examples/5/index.less?raw'),
     };
+
+    readonly example6: TuiDocExample = {
+        TypeScript: import('./examples/6/index.ts?raw'),
+        HTML: import('./examples/6/index.html?raw'),
+    };
 }

--- a/projects/demo/src/modules/utils/miscellaneous/miscellaneous.module.ts
+++ b/projects/demo/src/modules/utils/miscellaneous/miscellaneous.module.ts
@@ -3,13 +3,19 @@ import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
-import {TuiDataListModule} from '@taiga-ui/core';
-import {TuiDataListWrapperModule, TuiSelectModule} from '@taiga-ui/kit';
+import {TuiDataListModule, TuiErrorModule} from '@taiga-ui/core';
+import {
+    TuiDataListWrapperModule,
+    TuiFieldErrorPipeModule,
+    TuiInputModule,
+    TuiSelectModule,
+} from '@taiga-ui/kit';
 
 import {TuiMiscellaneousExample1} from './examples/1';
 import {TuiMiscellaneousExample2} from './examples/2';
 import {TuiMiscellaneousExample4} from './examples/4';
 import {TuiMiscellaneousExample5} from './examples/5';
+import {TuiMiscellaneousExample6} from './examples/6';
 import {ExampleMiscellaneousComponent} from './miscellaneous.component';
 
 @NgModule({
@@ -20,6 +26,9 @@ import {ExampleMiscellaneousComponent} from './miscellaneous.component';
         TuiSelectModule,
         TuiDataListModule,
         TuiDataListWrapperModule,
+        TuiInputModule,
+        TuiErrorModule,
+        TuiFieldErrorPipeModule,
         TuiAddonDocModule,
         RouterModule.forChild(tuiGenerateRoutes(ExampleMiscellaneousComponent)),
     ],
@@ -29,6 +38,7 @@ import {ExampleMiscellaneousComponent} from './miscellaneous.component';
         TuiMiscellaneousExample2,
         TuiMiscellaneousExample4,
         TuiMiscellaneousExample5,
+        TuiMiscellaneousExample6,
     ],
     exports: [ExampleMiscellaneousComponent],
 })

--- a/projects/demo/src/modules/utils/miscellaneous/miscellaneous.template.html
+++ b/projects/demo/src/modules/utils/miscellaneous/miscellaneous.template.html
@@ -41,6 +41,15 @@
         >
             <tui-miscellaneous-example-5></tui-miscellaneous-example-5>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="mark-control-as-touched-and-validate"
+            heading="markControlAsTouchedAndValidate"
+            description="Recursively marks form control as touched and triggers validation"
+            [content]="example6"
+        >
+            <tui-miscellaneous-example-6></tui-miscellaneous-example-6>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab="Setup">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [x] Documentation content changes

## What is the current behavior?

Closes #4321

## What is the new behavior?

* Added **MarkControlAsTouchedAndValidate** section to utils/miscellaneous docs page
* Updated **FieldError** first example, added link to **MarkControlAsTouchedAndValidate** and added `distinctUntilChanged` to `valueChanges` subscription (as mentioned in #4321)