### PR TITLE
fix(i18n): incorrect french translation for Bulgaria country name

### DIFF
--- a/projects/i18n/languages/french/countries.ts
+++ b/projects/i18n/languages/french/countries.ts
@@ -19,7 +19,7 @@ export const TUI_FRENCH_LANGUAGE_COUNTRIES: Record<TuiCountryIsoCode, string> = 
     [TuiCountryIsoCode.BD]: `Bangladesh`,
     [TuiCountryIsoCode.BE]: `Belgique`,
     [TuiCountryIsoCode.BF]: `Burkina Faso`,
-    [TuiCountryIsoCode.BG]: `Belgique`,
+    [TuiCountryIsoCode.BG]: `Bulgarie`,
     [TuiCountryIsoCode.BH]: `Bahrein`,
     [TuiCountryIsoCode.BI]: `Burundi`,
     [TuiCountryIsoCode.BJ]: `Bénin`,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
There are 2 Belgium in the countries file for the French translation, the one with the iso code 'BG' should be Bulgarie 
Closes # <!-- link to a relevant issue. -->

## What is the new behavior?
Change the country with 'BG'code to Bulgarie from Belgique