### PR TITLE
ci: support `github codespaces` instead of `codeflow`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+    "name": "taiga ui dev container",
+    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:18",
+    "hostRequirements": {
+        "memory": "8gb",
+        "cpus": 4
+    },
+    "waitFor": "onCreateCommand",
+    "updateContentCommand": "npm ci --force --loglevel silent --audit false --ignore-engines --ignore-platform --no-fund",
+    "postCreateCommand": "",
+    "postAttachCommand": "npm start -- --host 0.0.0.0 --disable-host-check",
+    "customizations": {
+        "codespaces": {
+            "openFiles": ["CONTRIBUTING.md"]
+        }
+    },
+    "portsAttributes": {
+        "3333": {
+            "label": "Demo",
+            "onAutoForward": "notify"
+        }
+    },
+    "forwardPorts": [3333]
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Downloads per month](https://img.shields.io/npm/dm/@taiga-ui/cdk?color=dark-green)](https://www.npmjs.com/package/@taiga-ui/cdk)
 [![Discord](https://img.shields.io/discord/748677963142135818?color=7289DA&label=%23taiga-ui&logo=discord&logoColor=white)](https://discord.gg/Us8d8JVaTg)
 [![angular-open-source-starter](https://img.shields.io/badge/made%20with-angular--open--source--starter-d81676?logo=angular)](https://github.com/tinkoff/angular-open-source-starter)
-[![Codeflow](https://img.shields.io/badge/codeflow-pr.new-blue)](https://pr.new/github.com/tinkoff/taiga-ui)
 
 [Website](https://taiga-ui.dev) • [Documentation](https://taiga-ui.dev/getting-started) • [Core team](#core-team) •
 [Figma](https://www.figma.com/community/file/1220308188005380608)

--- a/scripts/cspell/software.json
+++ b/scripts/cspell/software.json
@@ -24,6 +24,8 @@
         "preprocessor",
         "preprocessors",
         "postprocessor",
-        "postprocessors"
+        "postprocessors",
+        "loglevel",
+        "codespaces"
     ]
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the new behavior?

for example in tui-editor

<img width="940" alt="image" src="https://github.com/Tinkoff/taiga-ui/assets/12021443/027622cf-0e61-4e9f-9776-ebc61f594598">

![image](https://github.com/Tinkoff/taiga-ui/assets/12021443/66eb2af7-d0fa-4d89-ac36-a8e3a0e3e580)

![image](https://github.com/Tinkoff/taiga-ui/assets/12021443/f51e7048-509d-4c9d-9684-9c63d2851505)

