### PR TITLE
feat(kit): fix circular dependency error `TuiInputFilesDirective` and `TuiInputFilesComponent` with UMD bundle

### DIFF
--- a/projects/kit/components/input-files/input-files.directive.ts
+++ b/projects/kit/components/input-files/input-files.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, ElementRef, HostBinding, Inject} from '@angular/core';
+import {Directive, ElementRef, forwardRef, HostBinding, Inject} from '@angular/core';
 import {TuiIdService} from '@taiga-ui/cdk';
 
 // eslint-disable-next-line import/no-cycle
@@ -14,7 +14,8 @@ import {TUI_INPUT_FILES_OPTIONS, TuiInputFilesOptions} from './input-files.optio
 })
 export class TuiInputFilesDirective {
     constructor(
-        @Inject(TuiInputFilesComponent) readonly host: TuiInputFilesComponent,
+        @Inject(forwardRef(() => TuiInputFilesComponent))
+        readonly host: TuiInputFilesComponent,
         @Inject(ElementRef) private readonly el: ElementRef<HTMLInputElement>,
         @Inject(TuiIdService) private readonly idService: TuiIdService,
         @Inject(TUI_INPUT_FILES_OPTIONS) private readonly options: TuiInputFilesOptions,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

![image](https://github.com/Tinkoff/taiga-ui/assets/13107421/50a357b0-b766-48ed-8c24-022df6859140)

Closes # <!-- link to a relevant issue. -->

## What is the new behavior?

Work as expected