### PR TITLE
fix(core): reuse `tuiOption` styles inside `tuiDataList`

### DIFF
--- a/projects/core/components/data-list/data-list.style.less
+++ b/projects/core/components/data-list/data-list.style.less
@@ -1,4 +1,5 @@
 @import '../../styles/taiga-ui-local.less';
+@import './mixin.style.less';
 
 tui-data-list {
     --tui-data-list-padding: 0.25rem;
@@ -22,15 +23,23 @@ tui-data-list {
     &[data-list-size='s'] {
         /* stylelint-disable-next-line */
         --tui-data-list-margin: 0rem;
+
+        & > .t-empty {
+            .data-list-item('s');
+        }
+    }
+
+    &[data-list-size='m'] > .t-empty {
+        .data-list-item('m');
     }
 
     &[data-list-size='l'] {
         --tui-data-list-padding: 0.375rem;
         --tui-data-list-margin: 0.125rem;
-    }
 
-    & > .t-empty {
-        margin: 0.75rem 1rem;
+        & > .t-empty {
+            .data-list-item('l');
+        }
     }
 }
 

--- a/projects/core/components/data-list/mixin.style.less
+++ b/projects/core/components/data-list/mixin.style.less
@@ -1,0 +1,24 @@
+.data-list-item(@size: 'm') when (@size = 's'), (@size = 'm'), (@size = 'l') {
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    margin: var(--tui-data-list-margin) 0;
+
+    & when (@size = 's') {
+        font: var(--tui-font-text-s);
+        min-height: 2rem;
+        padding: 0.3125rem 0.5rem;
+    }
+
+    & when (@size = 'm') {
+        font: var(--tui-font-text-s);
+        min-height: 2.5rem;
+        padding: 0.375rem 0.5rem;
+    }
+
+    & when (@size = 'l') {
+        font: var(--tui-font-text-m);
+        min-height: 2.75rem;
+        padding: 0.375rem 0.625rem;
+    }
+}

--- a/projects/core/components/data-list/option/option.style.less
+++ b/projects/core/components/data-list/option/option.style.less
@@ -1,23 +1,17 @@
 @import '../../../styles/taiga-ui-local.less';
+@import '../mixin.style.less';
 
 :host {
     .clearbtn();
     .transition(background);
-    display: flex;
-    align-items: center;
     justify-content: space-between;
     text-align: left;
-    box-sizing: border-box;
     color: var(--tui-text-01);
     border-radius: var(--tui-radius-s);
     outline: none;
     text-decoration: none;
     cursor: pointer;
     background-clip: padding-box;
-    font: var(--tui-font-text-s);
-    min-height: 2.5rem;
-    padding: 0.375rem 0.5rem;
-    margin: 0.125rem 0;
 
     &:disabled {
         opacity: var(--tui-disabled-opacity);
@@ -34,26 +28,17 @@
     :host-context([data-list-size='xs']),
     &[data-size='s'][data-size='s'],
     &[data-size='xs'][data-size='xs'] {
-        font: var(--tui-font-text-s);
-        min-height: 2rem;
-        padding: 0.3125rem 0.5rem;
-        margin: var(--tui-data-list-margin) 0;
+        .data-list-item('s');
     }
 
     :host-context([data-list-size='m']),
     &[data-size='m'][data-size='m'] {
-        font: var(--tui-font-text-s);
-        min-height: 2.5rem;
-        padding: 0.375rem 0.5rem;
-        margin: var(--tui-data-list-margin) 0;
+        .data-list-item('m');
     }
 
     :host-context([data-list-size='l']),
     &[data-size='l'][data-size='l'] {
-        font: var(--tui-font-text-m);
-        min-height: 2.75rem;
-        padding: 0.375rem 0.625rem;
-        margin: var(--tui-data-list-margin) 0;
+        .data-list-item('l');
     }
 }
 


### PR DESCRIPTION
Extracted `tuiOption` styles into a separate `mixin.style.less` file. Imported into `tuiOption` and `tuiDataList` style files respectively.

Added appropriate text and margin/padding/size styles to the `.t-empty` selector to respect the size of the `tuiDataList`. 
Adding `tuiOption` and replacing `<div>` with either `<a>` or `<button>` would also work, but then custom content provided with polymorpheus could be broken, so decided to reuse styles instead.

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #4803

Size of `.t-empty` inside `data-list.template.html` was not respecting `tuiDataList`'s `size`.

## What is the new behavior?

Size of `tuiDataList` is used to determine text size of `.t-empty` selector.