### PR TITLE
chore(demo): fix Stakblitz for masked input example

### DIFF
--- a/projects/demo/src/modules/app/stackblitz/utils.ts
+++ b/projects/demo/src/modules/app/stackblitz/utils.ts
@@ -151,10 +151,11 @@ import {
 import {ScrollingModule} from '@angular/cdk/scrolling';
 import {HttpClientModule} from '@angular/common/http';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {RouterModule} from '@angular/router';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {MaskitoModule} from '@maskito/angular';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
-import {RouterModule} from '@angular/router';
 ${additionalModulesImports}
 
 export const ALL_TAIGA_UI_MODULES = [
@@ -165,6 +166,7 @@ export const ALL_TAIGA_UI_MODULES = [
     ReactiveFormsModule,
     ScrollingModule,
     PolymorpheusModule,
+    MaskitoModule,
     RouterModule.forRoot([]),
     /* CDK */
     ${cdk},


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [X] Documentation content changes

## What is the current behavior?
```
Error in src/app/app.component.html (10:13)
Can't bind to 'maskito' since it isn't a known property of 'tui-input'.
1. If 'tui-input' is an Angular component and it has 'maskito' input, then verify that it is part of this module.
2. If 'tui-input' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.
3. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.
```
