### PR TITLE
fix(kit): `ProgressCircle` should show empty circle if `max=0`

### DIFF
--- a/projects/demo/src/modules/components/progress-circle/progress-circle.component.ts
+++ b/projects/demo/src/modules/components/progress-circle/progress-circle.component.ts
@@ -2,11 +2,13 @@ import {Component} from '@angular/core';
 import {changeDetection} from '@demo/emulate/change-detection';
 import {TuiDocExample} from '@taiga-ui/addon-doc';
 import {TuiSizeS, TuiSizeXL} from '@taiga-ui/core';
+import {tuiInputNumberOptionsProvider} from '@taiga-ui/kit';
 
 @Component({
     selector: 'example-tui-progress-circle',
     templateUrl: './progress-circle.template.html',
     styleUrls: ['./progress-circle.style.less'],
+    providers: [tuiInputNumberOptionsProvider({min: 0})],
     changeDetection,
 })
 export class ExampleProgressCircleComponent {

--- a/projects/kit/components/progress/progress-circle/progress-circle.component.ts
+++ b/projects/kit/components/progress/progress-circle/progress-circle.component.ts
@@ -37,9 +37,11 @@ export class TuiProgressCircleComponent {
     @HostBinding('attr.data-size')
     size: TuiSizeS | TuiSizeXL = 'm';
 
-    @HostBinding('style.--progress-percentage')
-    get progressPercentage(): number {
-        return this.value / this.max;
+    @HostBinding('style.--progress-ratio')
+    get progressRatio(): number {
+        const ratio = this.value / this.max;
+
+        return Number.isFinite(ratio) ? ratio : 0;
     }
 
     animationDelay$ = of(true).pipe(delay(0));

--- a/projects/kit/components/progress/progress-circle/progress-circle.style.less
+++ b/projects/kit/components/progress/progress-circle/progress-circle.style.less
@@ -48,7 +48,7 @@
 
         &_filled {
             transition: stroke-dashoffset var(--tui-duration) linear;
-            stroke-dashoffset: calc(@circumference - var(--progress-percentage) * @circumference);
+            stroke-dashoffset: calc(@circumference - var(--progress-ratio) * @circumference);
         }
     }
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
https://taiga-ui.dev/components/progress-circle/API?max=0&value=0&size=xl

https://github.com/Tinkoff/taiga-ui/assets/35179038/d8c39f9d-0ec1-4158-bff9-fd3d9aed4600

