### PR TITLE
ci: fix name version for nightly builds

### DIFF
--- a/scripts/publish-dev-builds.ts
+++ b/scripts/publish-dev-builds.ts
@@ -8,7 +8,7 @@ import {execute} from './shared/execute';
     const [major, minor, patch] = version.split(/[.-]/);
 
     // construct new version from base version x.y.z to become x.y.z-{dev}.{shortSha}
-    const newVersion = `${major}.${minor}.${patch}-dev.${branch}-${commit}`;
+    const newVersion = `${major}.${minor}.${patch}-dev.${branch}.${commit}`;
 
     infoLog(`New dev version - ${newVersion}`);
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

Nx cannot parse `x.y.z-{dev}-{shortSha}`
<img width="643" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/2074854f-1ce0-41df-868f-598d22c07ac2">

It should be `x.y.z-{dev}.{shortSha}`