### PR TITLE
refactor(kit): `InputYear` uses `min` property from `Number` (`Maskito` built-in mask)

### DIFF
--- a/projects/kit/components/input-year/input-year.component.ts
+++ b/projects/kit/components/input-year/input-year.component.ts
@@ -81,9 +81,10 @@ export class TuiInputYearComponent
     }
 
     @tuiPure
-    getMaskOptions(max: number): MaskitoOptions {
+    getMaskOptions(min: number, max: number): MaskitoOptions {
         return {
             ...maskitoNumberOptionsGenerator({
+                min,
                 max,
                 thousandSeparator: '',
             }),
@@ -102,10 +103,6 @@ export class TuiInputYearComponent
 
     onFocused(focused: boolean): void {
         this.updateFocused(focused);
-
-        if (!focused && this.value && this.value < this.min) {
-            this.value = this.min;
-        }
     }
 
     onOpenChange(open: boolean): void {

--- a/projects/kit/components/input-year/input-year.template.html
+++ b/projects/kit/components/input-year/input-year.template.html
@@ -15,7 +15,7 @@
         [pseudoFocus]="pseudoFocus"
         [pseudoHover]="pseudoHover"
         [invalid]="computedInvalid"
-        [maskito]="getMaskOptions(max)"
+        [maskito]="getMaskOptions(min, max)"
         [value]="value?.toString() || ''"
         (valueChange)="onValueChange($event)"
         (focusedChange)="onFocused($event)"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes
